### PR TITLE
chore: Update Docker Compose and CI workflow for Lavalink deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_BOT: ghcr.io/${{ github.repository_owner }}/dimbybot2/bot:latest
+      IMAGE_LAVALINK: ghcr.io/${{ github.repository_owner }}/dimbybot2/lavalink:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -34,9 +35,17 @@ jobs:
         run: |
           docker build -t $IMAGE_BOT -f Dockerfile .
 
+      - name: Build lavalink image
+        run: |
+          docker build -t $IMAGE_LAVALINK -f Lavalink/Dockerfile ./Lavalink
+
       - name: Push bot image
         run: |
           docker push $IMAGE_BOT
+
+      - name: Push lavalink image
+        run: |
+          docker push $IMAGE_LAVALINK
 
   deploy:
     needs: build-and-push
@@ -45,6 +54,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_BOT: ghcr.io/${{ github.repository_owner }}/dimbybot2/bot:latest
+      IMAGE_LAVALINK: ghcr.io/${{ github.repository_owner }}/dimbybot2/lavalink:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -75,6 +85,7 @@ jobs:
           EMAIL_PASS=${{ secrets.EMAIL_PASS }}
           GITLAB_EMAIL=${{ secrets.GITLAB_EMAIL }}
           BOT_IMAGE=${{ env.IMAGE_BOT }}
+          LAVALINK_IMAGE=${{ env.IMAGE_LAVALINK }}
           GH_ACTOR=${{ github.actor }}
           GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
           EOF
@@ -86,7 +97,7 @@ jobs:
           username: ${{ secrets.DEPLOY_SERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.DEPLOY_SERVER_SSH_PORT }}
-          source: ".env,docker-compose.yml,Lavalink/entrypoint.sh"
+          source: ".env,docker-compose.yml"
           target: "/home/bot/"
 
       - name: Copy deployment script to server
@@ -97,6 +108,7 @@ jobs:
           cd /home/bot
           export $(grep -v '^#' .env | xargs)
           sed -i "s|image: .*bot.*|image: $BOT_IMAGE|" docker-compose.yml
+          sed -i "s|image: .*lavalink.*|image: $LAVALINK_IMAGE|" docker-compose.yml
           echo "$GH_TOKEN" | /usr/bin/docker login ghcr.io -u "$GH_ACTOR" --password-stdin
           /usr/bin/docker compose down
           /usr/bin/docker compose pull

--- a/Lavalink/Dockerfile
+++ b/Lavalink/Dockerfile
@@ -1,0 +1,40 @@
+# Use an appropriate base image with Java (e.g., OpenJDK JRE)
+FROM eclipse-temurin:17-jre-alpine
+
+WORKDIR /app
+
+# Install required system libraries and utilities
+RUN apk add --no-cache \
+    libgcc \
+    gcompat \
+    dos2unix \
+    curl
+
+# Download the latest Lavalink.jar
+RUN curl -L https://github.com/lavalink-devs/Lavalink/releases/latest/download/Lavalink.jar -o Lavalink.jar
+
+# Copy the entrypoint script
+COPY entrypoint.sh entrypoint.sh
+# Ensure script has correct line endings (LF) and is executable
+# Ensure /tmp exists and has correct permissions
+RUN dos2unix entrypoint.sh \
+    && chmod +x entrypoint.sh \
+    && mkdir -p /tmp \
+    && chmod 1777 /tmp \
+    # Add debugging steps:
+    && echo "--- Listing /app contents:" \
+    && ls -la /app/ \
+    && echo "--- Checking for /bin/sh:" \
+    && which sh
+
+# Default port Lavalink runs on
+EXPOSE 2333
+
+# Health check to see if Lavalink is ready
+# Requires LAVALINK_PORT and LAVALINK_PASSWORD env vars to be set
+HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=5 \
+  CMD curl --fail -H "Authorization: ${LAVALINK_PASSWORD}" http://localhost:${LAVALINK_PORT:-2333}/version || exit 1
+
+# Run the entrypoint script which generates application.yml and starts Lavalink
+# Use absolute path and explicitly invoke sh to bypass shebang issues
+ENTRYPOINT ["/bin/sh", "/app/entrypoint.sh"] 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
 services:
   lavalink:
-    image: ghcr.io/lavalink-devs/lavalink:4.1.1
+    image: placeholder-lavalink # This will be replaced by the deploy script
     container_name: lavalink
     restart: unless-stopped
-    working_dir: /app
-    entrypoint: ["sh", "/app/entrypoint.sh"]
     environment:
       # These will be picked up by Lavalink/entrypoint.sh
       - LAVALINK_PORT=${LAVALINK_PORT}
@@ -20,7 +18,6 @@ services:
     ports:
       - "${LAVALINK_PORT}:${LAVALINK_PORT}" # Map host port to container port
     volumes:
-      - ./Lavalink/entrypoint.sh:/app/entrypoint.sh
       - lavalink-plugins:/app/plugins
       - dimbybot-downloads:/app/downloads
     networks:


### PR DESCRIPTION
This commit modifies the Docker Compose configuration to use a placeholder image for Lavalink, which will be replaced by the deploy script. Additionally, the CI workflow has been updated to build and push the Lavalink image, ensuring it aligns with the new deployment strategy. Unused entrypoint script references have been removed from the Docker Compose file.