### PR TITLE
feat: autoplay button on control panel + startup refresh

### DIFF
--- a/src/commands/admin/Control-Channel.ts
+++ b/src/commands/admin/Control-Channel.ts
@@ -131,7 +131,7 @@ export default {
         )
         const controlMessage = await targetChannel.send({
           embeds: [controlEmbed],
-          components: [controlButtons],
+          components: controlButtons,
         })
         client.debug(`[Control-Channel] Sent new control message ${controlMessage.id}.`)
 

--- a/src/commands/music/Autoplay.ts
+++ b/src/commands/music/Autoplay.ts
@@ -3,7 +3,7 @@ import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
 
-import { clearAutoplayRecent, seedAutoplayHistoryFromPlayer } from "../../util/autoplayHistory.js"
+import { toggleAutoplay } from "../../util/autoplayHistory.js"
 import { updateControlMessage } from "../../events/handlers/handleControlChannel.js"
 
 export default {
@@ -41,14 +41,7 @@ export default {
       })
     }
 
-    const current = !!player.get("autoplay")
-    player.set("autoplay", !current)
-    const enabled = !current
-    if (!enabled) {
-      clearAutoplayRecent(player)
-    } else {
-      seedAutoplayHistoryFromPlayer(player)
-    }
+    const enabled = toggleAutoplay(player)
 
     await interaction.reply({
       content: enabled ? "Autoplay is now **enabled**." : "Autoplay is now **disabled**.",

--- a/src/events/handlers/handleControlButtonInteraction.ts
+++ b/src/events/handlers/handleControlButtonInteraction.ts
@@ -104,7 +104,7 @@ export async function handleControlButtonInteraction(
       }
       return
     }
-    if (player.connected && player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
+    if (player.connected && player.voiceChannelId !== voiceChannel.id) {
       try {
         await interaction.followUp({
           content: "You need to be in the same voice channel as the bot!",

--- a/src/events/handlers/handleControlButtonInteraction.ts
+++ b/src/events/handlers/handleControlButtonInteraction.ts
@@ -1,6 +1,7 @@
 import type { ButtonInteraction } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import { getGuildSettings } from "../../util/saveControlChannel.js"
+import { toggleAutoplay } from "../../util/autoplayHistory.js"
 import { updateControlMessage } from "./handleControlChannel.js"
 
 export async function handleControlButtonInteraction(
@@ -91,41 +92,70 @@ export async function handleControlButtonInteraction(
     `[ControlButtonHandler] Found player for guild ${guildId}. Connected: ${player.connected}, Playing: ${player.playing}`
   )
 
-  // 4. Voice Channel Check
-  if (!member.voice?.channel) {
-    client.debug(`[ControlButtonHandler] User ${interaction.user.id} not in a voice channel.`)
-    try {
-      await interaction.followUp({
-        content: "You must be in a voice channel to use the controls!",
-      })
-    } catch (e: unknown) {
-      client.error("Error sending VC check follow-up:", e)
+  // 4. Voice channel check (autoplay matches `/autoplay`; other controls require same VC as player when known)
+  if (customId === "control_autoplay") {
+    const voiceChannel = member.voice?.channel
+    if (!voiceChannel) {
+      client.debug(`[ControlButtonHandler] User ${interaction.user.id} not in VC for autoplay toggle.`)
+      try {
+        await interaction.followUp({ content: "Join a voice channel first!" })
+      } catch (e: unknown) {
+        client.error("Error sending VC check follow-up:", e)
+      }
+      return
     }
-    return
-  }
-  if (!player.voiceChannelId) {
-    client.warn(`[ControlButtonHandler] Player for guild ${guildId} exists but has no voiceChannelId. Cannot verify user channel.`)
-    try {
-      await interaction.followUp({
-        content: "Cannot verify player's voice channel. Controls unavailable.",
-      })
-    } catch (e: unknown) {
-      client.error("Error sending player VC check follow-up:", e)
+    if (player.connected && player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
+      try {
+        await interaction.followUp({
+          content: "You need to be in the same voice channel as the bot!",
+        })
+      } catch (e: unknown) {
+        client.error("Error sending VC mismatch follow-up:", e)
+      }
+      return
     }
-    return
-  }
-  if (member.voice.channel.id !== player.voiceChannelId) {
-    client.debug(`[ControlButtonHandler] User ${interaction.user.id} in different VC (${member.voice.channel.id}) than player (${player.voiceChannelId}).`)
-    try {
-      await interaction.followUp({
-        content: "You must be in the same voice channel as the bot to use the controls!",
-      })
-    } catch (e: unknown) {
-      client.error("Error sending mismatched VC follow-up:", e)
+  } else {
+    if (!member.voice?.channel) {
+      client.debug(`[ControlButtonHandler] User ${interaction.user.id} not in a voice channel.`)
+      try {
+        await interaction.followUp({
+          content: "You must be in a voice channel to use the controls!",
+        })
+      } catch (e: unknown) {
+        client.error("Error sending VC check follow-up:", e)
+      }
+      return
     }
-    return
+    if (!player.voiceChannelId) {
+      client.warn(
+        `[ControlButtonHandler] Player for guild ${guildId} exists but has no voiceChannelId. Cannot verify user channel.`
+      )
+      try {
+        await interaction.followUp({
+          content: "Cannot verify player's voice channel. Controls unavailable.",
+        })
+      } catch (e: unknown) {
+        client.error("Error sending player VC check follow-up:", e)
+      }
+      return
+    }
+    if (member.voice.channel.id !== player.voiceChannelId) {
+      client.debug(
+        `[ControlButtonHandler] User ${interaction.user.id} in different VC (${member.voice.channel.id}) than player (${player.voiceChannelId}).`
+      )
+      try {
+        await interaction.followUp({
+          content: "You must be in the same voice channel as the bot to use the controls!",
+        })
+      } catch (e: unknown) {
+        client.error("Error sending mismatched VC follow-up:", e)
+      }
+      return
+    }
+    client.debug(
+      `[ControlButtonHandler] User ${interaction.user.id} is in the correct voice channel (${player.voiceChannelId}).`
+    )
   }
-  client.debug(`[ControlButtonHandler] User ${interaction.user.id} is in the correct voice channel (${player.voiceChannelId}).`)
 
   // 5. Execute Action & Update Control Message
   let actionTaken = false
@@ -328,6 +358,14 @@ export async function handleControlButtonInteraction(
           client.error("[ControlButtonHandler] Error setting loop mode:", loopError)
           await interaction.followUp({ content: "An error occurred while setting loop mode." }).catch(() => {})
         }
+        break
+      }
+      case "control_autoplay": {
+        const enabled = toggleAutoplay(player)
+        await interaction.followUp({
+          content: enabled ? "Autoplay **enabled**." : "Autoplay **disabled**.",
+        })
+        actionTaken = true
         break
       }
       default: {

--- a/src/events/handlers/handleControlChannel.ts
+++ b/src/events/handlers/handleControlChannel.ts
@@ -258,12 +258,15 @@ export async function cleanupControlChannel(
 
 
 /**
- * Updates the persistent control message for a guild and cleans up the channel.
+ * Updates the persistent control message for a guild and optionally cleans up the channel.
  * Fetches player state, channel, and message based on stored settings.
- * @param {import('../../lib/BotClient.js').default} client The bot client.
- * @param {string} guildId The ID of the guild.
+ * @param performCleanup When false, skips {@link cleanupControlChannel} (e.g. startup refresh should not bulk-delete).
  */
-export async function updateControlMessage(client: BotClient, guildId: string) {
+export async function updateControlMessage(
+  client: BotClient,
+  guildId: string,
+  performCleanup = true
+) {
   client.debug(`[ControlHandler] Attempting to update control message for guild ${guildId}`)
   const guildSettings = getGuildSettings(client)
   const settings = guildSettings[guildId]
@@ -320,10 +323,12 @@ export async function updateControlMessage(client: BotClient, guildId: string) {
       `[ControlHandler] Successfully edited control message ${controlMessage.id} in guild ${guildId}`
     )
 
-    // Don't await cleanup; let it run in the background after a delay.
-    cleanupControlChannel(controlChannel, controlMessage.id, client).catch((err: unknown) => {
-      client.error(`[ControlHandler] Background cleanup failed for channel ${controlChannel!.id}:`, err)
-    })
+    if (performCleanup) {
+      // Don't await cleanup; let it run in the background after a delay.
+      cleanupControlChannel(controlChannel, controlMessage.id, client).catch((err: unknown) => {
+        client.error(`[ControlHandler] Background cleanup failed for channel ${controlChannel!.id}:`, err)
+      })
+    }
   } catch (error: unknown) {
     const code =
       typeof error === "object" && error !== null && "code" in error
@@ -350,7 +355,7 @@ export async function refreshAllControlMessages(client: BotClient): Promise<void
   )
   client.info(`[ControlHandler] Refreshing ${guildIds.length} control message(s) after startup.`)
   for (const gid of guildIds) {
-    await updateControlMessage(client, gid).catch((err: unknown) =>
+    await updateControlMessage(client, gid, false).catch((err: unknown) =>
       client.warn(`[ControlHandler] Startup refresh failed for guild ${gid}: ${err}`)
     )
     await sleep(400)

--- a/src/events/handlers/handleControlChannel.ts
+++ b/src/events/handlers/handleControlChannel.ts
@@ -182,7 +182,7 @@ export function createControlButtons(
       "data" in c && c.data && "label" in c.data ? String((c.data as { label?: string }).label ?? "") : "?"
     )
     .join(", ")
-  client.debug(`[guildSettings] Control buttons created. Button labels: ${labels}`)
+  client.debug(`[ControlHandler] Control buttons created. Button labels: ${labels}`)
   return rows
 }
 

--- a/src/events/handlers/handleControlChannel.ts
+++ b/src/events/handlers/handleControlChannel.ts
@@ -115,13 +115,12 @@ export function createControlEmbed(client: BotClient, player: Player | null | un
 }
 
 /**
- * Creates the action row with buttons for the player control message.
- * @param {import("../../lib/BotClient").default} client The bot client instance for logging.
- * @param {import("lavalink-client").Player | null | undefined} player The Lavalink player (if any).
- * @returns {ActionRowBuilder<ButtonBuilder>} The created action row.
+ * Creates action rows for the player control message (max 5 buttons per row; autoplay is on row 2).
  */
-// Pass client for logging
-export function createControlButtons(client: BotClient, player: Player | null | undefined) {
+export function createControlButtons(
+  client: BotClient,
+  player: Player | null | undefined
+): ActionRowBuilder<ButtonBuilder>[] {
   client.debug(
     `[ControlHandler] Creating control buttons. Player state: ${player ? `Playing: ${player.playing}, Current: ${!!player.queue?.current}, Queue Size: ${player.queue?.tracks?.length ?? 0}` : "null"}`
   )
@@ -159,19 +158,32 @@ export function createControlButtons(client: BotClient, player: Player | null | 
     .setStyle(ButtonStyle.Secondary)
     .setDisabled(!hasCurrent && !hasQueue)
 
-  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+  const mainRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
     playPauseButton,
     stopButton,
     skipButton,
     shuffleButton,
     loopButton
   )
-  client.debug(
-    `[guildSettings] Control buttons created. Button labels: ${row.components
-      .map((c) => ("data" in c && c.data && "label" in c.data ? String((c.data as { label?: string }).label ?? "") : "?"))
-      .join(", ")}`
-  )
-  return row
+
+  const autoplayOn = Boolean(player?.get?.("autoplay"))
+  const autoplayButton = new ButtonBuilder()
+    .setCustomId("control_autoplay")
+    .setLabel(autoplayOn ? "Autoplay: On" : "Autoplay: Off")
+    .setStyle(autoplayOn ? ButtonStyle.Success : ButtonStyle.Secondary)
+    .setDisabled(!player)
+
+  const autoplayRow = new ActionRowBuilder<ButtonBuilder>().addComponents(autoplayButton)
+
+  const rows = [mainRow, autoplayRow]
+  const labels = rows
+    .flatMap((r) => r.components)
+    .map((c) =>
+      "data" in c && c.data && "label" in c.data ? String((c.data as { label?: string }).label ?? "") : "?"
+    )
+    .join(", ")
+  client.debug(`[guildSettings] Control buttons created. Button labels: ${labels}`)
+  return rows
 }
 
 /**
@@ -303,7 +315,7 @@ export async function updateControlMessage(client: BotClient, guildId: string) {
     const updatedEmbed = createControlEmbed(client, player)
     const updatedButtons = createControlButtons(client, player)
 
-    await controlMessage.edit({ embeds: [updatedEmbed], components: [updatedButtons] })
+    await controlMessage.edit({ embeds: [updatedEmbed], components: updatedButtons })
     client.debug(
       `[ControlHandler] Successfully edited control message ${controlMessage.id} in guild ${guildId}`
     )
@@ -324,5 +336,23 @@ export async function updateControlMessage(client: BotClient, guildId: string) {
     } else {
       client.error(`[ControlHandler] Failed to update control message for guild ${guildId}:`, error)
     }
+  }
+}
+
+/**
+ * Re-edits every guild control message so new buttons/layout apply without `/control-channel set`.
+ * Called once after login; staggered to reduce rate limits.
+ */
+export async function refreshAllControlMessages(client: BotClient): Promise<void> {
+  const store = getGuildSettings(client)
+  const guildIds = Object.keys(store).filter(
+    (id) => store[id]?.controlChannelId && store[id]?.controlMessageId
+  )
+  client.info(`[ControlHandler] Refreshing ${guildIds.length} control message(s) after startup.`)
+  for (const gid of guildIds) {
+    await updateControlMessage(client, gid).catch((err: unknown) =>
+      client.warn(`[ControlHandler] Startup refresh failed for guild ${gid}: ${err}`)
+    )
+    await sleep(400)
   }
 }

--- a/src/events/onReady.ts
+++ b/src/events/onReady.ts
@@ -1,5 +1,6 @@
 import { ActivityType } from "discord.js"
 import type BotClient from "../lib/BotClient.js"
+import { refreshAllControlMessages } from "./handlers/handleControlChannel.js"
 
 export default async (client: BotClient) => {
   client.on("clientReady", () => {
@@ -12,6 +13,10 @@ export default async (client: BotClient) => {
     client.lavalink.init({ id: user.id, username: user.username })
 
     client.info(`Logged in as ${user.tag}! (${user.id})`)
+
+    refreshAllControlMessages(client).catch((err: unknown) =>
+      client.error("[ControlHandler] refreshAllControlMessages failed:", err)
+    )
 
     user.setActivity("I hate that Pancake guy!", { type: ActivityType.Custom })
     

--- a/src/util/autoplayHistory.ts
+++ b/src/util/autoplayHistory.ts
@@ -545,6 +545,16 @@ export function seedAutoplayHistoryFromPlayer(player: Player) {
   if (cur?.info) rememberAutoplayPlayed(player, cur.info)
 }
 
+/** Toggles Spotify-based autoplay on the player and syncs session history (same behavior as `/autoplay`). */
+export function toggleAutoplay(player: Player): boolean {
+  const wasOn = !!player.get("autoplay")
+  const next = !wasOn
+  player.set("autoplay", next)
+  if (!next) clearAutoplayRecent(player)
+  else seedAutoplayHistoryFromPlayer(player)
+  return next
+}
+
 /**
  * True if the candidate is the same source as the track that just ended.
  */


### PR DESCRIPTION
## Summary
- Adds a second action row on the music control message with an **Autoplay** toggle (\control_autoplay\), mirroring \/autoplay\ (including voice rules when the player is connected).
- Introduces \	oggleAutoplay()\ in \utoplayHistory.ts\ and reuses it from the slash command and the button handler.
- On \clientReady\, \efreshAllControlMessages()\ re-edits every configured control message (staggered) so existing guilds get the new layout without re-running \/control-channel set\.

## Testing
- [ ] Restart bot; confirm control messages in configured guilds gain the autoplay row.
- [ ] Toggle autoplay from the button vs \/autoplay\; confirm embed state and behavior match.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autoplay toggle added to the control panel so users can enable/disable autoplay directly (with follow-up messages indicating state).

* **Improvements**
  * Reorganized control buttons into multiple rows for clearer layout.
  * Control messages now refresh automatically on startup to reflect current state.
  * Voice-channel validation tightened for autoplay interactions.
  * Control message updates support multi-row layouts and optional cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->