### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@ name: CI/CD
 
 permissions:
   contents: read
-  packages: write
 
 on:
   push:
@@ -20,6 +19,9 @@ jobs:
   build-and-push:
     if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skip_build }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
       REGISTRY: ghcr.io
       IMAGE_BOT: ghcr.io/${{ github.repository_owner }}/dimbybot2/bot:latest
@@ -55,6 +57,9 @@ jobs:
     needs: build-and-push
     if: always() && (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'skipped')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     env:
       REGISTRY: ghcr.io
       IMAGE_BOT: ghcr.io/${{ github.repository_owner }}/dimbybot2/bot:latest


### PR DESCRIPTION
Potential fix for [https://github.com/bpeters132/DimbyBot2/security/code-scanning/2](https://github.com/bpeters132/DimbyBot2/security/code-scanning/2)

In general, fix this by explicitly limiting `GITHUB_TOKEN` permissions in the workflow to the minimum required. For this workflow, the jobs need to: (1) read repository contents (for `actions/checkout`), and (2) push container images to GitHub Container Registry (packages). They do not need to modify repository contents, issues, or pull requests.

The best minimal fix is to add a root-level `permissions` block (applies to all jobs) right below the `name:` or `on:` block. Set `contents: read` and `packages: write`, which are sufficient for `actions/checkout` and `docker/login-action`/GHCR pushes. No changes are needed inside the jobs themselves. This keeps existing functionality intact while constraining the token’s scope.

Concretely, in `.github/workflows/deploy.yml`, insert:

```yaml
permissions:
  contents: read
  packages: write
```

near the top of the file (e.g., after `name: CI/CD` and before `on:`). No imports or additional methods are required since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced deployment workflow with improved security permissions configuration for build and deployment processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->