### PR TITLE
Round-robin queue (RRQ) with disconnect cleanup and rebalance

### DIFF
--- a/src/commands/music/PlayNext.ts
+++ b/src/commands/music/PlayNext.ts
@@ -2,6 +2,11 @@ import { SlashCommandBuilder } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import {
+    isRRQActive,
+    rebalancePlayerQueueRoundRobin,
+    stampRequesterUserIdOnTracks,
+} from "../../util/rrqDisconnect.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -64,7 +69,11 @@ export default {
         }
 
         const track = res.tracks[0]
+        stampRequesterUserIdOnTracks([track], interaction.user.id)
         player.queue.add(track, 0)
+        if (isRRQActive(player)) {
+            await rebalancePlayerQueueRoundRobin(player)
+        }
         return interaction.editReply(
             `Added [${track.info.title}](${track.info.uri}) to the top of the queue.`
         )

--- a/src/commands/music/RoundRobin.ts
+++ b/src/commands/music/RoundRobin.ts
@@ -1,0 +1,69 @@
+import { SlashCommandBuilder } from "discord.js"
+import type BotClient from "../../lib/BotClient.js"
+import type { ChatInputCommandInteraction } from "discord.js"
+import { guildMemberFromInteraction } from "../../util/guildMember.js"
+
+import { rebalancePlayerQueueRoundRobin, toggleRRQ } from "../../util/rrqDisconnect.js"
+import { updateControlMessage } from "../../events/handlers/handleControlChannel.js"
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName("roundrobin")
+        .setDescription("Toggle round-robin queue mode (fair track ordering per user)"),
+
+    /** Toggles round-robin queue for the guild player and refreshes the control message. */
+    async execute(interaction: ChatInputCommandInteraction, client: BotClient): Promise<unknown> {
+        const guild = interaction.guild
+        if (!guild) {
+            return interaction.reply({
+                content: "Use this command in a server.",
+                ephemeral: true,
+            })
+        }
+        const member = guildMemberFromInteraction(interaction)
+        if (!member) {
+            return interaction.reply({
+                content: "Could not resolve your member profile. Try again.",
+                ephemeral: true,
+            })
+        }
+
+        const voiceChannel = member.voice.channel
+        if (!voiceChannel) {
+            return interaction.reply({ content: "Join a voice channel first!", ephemeral: true })
+        }
+
+        const player = client.lavalink.getPlayer(guild.id)
+        if (!player) {
+            return interaction.reply({
+                content: "There is no player for this guild.",
+                ephemeral: true,
+            })
+        }
+
+        if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+            return interaction.reply({
+                content: "You need to be in the same voice channel as the bot!",
+                ephemeral: true,
+            })
+        }
+
+        const enabled = toggleRRQ(player)
+        if (enabled) {
+            await rebalancePlayerQueueRoundRobin(player)
+        }
+
+        await interaction.reply({
+            content: enabled
+                ? "Round-robin queue is now **enabled**."
+                : "Round-robin queue is now **disabled**.",
+        })
+
+        try {
+            await updateControlMessage(client, guild.id)
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e)
+            client.warn(`[RoundRobin] updateControlMessage failed: ${msg}`)
+        }
+    },
+}

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -349,7 +349,7 @@ export default async (client: BotClient) => {
             client.debug(
                 `[LavaMgrEvents] User joined player's channel: Guild ${player.guildId}, User: ${userId}`
             )
-            if (isRRQActive(player) && hasTrackedDisconnect(player, userId)) {
+            if (hasTrackedDisconnect(player, userId)) {
                 clearDisconnectedUser(player, userId)
                 client.debug(
                     `[LavaMgrEvents] User ${userId} rejoined VC in guild ${player.guildId}; RRQ queue removal cancelled.`
@@ -471,9 +471,10 @@ export default async (client: BotClient) => {
                                     userId
                                 )
                                 channelRrq
-                                    .send(
-                                        `Removed **${removedCount}** track(s) queued by ${who} (left voice channel).`
-                                    )
+                                    .send({
+                                        content: `Removed **${removedCount}** track(s) queued by ${who} (left voice channel).`,
+                                        allowedMentions: { parse: [] },
+                                    })
                                     .catch((e: unknown) =>
                                         client.error(
                                             "[LavaMgrEvents] Failed to send RRQ cleanup message:",

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -24,6 +24,7 @@ import {
     hasTrackedDisconnect,
     isDisconnectTimeoutCurrent,
     isRRQActive,
+    rebalancePlayerQueueRoundRobin,
     removeUserTracksFromQueue,
     trackDisconnectedUser,
     userHasQueuedTracks,
@@ -410,6 +411,10 @@ export default async (client: BotClient) => {
                     void (async () => {
                         const p = client.lavalink.getPlayer(guildId)
                         if (!p) return
+                        if (!isRRQActive(p)) {
+                            clearDisconnectedUser(p, userId)
+                            return
+                        }
                         if (!isDisconnectTimeoutCurrent(p, userId, timeoutHandle)) return
 
                         let removedCount = 0
@@ -425,6 +430,26 @@ export default async (client: BotClient) => {
                         }
 
                         if (removedCount > 0) {
+                            if (isRRQActive(p)) {
+                                try {
+                                    await rebalancePlayerQueueRoundRobin(p)
+                                } catch (rebalErr: unknown) {
+                                    client.warn(
+                                        "[LavaMgrEvents] RRQ rebalance after disconnect cleanup failed:",
+                                        rebalErr
+                                    )
+                                }
+                            }
+                            try {
+                                await updateControlMessage(client, p.guildId)
+                            } catch (ctrlErr: unknown) {
+                                const msg =
+                                    ctrlErr instanceof Error ? ctrlErr.message : String(ctrlErr)
+                                client.warn(
+                                    `[LavaMgrEvents] updateControlMessage after RRQ cleanup failed: ${msg}`
+                                )
+                            }
+
                             const textIdRrq = p.textChannelId
                             const channelRrq = textIdRrq
                                 ? client.channels.cache.get(textIdRrq)

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -19,6 +19,15 @@ import { getGuildSettings } from "../util/saveControlChannel.js"
 import { rememberAutoplayPlayed } from "../util/autoplayHistory.js"
 import { updateControlMessage } from "./handlers/handleControlChannel.js"
 import { discordDeleteErrorDetails } from "../util/discordErrorDetails.js"
+import {
+    clearDisconnectedUser,
+    hasTrackedDisconnect,
+    isDisconnectTimeoutCurrent,
+    isRRQActive,
+    removeUserTracksFromQueue,
+    trackDisconnectedUser,
+    userHasQueuedTracks,
+} from "../util/rrqDisconnect.js"
 
 type GuildTextSendable = { send: (content: string) => Promise<Message<boolean>> }
 
@@ -314,6 +323,12 @@ export default async (client: BotClient) => {
             client.debug(
                 `[LavaMgrEvents] User joined player's channel: Guild ${player.guildId}, User: ${userId}`
             )
+            if (isRRQActive(player) && hasTrackedDisconnect(player, userId)) {
+                clearDisconnectedUser(player, userId)
+                client.debug(
+                    `[LavaMgrEvents] User ${userId} rejoined VC in guild ${player.guildId}; RRQ queue removal cancelled.`
+                )
+            }
         })
         .on("playerVoiceLeave", (player: Player, userId: string) => {
             client.debug(
@@ -362,6 +377,59 @@ export default async (client: BotClient) => {
                         )
                     }
                 }, 5000)
+            }
+
+            if (isRRQActive(player) && userHasQueuedTracks(player, userId)) {
+                const guildId = player.guildId
+                const timeoutHandle = setTimeout(() => {
+                    void (async () => {
+                        const p = client.lavalink.getPlayer(guildId)
+                        if (!p) return
+                        if (!isDisconnectTimeoutCurrent(p, userId, timeoutHandle)) return
+
+                        let removedCount = 0
+                        try {
+                            removedCount = await removeUserTracksFromQueue(p, userId)
+                        } catch (err: unknown) {
+                            client.error(
+                                "[LavaMgrEvents] RRQ removeUserTracksFromQueue failed:",
+                                err
+                            )
+                        } finally {
+                            clearDisconnectedUser(p, userId)
+                        }
+
+                        if (removedCount > 0) {
+                            const textIdRrq = p.textChannelId
+                            const channelRrq = textIdRrq
+                                ? client.channels.cache.get(textIdRrq)
+                                : undefined
+                            const currentGuildSettingsRrq = getGuildSettings(client)
+                            const controlChannelIdRrq =
+                                currentGuildSettingsRrq[p.guildId]?.controlChannelId
+                            if (
+                                channelRrq &&
+                                textIdRrq !== controlChannelIdRrq &&
+                                isTextSendable(channelRrq)
+                            ) {
+                                client.debug(
+                                    `[LavaMgrEvents] Sending RRQ disconnect cleanup to non-control channel ${textIdRrq} in guild ${p.guildId}.`
+                                )
+                                channelRrq
+                                    .send(
+                                        `Removed **${removedCount}** track(s) queued by <@${userId}> (left voice channel).`
+                                    )
+                                    .catch((e: unknown) =>
+                                        client.error(
+                                            "[LavaMgrEvents] Failed to send RRQ cleanup message:",
+                                            e
+                                        )
+                                    )
+                            }
+                        }
+                    })()
+                }, 60_000)
+                trackDisconnectedUser(player, userId, timeoutHandle)
             }
         })
 

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -40,6 +40,31 @@ function isTextSendable(channel: unknown): channel is GuildTextSendable {
     )
 }
 
+function escapeDiscordMarkdown(text: string): string {
+    return text
+        .replace(/\\/g, "\\\\")
+        .replace(/\*/g, "\\*")
+        .replace(/_/g, "\\_")
+        .replace(/`/g, "\\`")
+}
+
+/** Guild nickname if cached/fetchable, else global/username — plain text, no @ mention. */
+async function displayNameForRRQMessage(
+    client: BotClient,
+    guildId: string,
+    userId: string
+): Promise<string> {
+    const guild =
+        client.guilds.cache.get(guildId) ?? (await client.guilds.fetch(guildId).catch(() => null))
+    if (guild) {
+        const member = await guild.members.fetch(userId).catch(() => null)
+        if (member) return escapeDiscordMarkdown(member.displayName)
+    }
+    const user = await client.users.fetch(userId).catch(() => null)
+    if (user) return escapeDiscordMarkdown(user.globalName ?? user.username)
+    return "someone"
+}
+
 export default async (client: BotClient) => {
     client.lavalink
         /**
@@ -415,9 +440,14 @@ export default async (client: BotClient) => {
                                 client.debug(
                                     `[LavaMgrEvents] Sending RRQ disconnect cleanup to non-control channel ${textIdRrq} in guild ${p.guildId}.`
                                 )
+                                const who = await displayNameForRRQMessage(
+                                    client,
+                                    p.guildId,
+                                    userId
+                                )
                                 channelRrq
                                     .send(
-                                        `Removed **${removedCount}** track(s) queued by <@${userId}> (left voice channel).`
+                                        `Removed **${removedCount}** track(s) queued by ${who} (left voice channel).`
                                     )
                                     .catch((e: unknown) =>
                                         client.error(

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -5,7 +5,7 @@
  * @see https://tomato6966.github.io/lavalink-client/api/types/manager/interfaces/lavalinkmanagerevents/
  */
 
-import type { Message } from "discord.js"
+import type { Message, MessageCreateOptions, MessagePayload } from "discord.js"
 import type {
     Player,
     Track,
@@ -24,13 +24,14 @@ import {
     hasTrackedDisconnect,
     isDisconnectTimeoutCurrent,
     isRRQActive,
-    rebalancePlayerQueueRoundRobin,
-    removeUserTracksFromQueue,
+    removeAndRebalanceRrqAfterDisconnect,
     trackDisconnectedUser,
     userHasQueuedTracks,
 } from "../util/rrqDisconnect.js"
 
-type GuildTextSendable = { send: (content: string) => Promise<Message<boolean>> }
+type GuildTextSendable = {
+    send: (content: string | MessagePayload | MessageCreateOptions) => Promise<Message<boolean>>
+}
 
 function isTextSendable(channel: unknown): channel is GuildTextSendable {
     return (
@@ -417,29 +418,20 @@ export default async (client: BotClient) => {
                         }
                         if (!isDisconnectTimeoutCurrent(p, userId, timeoutHandle)) return
 
-                        let removedCount = 0
-                        try {
-                            removedCount = await removeUserTracksFromQueue(p, userId)
-                        } catch (err: unknown) {
-                            client.error(
-                                "[LavaMgrEvents] RRQ removeUserTracksFromQueue failed:",
-                                err
-                            )
-                        } finally {
-                            clearDisconnectedUser(p, userId)
-                        }
+                        const removedCount = await removeAndRebalanceRrqAfterDisconnect(p, userId, {
+                            onRemoveError: (err: unknown) =>
+                                client.error(
+                                    "[LavaMgrEvents] RRQ removeUserTracksFromQueue failed:",
+                                    err
+                                ),
+                            onRebalanceError: (rebalErr: unknown) =>
+                                client.warn(
+                                    "[LavaMgrEvents] RRQ rebalance after disconnect cleanup failed:",
+                                    rebalErr
+                                ),
+                        })
 
                         if (removedCount > 0) {
-                            if (isRRQActive(p)) {
-                                try {
-                                    await rebalancePlayerQueueRoundRobin(p)
-                                } catch (rebalErr: unknown) {
-                                    client.warn(
-                                        "[LavaMgrEvents] RRQ rebalance after disconnect cleanup failed:",
-                                        rebalErr
-                                    )
-                                }
-                            }
                             try {
                                 await updateControlMessage(client, p.guildId)
                             } catch (ctrlErr: unknown) {

--- a/src/lib/LavalinkManager.ts
+++ b/src/lib/LavalinkManager.ts
@@ -24,6 +24,7 @@ import {
 } from "../util/autoplayHistory.js"
 import { updateControlMessage } from "../events/handlers/handleControlChannel.js"
 import { getGuildSettings } from "../util/saveControlChannel.js"
+import { isRRQActive, rebalancePlayerQueueRoundRobin } from "../util/rrqDisconnect.js"
 import type BotClient from "./BotClient.js"
 
 /** If title starts with artist then a separator (-–—:|), returns the rest; otherwise null (no dynamic RegExp from user data). */
@@ -272,6 +273,9 @@ async function tryQueueAndPlayAutoplay(
         if (!shouldStillInjectAutoplayTrack(player)) return false
 
         player.queue.add(lavalinkTrack)
+        if (isRRQActive(player)) {
+            await rebalancePlayerQueueRoundRobin(player)
+        }
         try {
             await player.play()
         } catch (playErr: unknown) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,3 +109,17 @@ export interface LoggerInterface {
     /** When set, each log line is forwarded (e.g. to Discord) after console/file logging. */
     setDiscordForwarder?(callback: DiscordLogForwarder | null): void
 }
+
+/** Tracks a user who left voice while RRQ is active and has queued tracks. */
+export interface DisconnectedRRQUser {
+    userId: string
+    /** Epoch ms when the user left the voice channel. */
+    leftAt: number
+    timeoutHandle: NodeJS.Timeout
+}
+
+/**
+ * Per-player map of disconnected users pending queue cleanup.
+ * Stored on the player via `player.set("rrqDisconnectedUsers", map)`.
+ */
+export type RRQDisconnectedUsersMap = Map<string, DisconnectedRRQUser>

--- a/src/util/musicManager.ts
+++ b/src/util/musicManager.ts
@@ -14,6 +14,11 @@ import {
 import type { Player, PlayerJson, Track, UnresolvedTrack } from "lavalink-client"
 import type BotClient from "../lib/BotClient.js"
 import type { LocalFile, QueryPlayResult } from "../types/index.js"
+import {
+    isRRQActive,
+    rebalancePlayerQueueRoundRobin,
+    stampRequesterUserIdOnTracks,
+} from "./rrqDisconnect.js"
 
 type SearchAttempt =
     | { source: string; success: true; loadType?: string }
@@ -581,13 +586,19 @@ export async function handleQueryAndPlay(
                 await ensurePlayerConnected(client, player, voiceChannel)
 
                 if (isPlaylistEnqueue && searchResult.tracks.length > 0) {
+                    stampRequesterUserIdOnTracks(searchResult.tracks, requester.id)
                     player.queue.add(searchResult.tracks)
                     client.debug(
                         `[MusicManager] Enqueued playlist (${searchResult.tracks.length} tracks) for guild ${guildId}.`
                     )
                 } else {
+                    stampRequesterUserIdOnTracks([trackToAdd], requester.id)
                     player.queue.add(trackToAdd)
                     client.debug(`[MusicManager] Enqueued single track [${trackToAdd.info.title}].`)
+                }
+
+                if (isRRQActive(player)) {
+                    await rebalancePlayerQueueRoundRobin(player)
                 }
 
                 if (!feedbackText) {

--- a/src/util/rrqDisconnect.ts
+++ b/src/util/rrqDisconnect.ts
@@ -196,3 +196,54 @@ export async function removeUserTracksFromQueue(player: Player, userId: string):
     }
     return removed
 }
+
+const rrqMutationChainByGuild = new Map<string, Promise<unknown>>()
+
+function enqueueRrqMutation<T>(guildId: string, work: () => Promise<T>): Promise<T> {
+    const prior = rrqMutationChainByGuild.get(guildId) ?? Promise.resolve()
+    const result = prior.then(() => work())
+    rrqMutationChainByGuild.set(
+        guildId,
+        result.then(
+            () => undefined,
+            () => undefined
+        )
+    )
+    return result
+}
+
+export type RemoveAndRebalanceRrqHooks = {
+    onRemoveError?: (err: unknown) => void
+    onRebalanceError?: (err: unknown) => void
+}
+
+/**
+ * Runs disconnect cleanup (remove user’s queued tracks, clear disconnect tracking, optional rebalance)
+ * serialized per guild so reordering cannot race with other RRQ queue mutations for that player.
+ */
+export async function removeAndRebalanceRrqAfterDisconnect(
+    player: Player,
+    userId: string,
+    hooks?: RemoveAndRebalanceRrqHooks
+): Promise<number> {
+    return enqueueRrqMutation(player.guildId, async () => {
+        let removedCount = 0
+        try {
+            removedCount = await removeUserTracksFromQueue(player, userId)
+        } catch (err: unknown) {
+            hooks?.onRemoveError?.(err)
+        } finally {
+            clearDisconnectedUser(player, userId)
+        }
+
+        if (removedCount > 0 && isRRQActive(player)) {
+            try {
+                await rebalancePlayerQueueRoundRobin(player)
+            } catch (rebalErr: unknown) {
+                hooks?.onRebalanceError?.(rebalErr)
+            }
+        }
+
+        return removedCount
+    })
+}

--- a/src/util/rrqDisconnect.ts
+++ b/src/util/rrqDisconnect.ts
@@ -1,0 +1,198 @@
+import type { Player, Track, UnresolvedTrack } from "lavalink-client"
+import type { RRQDisconnectedUsersMap } from "../types/index.js"
+
+const RRQ_DISCONNECTED_USERS_KEY = "rrqDisconnectedUsers"
+const RRQ_ENABLED_KEY = "rrqEnabled"
+
+/** Discord user id from a Lavalink requester (string id or object with `id`). */
+const UNKNOWN_REQUESTER_KEY = "__unknown__"
+
+/** Sentinel: no "previous" requester for adjacency (nothing playing or fresh sequence). */
+const RRQ_NO_PREVIOUS = "__rrq_none__"
+
+export function getRequesterUserId(requester: unknown): string | null {
+    if (typeof requester === "string") return requester
+    if (typeof requester === "object" && requester !== null && "id" in requester) {
+        const id = (requester as { id: unknown }).id
+        if (typeof id === "string") return id
+    }
+    return null
+}
+
+function requesterMatchesUser(requester: unknown, userId: string): boolean {
+    return getRequesterUserId(requester) === userId
+}
+
+/** Sets `track.requester` to the Discord user id so RRQ logic always has a stable string id. */
+export function stampRequesterUserIdOnTracks(
+    tracks: (Track | UnresolvedTrack)[],
+    userId: string
+): void {
+    for (const t of tracks) {
+        ;(t as unknown as { requester?: string }).requester = userId
+    }
+}
+
+/**
+ * Reorders upcoming tracks so the same requester is avoided back-to-back when possible
+ * (uses the currently playing track’s requester as the prior slot).
+ * Heavier requesters are scheduled earlier among valid choices to reduce long same-user runs at the tail.
+ */
+export function roundRobinReorderTracks(
+    tracks: (Track | UnresolvedTrack)[],
+    previousRequesterKey: string
+): (Track | UnresolvedTrack)[] {
+    if (tracks.length <= 1) return [...tracks]
+
+    const byUser = new Map<string, (Track | UnresolvedTrack)[]>()
+    for (const t of tracks) {
+        const id = getRequesterUserId(t.requester) ?? UNKNOWN_REQUESTER_KEY
+        const list = byUser.get(id)
+        if (list) list.push(t)
+        else byUser.set(id, [t])
+    }
+
+    const result: (Track | UnresolvedTrack)[] = []
+    let lastPlaced = previousRequesterKey
+
+    while (byUser.size > 0) {
+        const keysWithTracks = [...byUser.keys()].filter((k) => byUser.get(k)!.length > 0)
+        const candidates = keysWithTracks.filter((k) => k !== lastPlaced)
+        let pickKey: string
+        if (candidates.length > 0) {
+            pickKey = candidates.reduce((best, k) =>
+                byUser.get(k)!.length > byUser.get(best)!.length ? k : best
+            )
+        } else {
+            pickKey = keysWithTracks.reduce((best, k) =>
+                byUser.get(k)!.length > byUser.get(best)!.length ? k : best
+            )
+        }
+        const arr = byUser.get(pickKey)!
+        const next = arr.shift()!
+        if (arr.length === 0) byUser.delete(pickKey)
+        result.push(next)
+        lastPlaced = pickKey
+    }
+
+    return result
+}
+
+/** Re-sorts `player.queue.tracks` for round-robin fairness when RRQ mode is on. */
+export async function rebalancePlayerQueueRoundRobin(player: Player): Promise<void> {
+    if (!isRRQActive(player)) return
+    const tracks = player.queue.tracks
+    const n = tracks.length
+    if (n <= 1) return
+
+    const current = player.queue.current
+    const previousKey = current
+        ? (getRequesterUserId(current.requester) ?? UNKNOWN_REQUESTER_KEY)
+        : RRQ_NO_PREVIOUS
+
+    const ordered = roundRobinReorderTracks([...tracks], previousKey)
+    const unchanged = ordered.length === n && ordered.every((t, i) => t === tracks[i])
+    if (unchanged) return
+
+    await player.queue.splice(0, n, ordered)
+}
+
+/** Returns the per-player map of users pending RRQ disconnect cleanup, creating it if missing. */
+export function getDisconnectedUsers(player: Player): RRQDisconnectedUsersMap {
+    const existing = player.get(RRQ_DISCONNECTED_USERS_KEY) as unknown
+    if (existing instanceof Map) {
+        return existing as RRQDisconnectedUsersMap
+    }
+    const map: RRQDisconnectedUsersMap = new Map()
+    player.set(RRQ_DISCONNECTED_USERS_KEY, map)
+    return map
+}
+
+/** Records a pending disconnect cleanup timer for a user (replaces any prior timer for that user). */
+export function trackDisconnectedUser(
+    player: Player,
+    userId: string,
+    timeoutHandle: NodeJS.Timeout
+): void {
+    const map = getDisconnectedUsers(player)
+    const prior = map.get(userId)
+    if (prior) clearTimeout(prior.timeoutHandle)
+    map.set(userId, { userId, leftAt: Date.now(), timeoutHandle })
+}
+
+/** Cancels the disconnect timer and removes tracking for a user. */
+export function clearDisconnectedUser(player: Player, userId: string): void {
+    const raw = player.get(RRQ_DISCONNECTED_USERS_KEY) as unknown
+    if (!(raw instanceof Map)) return
+    const map = raw as RRQDisconnectedUsersMap
+    const entry = map.get(userId)
+    if (!entry) return
+    clearTimeout(entry.timeoutHandle)
+    map.delete(userId)
+}
+
+/** Whether round-robin queue mode (and disconnect cleanup) is enabled for this player. */
+export function isRRQActive(player: Player): boolean {
+    return player.get(RRQ_ENABLED_KEY) === true
+}
+
+/** True if the user has a pending disconnect cleanup entry (without creating a map). */
+export function hasTrackedDisconnect(player: Player, userId: string): boolean {
+    const raw = player.get(RRQ_DISCONNECTED_USERS_KEY) as unknown
+    return raw instanceof Map && (raw as RRQDisconnectedUsersMap).has(userId)
+}
+
+/** True if this timer is still the active disconnect cleanup for the user (guards stale callbacks). */
+export function isDisconnectTimeoutCurrent(
+    player: Player,
+    userId: string,
+    timeoutHandle: NodeJS.Timeout
+): boolean {
+    const raw = player.get(RRQ_DISCONNECTED_USERS_KEY) as unknown
+    if (!(raw instanceof Map)) return false
+    const map = raw as RRQDisconnectedUsersMap
+    const entry = map.get(userId)
+    return entry?.timeoutHandle === timeoutHandle
+}
+
+function clearAllDisconnectedTimers(player: Player): void {
+    const raw = player.get(RRQ_DISCONNECTED_USERS_KEY) as unknown
+    if (!(raw instanceof Map)) return
+    const map = raw as RRQDisconnectedUsersMap
+    for (const entry of map.values()) {
+        clearTimeout(entry.timeoutHandle)
+    }
+    map.clear()
+}
+
+/**
+ * Toggles RRQ on/off. When disabling, clears all pending disconnect timers.
+ * @returns The new enabled state.
+ */
+export function toggleRRQ(player: Player): boolean {
+    const next = !isRRQActive(player)
+    player.set(RRQ_ENABLED_KEY, next)
+    if (!next) clearAllDisconnectedTimers(player)
+    return next
+}
+
+/** True if the user has any upcoming queued tracks (not the current track). */
+export function userHasQueuedTracks(player: Player, userId: string): boolean {
+    return player.queue.tracks.some((track) => requesterMatchesUser(track.requester, userId))
+}
+
+/**
+ * Removes upcoming queue tracks requested by the user. Does not alter the currently playing track.
+ * @returns How many tracks were removed.
+ */
+export async function removeUserTracksFromQueue(player: Player, userId: string): Promise<number> {
+    let removed = 0
+    for (let i = player.queue.tracks.length - 1; i >= 0; i--) {
+        const track = player.queue.tracks[i]
+        if (requesterMatchesUser(track.requester, userId)) {
+            await player.queue.splice(i, 1)
+            removed++
+        }
+    }
+    return removed
+}

--- a/src/util/rrqDisconnect.ts
+++ b/src/util/rrqDisconnect.ts
@@ -4,6 +4,9 @@ import type { RRQDisconnectedUsersMap } from "../types/index.js"
 const RRQ_DISCONNECTED_USERS_KEY = "rrqDisconnectedUsers"
 const RRQ_ENABLED_KEY = "rrqEnabled"
 
+/** Discord user id or Lavalink-style requester payload; RRQ stamps string ids for stable reads via getRequesterUserId. */
+export type RrqRequester = string | { id: string }
+
 /** Discord user id from a Lavalink requester (string id or object with `id`). */
 const UNKNOWN_REQUESTER_KEY = "__unknown__"
 
@@ -23,14 +26,17 @@ function requesterMatchesUser(requester: unknown, userId: string): boolean {
     return getRequesterUserId(requester) === userId
 }
 
-/** Sets `track.requester` to the Discord user id so RRQ logic always has a stable string id. */
+/** Sets `track.requester` to the Discord user id so RRQ logic always has a stable string id (see getRequesterUserId). */
+function setRequesterUserId(track: Track | UnresolvedTrack, userId: string): void {
+    const requester: RrqRequester = userId
+    ;(track as (Track | UnresolvedTrack) & { requester?: RrqRequester }).requester = requester
+}
+
 export function stampRequesterUserIdOnTracks(
     tracks: (Track | UnresolvedTrack)[],
     userId: string
 ): void {
-    for (const t of tracks) {
-        ;(t as unknown as { requester?: string }).requester = userId
-    }
+    for (const t of tracks) setRequesterUserId(t, userId)
 }
 
 /**
@@ -78,8 +84,8 @@ export function roundRobinReorderTracks(
     return result
 }
 
-/** Re-sorts `player.queue.tracks` for round-robin fairness when RRQ mode is on. */
-export async function rebalancePlayerQueueRoundRobin(player: Player): Promise<void> {
+/** Core reorder; must run inside enqueueRrqMutation (or call exported rebalancePlayerQueueRoundRobin). */
+async function rebalancePlayerQueueRoundRobinImpl(player: Player): Promise<void> {
     if (!isRRQActive(player)) return
     const tracks = player.queue.tracks
     const n = tracks.length
@@ -95,6 +101,14 @@ export async function rebalancePlayerQueueRoundRobin(player: Player): Promise<vo
     if (unchanged) return
 
     await player.queue.splice(0, n, ordered)
+}
+
+/**
+ * Re-sorts `player.queue.tracks` for round-robin fairness when RRQ mode is on.
+ * Serialized per guild with other RRQ queue mutations so snapshot/reorder cannot race concurrent splices.
+ */
+export async function rebalancePlayerQueueRoundRobin(player: Player): Promise<void> {
+    return enqueueRrqMutation(player.guildId, () => rebalancePlayerQueueRoundRobinImpl(player))
 }
 
 /** Returns the per-player map of users pending RRQ disconnect cleanup, creating it if missing. */
@@ -238,7 +252,7 @@ export async function removeAndRebalanceRrqAfterDisconnect(
 
         if (removedCount > 0 && isRRQActive(player)) {
             try {
-                await rebalancePlayerQueueRoundRobin(player)
+                await rebalancePlayerQueueRoundRobinImpl(player)
             } catch (rebalErr: unknown) {
                 hooks?.onRebalanceError?.(rebalErr)
             }


### PR DESCRIPTION
## Summary
Adds optional **round-robin queue** mode for fair multi-user sessions: /roundrobin toggles it per player (default off).

## Behavior
- **Enqueue**: Requester is stored as Discord user id on each track (/play, playlists, /playnext).
- **Rebalance** (when RRQ on): Reorders upcoming tracks to avoid the same requester back-to-back, respecting the currently playing track’s requester. Runs after play, playnext, enabling RRQ, and autoplay injects.
- **Disconnect**: If a user leaves voice with queued tracks, a 60s timer removes their upcoming tracks unless they rejoin; works alongside the existing alone-in-VC logic.

## Fix
- **Rebalance splice**: queue.splice takes (index, amount, TrackOrTracks) — pass the track **array** as the third argument, not ...spread, or only one track was re-inserted and the rest of the queue was lost.

## Follow-up
Deploy slash commands after merge: \yarn build\ then \yarn deployGlobal\ / \yarn deployGuild\.

Made with [Cursor](https://cursor.com)