### PR TITLE
feat(admin): developer dashboard, admin API, and /api routing fix

### DIFF
--- a/src/botApi/createBotApiApp.ts
+++ b/src/botApi/createBotApiApp.ts
@@ -7,6 +7,9 @@ import { playerPlayPOST } from "./handlers/playerPlay.js"
 import { queueDELETE, queueGET, queuePOST } from "./handlers/queue.js"
 import { queueIndexDELETE, queueIndexPATCH } from "./handlers/queueIndex.js"
 import { dashboardPermissionsGET } from "./handlers/dashboardPermissions.js"
+import { adminMetricsGET } from "./handlers/admin/metrics.js"
+import { adminErrorsDELETE, adminErrorsGET } from "./handlers/admin/errors.js"
+import { adminDbCleanupPOST, adminDbStatsGET } from "./handlers/admin/database.js"
 import { BotClientNotInitializedError } from "../lib/botClientRegistry.js"
 
 /** Redacts credentials and long base64-like blobs from bot API error strings before JSON responses. */
@@ -166,6 +169,57 @@ export function createBotApiApp(): express.Express {
                 req.params.guildId,
                 req.params.index,
                 req.body
+            )
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.get("/api/admin/metrics", async (req, res, next) => {
+        try {
+            const r = await adminMetricsGET(incomingMessageToHeaders(req))
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.get("/api/admin/errors", async (req, res, next) => {
+        try {
+            const url = new URL(req.originalUrl || req.url || "/", "http://localhost")
+            const r = await adminErrorsGET(incomingMessageToHeaders(req), url.searchParams)
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.delete("/api/admin/errors", async (req, res, next) => {
+        try {
+            const r = await adminErrorsDELETE(incomingMessageToHeaders(req))
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.get("/api/admin/database/stats", async (req, res, next) => {
+        try {
+            const r = await adminDbStatsGET(incomingMessageToHeaders(req))
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.post("/api/admin/database/cleanup", async (req, res, next) => {
+        try {
+            const url = new URL(req.originalUrl || req.url || "/", "http://localhost")
+            const r = await adminDbCleanupPOST(
+                incomingMessageToHeaders(req),
+                req.body,
+                url.searchParams
             )
             res.status(r.status).json(r.body)
         } catch (error) {

--- a/src/botApi/handlers/admin/database.ts
+++ b/src/botApi/handlers/admin/database.ts
@@ -1,0 +1,118 @@
+import { requireDeveloperAccess } from "../../../shared/api-auth.js"
+import { getPrismaClient } from "../../../lib/database.js"
+import type { ApiResponse } from "../../../types/index.js"
+
+export interface AdminDbStatsResponse {
+    sessions: { total: number; expired: number }
+    verifications: { total: number; expired: number }
+}
+
+export type AdminDbCleanupTarget = "sessions" | "verifications" | "all"
+
+export interface AdminDbCleanupBody {
+    target: AdminDbCleanupTarget
+}
+
+export interface AdminDbCleanupResponse {
+    dryRun: boolean
+    deleted: { sessions?: number; verifications?: number }
+}
+
+function expiredWhere() {
+    return { expiresAt: { lt: new Date() } }
+}
+
+function isCleanupTarget(value: unknown): value is AdminDbCleanupTarget {
+    return value === "sessions" || value === "verifications" || value === "all"
+}
+
+export async function adminDbStatsGET(
+    headers: Headers
+): Promise<{ status: number; body: ApiResponse<AdminDbStatsResponse> }> {
+    const guard = await requireDeveloperAccess(headers)
+    if (guard.ok === false) {
+        return {
+            status: guard.status,
+            body: { ok: false, error: { error: guard.error, details: guard.details } },
+        }
+    }
+
+    const prisma = getPrismaClient()
+    const expiredFilter = expiredWhere()
+
+    const [sessionsTotal, sessionsExpired, verificationsTotal, verificationsExpired] =
+        await Promise.all([
+            prisma.session.count(),
+            prisma.session.count({ where: expiredFilter }),
+            prisma.verification.count(),
+            prisma.verification.count({ where: expiredFilter }),
+        ])
+
+    return {
+        status: 200,
+        body: {
+            ok: true,
+            data: {
+                sessions: { total: sessionsTotal, expired: sessionsExpired },
+                verifications: { total: verificationsTotal, expired: verificationsExpired },
+            },
+        },
+    }
+}
+
+export async function adminDbCleanupPOST(
+    headers: Headers,
+    rawBody: unknown,
+    query: URLSearchParams
+): Promise<{ status: number; body: ApiResponse<AdminDbCleanupResponse> }> {
+    const guard = await requireDeveloperAccess(headers)
+    if (guard.ok === false) {
+        return {
+            status: guard.status,
+            body: { ok: false, error: { error: guard.error, details: guard.details } },
+        }
+    }
+
+    const body = rawBody as AdminDbCleanupBody | null
+    const target = body?.target
+    if (!isCleanupTarget(target)) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: {
+                    error: "Invalid request",
+                    details: 'Body must include target: "sessions", "verifications", or "all".',
+                },
+            },
+        }
+    }
+
+    const dryRun = query.get("dryRun") === "true"
+    const prisma = getPrismaClient()
+    const where = expiredWhere()
+    const deleted: AdminDbCleanupResponse["deleted"] = {}
+
+    if (target === "sessions" || target === "all") {
+        if (dryRun) {
+            deleted.sessions = await prisma.session.count({ where })
+        } else {
+            const result = await prisma.session.deleteMany({ where })
+            deleted.sessions = result.count
+        }
+    }
+
+    if (target === "verifications" || target === "all") {
+        if (dryRun) {
+            deleted.verifications = await prisma.verification.count({ where })
+        } else {
+            const result = await prisma.verification.deleteMany({ where })
+            deleted.verifications = result.count
+        }
+    }
+
+    return {
+        status: 200,
+        body: { ok: true, data: { dryRun, deleted } },
+    }
+}

--- a/src/botApi/handlers/admin/errors.ts
+++ b/src/botApi/handlers/admin/errors.ts
@@ -1,0 +1,63 @@
+import { requireDeveloperAccess } from "../../../shared/api-auth.js"
+import {
+    clearErrorHistory,
+    getErrorsByGuild,
+    getRecentErrors,
+    type ErrorHistoryEntry,
+} from "../../../lib/errorHistory.js"
+import type { ApiResponse } from "../../../types/index.js"
+
+export interface AdminErrorsListResponse {
+    entries: ErrorHistoryEntry[]
+}
+
+export interface AdminErrorsClearResponse {
+    cleared: true
+}
+
+function parseLimit(raw: string | null): number {
+    if (!raw) return 100
+    const n = Number.parseInt(raw, 10)
+    if (!Number.isFinite(n)) return 100
+    return Math.max(1, Math.min(n, 500))
+}
+
+export async function adminErrorsGET(
+    headers: Headers,
+    query: URLSearchParams
+): Promise<{ status: number; body: ApiResponse<AdminErrorsListResponse> }> {
+    const guard = await requireDeveloperAccess(headers)
+    if (guard.ok === false) {
+        return {
+            status: guard.status,
+            body: { ok: false, error: { error: guard.error, details: guard.details } },
+        }
+    }
+
+    const limit = parseLimit(query.get("limit"))
+    const guildId = query.get("guildId")?.trim()
+    const entries = guildId ? getErrorsByGuild(guildId, limit) : getRecentErrors(limit)
+
+    return {
+        status: 200,
+        body: { ok: true, data: { entries } },
+    }
+}
+
+export async function adminErrorsDELETE(
+    headers: Headers
+): Promise<{ status: number; body: ApiResponse<AdminErrorsClearResponse> }> {
+    const guard = await requireDeveloperAccess(headers)
+    if (guard.ok === false) {
+        return {
+            status: guard.status,
+            body: { ok: false, error: { error: guard.error, details: guard.details } },
+        }
+    }
+
+    clearErrorHistory()
+    return {
+        status: 200,
+        body: { ok: true, data: { cleared: true } },
+    }
+}

--- a/src/botApi/handlers/admin/metrics.ts
+++ b/src/botApi/handlers/admin/metrics.ts
@@ -1,0 +1,91 @@
+import type { Player, Track, UnresolvedTrack } from "lavalink-client"
+import { requireDeveloperAccess } from "../../../shared/api-auth.js"
+import { getBotClient } from "../../../lib/botClientRegistry.js"
+import type { ApiResponse } from "../../../types/index.js"
+import type {
+    AdminGuildSummary,
+    AdminMetricsResponse,
+    AdminMetricsPlayerSummary,
+} from "../../../types/web.js"
+
+export type {
+    AdminGuildSummary,
+    AdminMetricsPlayerSummary,
+    AdminMetricsResponse,
+} from "../../../types/web.js"
+
+function playerStatus(player: Player): "playing" | "paused" | "idle" {
+    if (player.playing) return "playing"
+    if (player.paused) return "paused"
+    return "idle"
+}
+
+function currentTrackSummary(
+    track: Track | UnresolvedTrack | null | undefined
+): AdminMetricsPlayerSummary["currentTrack"] {
+    if (!track?.info) return null
+    const info = track.info
+    const title =
+        typeof info.title === "string" && info.title.trim() ? info.title.trim() : "Unknown"
+    const author =
+        typeof info.author === "string" && info.author.trim() ? info.author.trim() : undefined
+    const uri = typeof info.uri === "string" && info.uri.trim() ? info.uri.trim() : undefined
+    return { title, author, uri }
+}
+
+export async function adminMetricsGET(
+    headers: Headers
+): Promise<{ status: number; body: ApiResponse<AdminMetricsResponse> }> {
+    const guard = await requireDeveloperAccess(headers)
+    if (guard.ok === false) {
+        return {
+            status: guard.status,
+            body: { ok: false, error: { error: guard.error, details: guard.details } },
+        }
+    }
+
+    const client = getBotClient()
+    const players = client.lavalink.players
+    const summaries: AdminMetricsPlayerSummary[] = []
+
+    const guilds: AdminGuildSummary[] = []
+    for (const guild of client.guilds.cache.values()) {
+        const mc = guild.memberCount
+        guilds.push({
+            guildId: guild.id,
+            guildName: guild.name,
+            memberCount: typeof mc === "number" && Number.isFinite(mc) ? mc : null,
+        })
+    }
+    guilds.sort((a, b) =>
+        a.guildName.localeCompare(b.guildName, undefined, { sensitivity: "base" })
+    )
+
+    for (const player of players.values()) {
+        const guild = client.guilds.cache.get(player.guildId)
+        summaries.push({
+            guildId: player.guildId,
+            guildName: guild?.name ?? null,
+            status: playerStatus(player),
+            queueSize: player.queue?.tracks?.length ?? 0,
+            currentTrack: currentTrackSummary(player.queue?.current),
+        })
+    }
+
+    const nodeManager = client.lavalink.nodeManager as { nodes?: { size?: number } }
+    const nodeCount = typeof nodeManager.nodes?.size === "number" ? nodeManager.nodes.size : 0
+
+    return {
+        status: 200,
+        body: {
+            ok: true,
+            data: {
+                guildCount: guilds.length,
+                activePlayers: players.size,
+                nodeCount,
+                guilds,
+                players: summaries,
+            },
+        },
+    }
+}

--- a/src/lib/Logger.ts
+++ b/src/lib/Logger.ts
@@ -1,6 +1,7 @@
 import winston from "winston"
 import colors from "colors"
 import type { DiscordLogForwarder, DiscordLogLevelName, LoggerInterface } from "../types/index.js"
+import { captureError } from "./errorHistory.js"
 
 /**
  * A simple logger class that logs to both the console with colors and a file.
@@ -193,6 +194,11 @@ export default class Logger implements LoggerInterface {
         this.logger.warn(fullMessage)
         console.log(colors.gray(this._getTimestamp()) + colors.yellow(` | WARN | ${fullMessage}`))
         this._notifyDiscord("warn", fullMessage)
+        try {
+            captureError("warn", fullMessage, Date.now())
+        } catch {
+            // Never break logging if the history buffer fails.
+        }
     }
 
     error(text: string, ...args: unknown[]) {
@@ -218,6 +224,16 @@ export default class Logger implements LoggerInterface {
             colors.gray(this._getTimestamp()) + colors.red(` | ERROR | ${consoleAndDiscordMessage}`)
         )
         this._notifyDiscord("error", consoleAndDiscordMessage)
+        try {
+            captureError(
+                "error",
+                consoleAndDiscordMessage,
+                Date.now(),
+                errorArg?.stack ?? undefined
+            )
+        } catch {
+            // Never break logging if the history buffer fails.
+        }
     }
 
     debug(text: string, ...args: unknown[]) {

--- a/src/lib/errorHistory.ts
+++ b/src/lib/errorHistory.ts
@@ -1,0 +1,58 @@
+const ERROR_HISTORY_CAP = 500
+const DISCORD_SNOWFLAKE_IN_MESSAGE_RE = /\b\d{17,20}\b/
+
+export interface ErrorHistoryEntry {
+    timestamp: number
+    level: "error" | "warn"
+    message: string
+    guildId?: string
+    stack?: string
+}
+
+const buffer: ErrorHistoryEntry[] = []
+
+function extractGuildIdFromMessage(message: string): string | undefined {
+    const match = message.match(DISCORD_SNOWFLAKE_IN_MESSAGE_RE)
+    return match?.[0]
+}
+
+/** Records a log line in the in-memory ring buffer (newest first). */
+export function captureError(
+    level: "error" | "warn",
+    message: string,
+    timestamp: number,
+    stack?: string
+): void {
+    const entry: ErrorHistoryEntry = {
+        timestamp,
+        level,
+        message,
+        stack,
+    }
+    const guildId = extractGuildIdFromMessage(message)
+    if (guildId) {
+        entry.guildId = guildId
+    }
+    buffer.unshift(entry)
+    if (buffer.length > ERROR_HISTORY_CAP) {
+        buffer.length = ERROR_HISTORY_CAP
+    }
+}
+
+/** Returns the most recent error/warn entries (newest first). */
+export function getRecentErrors(limit = 100): ErrorHistoryEntry[] {
+    const capped = Math.max(1, Math.min(limit, ERROR_HISTORY_CAP))
+    return buffer.slice(0, capped)
+}
+
+/** Returns recent entries whose message contained the given guild snowflake. */
+export function getErrorsByGuild(guildId: string, limit = 100): ErrorHistoryEntry[] {
+    const capped = Math.max(1, Math.min(limit, ERROR_HISTORY_CAP))
+    const filtered = buffer.filter((e) => e.guildId === guildId)
+    return filtered.slice(0, capped)
+}
+
+/** Clears all buffered entries (admin maintenance). */
+export function clearErrorHistory(): void {
+    buffer.length = 0
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -148,7 +148,7 @@ async function run(): Promise<void> {
             )
         }
         logger.info(
-            "Serving bot HTTP: /health, /api/guilds/* (Express), /ws (WebSocket). Next.js is not used here."
+            "Serving bot HTTP: /health, /api/* (Express guild + admin routes), /ws (WebSocket). Next.js is not used here."
         )
 
         wss = new WebSocketServer({ noServer: true })
@@ -175,7 +175,7 @@ async function run(): Promise<void> {
                 res.end("ok")
                 return
             }
-            if (pathOnly.startsWith("/api/guilds")) {
+            if (pathOnly.startsWith("/api/")) {
                 botApiApp(req, res)
                 return
             }

--- a/src/shared/api-auth.ts
+++ b/src/shared/api-auth.ts
@@ -672,10 +672,22 @@ export async function requireDeveloperAccess(
     }
 
     const resolvedHeaders = asHeaders(headers)
-    const discordUserId = await resolveDiscordUserSnowflake(
-        sessionResult.session.user.id,
-        resolvedHeaders
-    )
+    let discordUserId: string | null
+    try {
+        discordUserId = await resolveDiscordUserSnowflake(
+            sessionResult.session.user.id,
+            resolvedHeaders
+        )
+    } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : String(error)
+        console.error("[api-auth] requireDeveloperAccess resolveDiscordUserSnowflake failed:", msg)
+        return {
+            ok: false,
+            status: 403,
+            error: "Discord account required",
+            details: `${msg} — Sign in with Discord, or sign out and sign in again.`,
+        }
+    }
     if (!discordUserId) {
         return {
             ok: false,

--- a/src/shared/api-auth.ts
+++ b/src/shared/api-auth.ts
@@ -1,6 +1,7 @@
 import {
     WebPermission,
     type PermissionResolution,
+    getCachedOwnerId,
     hasRequiredPermissions,
     resolveGuildMemberForPermissions,
     resolveOauthGuildPermissionFallback,
@@ -51,6 +52,14 @@ export interface PermissionGuardSuccess {
 }
 
 export type PermissionGuardResult = GuardFailure | PermissionGuardSuccess
+
+export interface DeveloperGuardSuccess {
+    ok: true
+    session: AuthenticatedSession
+    discordUserId: string
+}
+
+export type DeveloperGuardResult = GuardFailure | DeveloperGuardSuccess
 
 export type GuildAccessResult =
     | { ok: true; memberResolved: boolean }
@@ -648,5 +657,48 @@ export async function requirePermissions(
         session: ctx.session,
         discordUserId: ctx.discordUserId,
         permissionResolution,
+    }
+}
+
+/**
+ * Authenticates the session and restricts access to the bot owner (`OWNER_ID`).
+ */
+export async function requireDeveloperAccess(
+    headers: Headers | Record<string, string>
+): Promise<DeveloperGuardResult> {
+    const sessionResult = await getAuthenticatedSession(headers)
+    if (sessionResult.ok === false) {
+        return sessionResult
+    }
+
+    const resolvedHeaders = asHeaders(headers)
+    const discordUserId = await resolveDiscordUserSnowflake(
+        sessionResult.session.user.id,
+        resolvedHeaders
+    )
+    if (!discordUserId) {
+        return {
+            ok: false,
+            status: 403,
+            error: "Discord account required",
+            details:
+                "We could not resolve your Discord user id (needed for roles and voice state). Sign in with Discord, or sign out and sign in again.",
+        }
+    }
+
+    const ownerId = getCachedOwnerId()
+    if (!ownerId || discordUserId !== ownerId) {
+        return {
+            ok: false,
+            status: 403,
+            error: "Forbidden",
+            details: "Developer access required.",
+        }
+    }
+
+    return {
+        ok: true,
+        session: sessionResult.session,
+        discordUserId,
     }
 }

--- a/src/shared/api-auth.ts
+++ b/src/shared/api-auth.ts
@@ -685,7 +685,8 @@ export async function requireDeveloperAccess(
             ok: false,
             status: 403,
             error: "Discord account required",
-            details: `${msg} — Sign in with Discord, or sign out and sign in again.`,
+            details:
+                "Discord account required — please sign in with Discord or try again.",
         }
     }
     if (!discordUserId) {

--- a/src/shared/permissions.ts
+++ b/src/shared/permissions.ts
@@ -181,6 +181,11 @@ function parseEnvBotOwnerId(): string | undefined {
 
 const CACHED_OWNER_ID = parseEnvBotOwnerId()
 
+/** Parsed `OWNER_ID` snowflake from env (undefined when unset or invalid). */
+export function getCachedOwnerId(): string | undefined {
+    return CACHED_OWNER_ID
+}
+
 export async function resolveUserPermissions(
     client: PermissionClient,
     guildId: string,

--- a/src/types/web.ts
+++ b/src/types/web.ts
@@ -155,3 +155,51 @@ export type WSMessage =
     | WsPingMessage
     | WsPongMessage
     | WsErrorMessage
+
+export interface AdminMetricsPlayerSummary {
+    guildId: string
+    guildName: string | null
+    status: "playing" | "paused" | "idle"
+    queueSize: number
+    currentTrack: { title: string; author?: string; uri?: string } | null
+}
+
+/** One Discord guild the bot is in (from guild cache). */
+export interface AdminGuildSummary {
+    guildId: string
+    guildName: string
+    memberCount: number | null
+}
+
+export interface AdminMetricsResponse {
+    /** Guilds the bot is currently in (Discord.js cache). */
+    guildCount: number
+    activePlayers: number
+    nodeCount: number
+    guilds: AdminGuildSummary[]
+    players: AdminMetricsPlayerSummary[]
+}
+
+export interface ErrorHistoryEntry {
+    timestamp: number
+    level: "error" | "warn"
+    message: string
+    guildId?: string
+    stack?: string
+}
+
+export interface AdminErrorsListResponse {
+    entries: ErrorHistoryEntry[]
+}
+
+export interface AdminDbStatsResponse {
+    sessions: { total: number; expired: number }
+    verifications: { total: number; expired: number }
+}
+
+export type AdminDbCleanupTarget = "sessions" | "verifications" | "all"
+
+export interface AdminDbCleanupResponse {
+    dryRun: boolean
+    deleted: { sessions?: number; verifications?: number }
+}

--- a/src/web/app/admin/database/DatabaseTools.tsx
+++ b/src/web/app/admin/database/DatabaseTools.tsx
@@ -6,11 +6,36 @@ import type {
     AdminDbCleanupResponse,
     AdminDbCleanupTarget,
     AdminDbStatsResponse,
-    ApiResponse,
 } from "@/types/web"
 
 type DatabaseToolsProps = {
     initialStats: AdminDbStatsResponse
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null
+}
+
+function isAdminDbCleanupResponse(value: unknown): value is AdminDbCleanupResponse {
+    if (!isRecord(value)) return false
+    if (typeof value.dryRun !== "boolean") return false
+    if (!isRecord(value.deleted)) return false
+    const { sessions, verifications } = value.deleted
+    const sessionsOk = sessions === undefined || typeof sessions === "number"
+    const verOk = verifications === undefined || typeof verifications === "number"
+    return sessionsOk && verOk
+}
+
+function isAdminDbStatsResponse(value: unknown): value is AdminDbStatsResponse {
+    if (!isRecord(value)) return false
+    const { sessions, verifications } = value
+    if (!isRecord(sessions) || !isRecord(verifications)) return false
+    return (
+        typeof sessions.total === "number" &&
+        typeof sessions.expired === "number" &&
+        typeof verifications.total === "number" &&
+        typeof verifications.expired === "number"
+    )
 }
 
 /** Expired session/verification cleanup with dry-run preview. */
@@ -37,32 +62,91 @@ export function DatabaseTools({ initialStats }: DatabaseToolsProps) {
                 headers: { "content-type": "application/json" },
                 body: JSON.stringify({ target }),
             })
-            const payload = (await res.json()) as ApiResponse<AdminDbCleanupResponse>
-            if (!res.ok || payload.ok === false) {
-                const msg =
-                    payload.ok === false
-                        ? (payload.error.details ?? payload.error.error)
-                        : `HTTP ${res.status}`
+            let payloadUnknown: unknown
+            try {
+                payloadUnknown = await res.json()
+            } catch {
+                setError(`HTTP ${res.status}: response was not valid JSON`)
+                return
+            }
+
+            if (!res.ok) {
+                let msg: string
+                if (
+                    isRecord(payloadUnknown) &&
+                    payloadUnknown.ok === false &&
+                    isRecord(payloadUnknown.error)
+                ) {
+                    const errObj = payloadUnknown.error
+                    const details = errObj.details
+                    const errStr = errObj.error
+                    msg =
+                        typeof details === "string"
+                            ? details
+                            : typeof errStr === "string"
+                              ? errStr
+                              : `HTTP ${res.status}`
+                } else {
+                    msg = `HTTP ${res.status}`
+                }
                 setError(String(msg))
                 return
             }
+
+            if (
+                !isRecord(payloadUnknown) ||
+                payloadUnknown.ok !== true ||
+                !("data" in payloadUnknown) ||
+                !isAdminDbCleanupResponse(payloadUnknown.data)
+            ) {
+                setError("Invalid cleanup response from server")
+                return
+            }
+
+            const data = payloadUnknown.data
+
             if (dryRun) {
-                setPreview(payload.data)
+                setPreview(data)
                 setConfirmRun(false)
             } else {
-                setResult(payload.data)
+                setResult(data)
                 setPreview(null)
                 setConfirmRun(false)
-                const statsRes = await fetch("/api/admin/database/stats", {
-                    credentials: "include",
-                })
-                const statsPayload = (await statsRes.json()) as ApiResponse<AdminDbStatsResponse>
-                if (statsRes.ok && statsPayload.ok === true) {
-                    setStats(statsPayload.data)
+                try {
+                    const statsRes = await fetch("/api/admin/database/stats", {
+                        credentials: "include",
+                    })
+                    if (!statsRes.ok) {
+                        console.warn(
+                            "[DatabaseTools] stats refresh failed:",
+                            `HTTP ${statsRes.status}`
+                        )
+                        return
+                    }
+                    let statsUnknown: unknown
+                    try {
+                        statsUnknown = await statsRes.json()
+                    } catch (parseErr: unknown) {
+                        console.warn("[DatabaseTools] stats refresh JSON parse failed:", parseErr)
+                        return
+                    }
+                    if (
+                        isRecord(statsUnknown) &&
+                        statsUnknown.ok === true &&
+                        "data" in statsUnknown &&
+                        isAdminDbStatsResponse(statsUnknown.data)
+                    ) {
+                        setStats(statsUnknown.data)
+                    } else {
+                        console.warn("[DatabaseTools] stats refresh returned unexpected payload")
+                    }
+                } catch (statsErr: unknown) {
+                    console.error("[DatabaseTools] stats refresh failed:", statsErr)
                 }
             }
         } catch (err: unknown) {
-            setError(err instanceof Error ? err.message : "Cleanup request failed")
+            console.error("[DatabaseTools] cleanup request failed:", err)
+            setError("Cleanup request failed")
         } finally {
             setLoading(false)
         }
@@ -111,6 +195,7 @@ export function DatabaseTools({ initialStats }: DatabaseToolsProps) {
                 </div>
 
                 <fieldset className="flex flex-wrap gap-4 text-sm">
+                    <legend className="sr-only">Cleanup target</legend>
                     {(
                         [
                             ["sessions", "Sessions only"],

--- a/src/web/app/admin/database/DatabaseTools.tsx
+++ b/src/web/app/admin/database/DatabaseTools.tsx
@@ -1,0 +1,202 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import type {
+    AdminDbCleanupResponse,
+    AdminDbCleanupTarget,
+    AdminDbStatsResponse,
+    ApiResponse,
+} from "@/types/web"
+
+type DatabaseToolsProps = {
+    initialStats: AdminDbStatsResponse
+}
+
+/** Expired session/verification cleanup with dry-run preview. */
+export function DatabaseTools({ initialStats }: DatabaseToolsProps) {
+    const [stats, setStats] = useState(initialStats)
+    const [target, setTarget] = useState<AdminDbCleanupTarget>("all")
+    const [preview, setPreview] = useState<AdminDbCleanupResponse | null>(null)
+    const [result, setResult] = useState<AdminDbCleanupResponse | null>(null)
+    const [confirmRun, setConfirmRun] = useState(false)
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    async function runCleanup(dryRun: boolean) {
+        setLoading(true)
+        setError(null)
+        if (!dryRun) setResult(null)
+        try {
+            const url = dryRun
+                ? "/api/admin/database/cleanup?dryRun=true"
+                : "/api/admin/database/cleanup"
+            const res = await fetch(url, {
+                method: "POST",
+                credentials: "include",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ target }),
+            })
+            const payload = (await res.json()) as ApiResponse<AdminDbCleanupResponse>
+            if (!res.ok || payload.ok === false) {
+                const msg =
+                    payload.ok === false
+                        ? (payload.error.details ?? payload.error.error)
+                        : `HTTP ${res.status}`
+                setError(String(msg))
+                return
+            }
+            if (dryRun) {
+                setPreview(payload.data)
+                setConfirmRun(false)
+            } else {
+                setResult(payload.data)
+                setPreview(null)
+                setConfirmRun(false)
+                const statsRes = await fetch("/api/admin/database/stats", {
+                    credentials: "include",
+                })
+                const statsPayload = (await statsRes.json()) as ApiResponse<AdminDbStatsResponse>
+                if (statsRes.ok && statsPayload.ok === true) {
+                    setStats(statsPayload.data)
+                }
+            }
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : "Cleanup request failed")
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    return (
+        <div className="space-y-6">
+            <section className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-lg border bg-card p-4">
+                    <h2 className="font-medium">Sessions</h2>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                        Total:{" "}
+                        <span className="font-mono text-foreground">{stats.sessions.total}</span>
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                        Expired:{" "}
+                        <span className="font-mono text-foreground">{stats.sessions.expired}</span>
+                    </p>
+                </div>
+                <div className="rounded-lg border bg-card p-4">
+                    <h2 className="font-medium">Verifications</h2>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                        Total:{" "}
+                        <span className="font-mono text-foreground">
+                            {stats.verifications.total}
+                        </span>
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                        Expired:{" "}
+                        <span className="font-mono text-foreground">
+                            {stats.verifications.expired}
+                        </span>
+                    </p>
+                </div>
+            </section>
+
+            <section className="space-y-4 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4">
+                <div>
+                    <h2 className="font-medium text-amber-950 dark:text-amber-100">
+                        Cleanup expired rows
+                    </h2>
+                    <p className="mt-1 text-sm text-amber-900/80 dark:text-amber-100/80">
+                        Deletes rows where <code className="text-xs">expiresAt</code> is in the
+                        past. Run a dry-run preview before deleting.
+                    </p>
+                </div>
+
+                <fieldset className="flex flex-wrap gap-4 text-sm">
+                    {(
+                        [
+                            ["sessions", "Sessions only"],
+                            ["verifications", "Verifications only"],
+                            ["all", "Sessions and verifications"],
+                        ] as const
+                    ).map(([value, label]) => (
+                        <label key={value} className="flex items-center gap-2">
+                            <input
+                                type="radio"
+                                name="cleanup-target"
+                                value={value}
+                                checked={target === value}
+                                onChange={() => {
+                                    setTarget(value)
+                                    setPreview(null)
+                                    setResult(null)
+                                    setConfirmRun(false)
+                                }}
+                            />
+                            {label}
+                        </label>
+                    ))}
+                </fieldset>
+
+                <div className="flex flex-wrap gap-2">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        disabled={loading}
+                        onClick={() => void runCleanup(true)}
+                    >
+                        Preview (dry run)
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="destructive"
+                        disabled={loading || !preview}
+                        onClick={() => {
+                            if (!confirmRun) {
+                                setConfirmRun(true)
+                                return
+                            }
+                            void runCleanup(false)
+                        }}
+                    >
+                        {confirmRun ? "Confirm delete expired rows" : "Run cleanup"}
+                    </Button>
+                    {confirmRun ? (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            disabled={loading}
+                            onClick={() => setConfirmRun(false)}
+                        >
+                            Cancel
+                        </Button>
+                    ) : null}
+                </div>
+
+                {preview ? (
+                    <div className="rounded-md border bg-background/60 p-3 text-sm">
+                        <p className="font-medium">Dry-run preview</p>
+                        {preview.deleted.sessions !== undefined ? (
+                            <p>Sessions to delete: {preview.deleted.sessions}</p>
+                        ) : null}
+                        {preview.deleted.verifications !== undefined ? (
+                            <p>Verifications to delete: {preview.deleted.verifications}</p>
+                        ) : null}
+                    </div>
+                ) : null}
+
+                {result && !result.dryRun ? (
+                    <div className="rounded-md border bg-background/60 p-3 text-sm">
+                        <p className="font-medium">Cleanup complete</p>
+                        {result.deleted.sessions !== undefined ? (
+                            <p>Sessions deleted: {result.deleted.sessions}</p>
+                        ) : null}
+                        {result.deleted.verifications !== undefined ? (
+                            <p>Verifications deleted: {result.deleted.verifications}</p>
+                        ) : null}
+                    </div>
+                ) : null}
+
+                {error ? <p className="text-sm text-destructive">{error}</p> : null}
+            </section>
+        </div>
+    )
+}

--- a/src/web/app/admin/database/page.tsx
+++ b/src/web/app/admin/database/page.tsx
@@ -1,35 +1,69 @@
 import { ServiceDegraded } from "@/components/ServiceDegraded"
 import { serverFetchBot } from "@/server/fetch-bot-api"
 import type { AdminDbStatsResponse, ApiResponse } from "@/types/web"
-import { DatabaseTools } from "./DatabaseTools"
+import { DatabaseTools } from "./DatabaseTools.js"
 
 export const dynamic = "force-dynamic"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null
+}
+
+function isAdminDbStatsResponse(value: unknown): value is AdminDbStatsResponse {
+    if (!isRecord(value)) return false
+    const { sessions, verifications } = value
+    if (!isRecord(sessions) || !isRecord(verifications)) return false
+    return (
+        typeof sessions.total === "number" &&
+        typeof sessions.expired === "number" &&
+        typeof verifications.total === "number" &&
+        typeof verifications.expired === "number"
+    )
+}
 
 async function loadStats(): Promise<
     { ok: true; data: AdminDbStatsResponse } | { ok: false; error: string }
 > {
-    const res = await serverFetchBot("/api/admin/database/stats")
-    const text = await res.text()
-    if (!text.trim()) {
-        return { ok: false, error: "Empty response from bot API." }
-    }
-    let payload: unknown
     try {
-        payload = JSON.parse(text)
-    } catch {
-        return { ok: false, error: "Bot API returned invalid JSON." }
+        const res = await serverFetchBot("/api/admin/database/stats")
+        const text = await res.text()
+        if (!text.trim()) {
+            return { ok: false, error: "Empty response from bot API." }
+        }
+        let payload: unknown
+        try {
+            payload = JSON.parse(text)
+        } catch {
+            return { ok: false, error: "Bot API returned invalid JSON." }
+        }
+
+        if (!isRecord(payload) || typeof payload.ok !== "boolean") {
+            return { ok: false, error: "Invalid response payload from bot API." }
+        }
+
+        const typed = payload as unknown as ApiResponse<AdminDbStatsResponse>
+        if (!res.ok || typed.ok === false) {
+            const details =
+                typed.ok === false && typed.error?.details
+                    ? String(typed.error.details)
+                    : typed.ok === false
+                      ? typed.error.error
+                      : `HTTP ${res.status}`
+            return { ok: false, error: details }
+        }
+
+        if (typed.ok !== true || !("data" in typed)) {
+            return { ok: false, error: "Invalid response payload: missing data." }
+        }
+
+        if (!isAdminDbStatsResponse(typed.data)) {
+            return { ok: false, error: "Invalid response payload: malformed stats." }
+        }
+
+        return { ok: true, data: typed.data }
+    } catch (err: unknown) {
+        return { ok: false, error: String(err) }
     }
-    const typed = payload as ApiResponse<AdminDbStatsResponse>
-    if (!res.ok || typed.ok === false) {
-        const details =
-            typed.ok === false && typed.error?.details
-                ? String(typed.error.details)
-                : typed.ok === false
-                  ? typed.error.error
-                  : `HTTP ${res.status}`
-        return { ok: false, error: details }
-    }
-    return { ok: true, data: typed.data }
 }
 
 /** Admin database maintenance: stats and expired-row cleanup. */

--- a/src/web/app/admin/database/page.tsx
+++ b/src/web/app/admin/database/page.tsx
@@ -43,11 +43,15 @@ async function loadStats(): Promise<
 
         const typed = payload as unknown as ApiResponse<AdminDbStatsResponse>
         if (!res.ok || typed.ok === false) {
+            const errObj =
+                typed.ok === false && typed.error && typeof typed.error === "object"
+                    ? (typed.error as { error?: unknown; details?: unknown })
+                    : null
             const details =
-                typed.ok === false && typed.error?.details
-                    ? String(typed.error.details)
-                    : typed.ok === false
-                      ? typed.error.error
+                errObj?.details != null
+                    ? String(errObj.details)
+                    : errObj?.error != null
+                      ? String(errObj.error)
                       : `HTTP ${res.status}`
             return { ok: false, error: details }
         }

--- a/src/web/app/admin/database/page.tsx
+++ b/src/web/app/admin/database/page.tsx
@@ -1,0 +1,60 @@
+import { ServiceDegraded } from "@/components/ServiceDegraded"
+import { serverFetchBot } from "@/server/fetch-bot-api"
+import type { AdminDbStatsResponse, ApiResponse } from "@/types/web"
+import { DatabaseTools } from "./DatabaseTools"
+
+export const dynamic = "force-dynamic"
+
+async function loadStats(): Promise<
+    { ok: true; data: AdminDbStatsResponse } | { ok: false; error: string }
+> {
+    const res = await serverFetchBot("/api/admin/database/stats")
+    const text = await res.text()
+    if (!text.trim()) {
+        return { ok: false, error: "Empty response from bot API." }
+    }
+    let payload: unknown
+    try {
+        payload = JSON.parse(text)
+    } catch {
+        return { ok: false, error: "Bot API returned invalid JSON." }
+    }
+    const typed = payload as ApiResponse<AdminDbStatsResponse>
+    if (!res.ok || typed.ok === false) {
+        const details =
+            typed.ok === false && typed.error?.details
+                ? String(typed.error.details)
+                : typed.ok === false
+                  ? typed.error.error
+                  : `HTTP ${res.status}`
+        return { ok: false, error: details }
+    }
+    return { ok: true, data: typed.data }
+}
+
+/** Admin database maintenance: stats and expired-row cleanup. */
+export default async function AdminDatabasePage() {
+    const result = await loadStats()
+
+    if (result.ok === false) {
+        return (
+            <ServiceDegraded
+                title="Could not load database stats"
+                description="The bot API did not return session/verification counts."
+                detail={result.error}
+            />
+        )
+    }
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <h1 className="text-2xl font-semibold">Database tools</h1>
+                <p className="text-sm text-muted-foreground">
+                    Better Auth session and verification table maintenance.
+                </p>
+            </div>
+            <DatabaseTools initialStats={result.data} />
+        </div>
+    )
+}

--- a/src/web/app/admin/errors/ErrorsList.tsx
+++ b/src/web/app/admin/errors/ErrorsList.tsx
@@ -1,0 +1,202 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import type { AdminErrorsListResponse, ApiResponse, ErrorHistoryEntry } from "@/types/web"
+
+const LIMIT_OPTIONS = [25, 50, 100, 250] as const
+
+function levelBadgeClass(level: ErrorHistoryEntry["level"]): string {
+    if (level === "error") {
+        return "bg-destructive/15 text-destructive"
+    }
+    return "bg-amber-500/15 text-amber-800 dark:text-amber-200"
+}
+
+function formatTimestamp(ts: number): string {
+    return new Date(ts).toLocaleString()
+}
+
+/** Scrollable admin error history with guild filter and clear action. */
+export function ErrorsList() {
+    const [entries, setEntries] = useState<ErrorHistoryEntry[]>([])
+    const [guildFilter, setGuildFilter] = useState("")
+    const [limit, setLimit] = useState<number>(100)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+    const [confirmClear, setConfirmClear] = useState(false)
+    const [clearing, setClearing] = useState(false)
+
+    const guildOptions = useMemo(() => {
+        const ids = new Set<string>()
+        for (const e of entries) {
+            if (e.guildId) ids.add(e.guildId)
+        }
+        return Array.from(ids).sort()
+    }, [entries])
+
+    const load = useCallback(async () => {
+        setLoading(true)
+        setError(null)
+        const params = new URLSearchParams({ limit: String(limit) })
+        if (guildFilter) params.set("guildId", guildFilter)
+        try {
+            const res = await fetch(`/api/admin/errors?${params.toString()}`, {
+                credentials: "include",
+            })
+            const payload = (await res.json()) as ApiResponse<AdminErrorsListResponse>
+            if (!res.ok || payload.ok === false) {
+                const msg =
+                    payload.ok === false
+                        ? (payload.error.details ?? payload.error.error)
+                        : `HTTP ${res.status}`
+                setError(String(msg))
+                setEntries([])
+                return
+            }
+            setEntries(payload.data.entries)
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : "Failed to load errors")
+            setEntries([])
+        } finally {
+            setLoading(false)
+        }
+    }, [guildFilter, limit])
+
+    useEffect(() => {
+        void load()
+    }, [load])
+
+    async function handleClear() {
+        if (!confirmClear) {
+            setConfirmClear(true)
+            return
+        }
+        setClearing(true)
+        setError(null)
+        try {
+            const res = await fetch("/api/admin/errors", {
+                method: "DELETE",
+                credentials: "include",
+            })
+            const payload = (await res.json()) as ApiResponse<{ cleared: true }>
+            if (!res.ok || payload.ok === false) {
+                const msg =
+                    payload.ok === false
+                        ? (payload.error.details ?? payload.error.error)
+                        : `HTTP ${res.status}`
+                setError(String(msg))
+                return
+            }
+            setConfirmClear(false)
+            setEntries([])
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : "Failed to clear history")
+        } finally {
+            setClearing(false)
+        }
+    }
+
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-wrap items-end gap-3">
+                <label className="flex flex-col gap-1 text-sm">
+                    <span className="text-muted-foreground">Guild filter</span>
+                    <select
+                        className="rounded-md border bg-background px-3 py-2"
+                        value={guildFilter}
+                        onChange={(e) => setGuildFilter(e.target.value)}
+                    >
+                        <option value="">All guilds</option>
+                        {guildOptions.map((id) => (
+                            <option key={id} value={id}>
+                                {id}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
+                    <span className="text-muted-foreground">Limit</span>
+                    <select
+                        className="rounded-md border bg-background px-3 py-2"
+                        value={limit}
+                        onChange={(e) => setLimit(Number(e.target.value))}
+                    >
+                        {LIMIT_OPTIONS.map((n) => (
+                            <option key={n} value={n}>
+                                {n}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+                <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => void load()}
+                    disabled={loading}
+                >
+                    Refresh
+                </Button>
+                <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={() => void handleClear()}
+                    disabled={clearing}
+                >
+                    {confirmClear ? "Confirm clear history" : "Clear history"}
+                </Button>
+                {confirmClear ? (
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => setConfirmClear(false)}
+                        disabled={clearing}
+                    >
+                        Cancel
+                    </Button>
+                ) : null}
+            </div>
+
+            {error ? (
+                <section className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+                    {error}
+                </section>
+            ) : null}
+
+            {loading ? (
+                <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : entries.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No errors in the buffer.</p>
+            ) : (
+                <ul className="max-h-[70vh] space-y-2 overflow-y-auto rounded-lg border p-2">
+                    {entries.map((entry, index) => (
+                        <li
+                            key={`${entry.timestamp}-${index}`}
+                            className="rounded-md border bg-card p-3 text-sm"
+                        >
+                            <div className="flex flex-wrap items-center gap-2">
+                                <time
+                                    className="text-xs text-muted-foreground"
+                                    dateTime={new Date(entry.timestamp).toISOString()}
+                                >
+                                    {formatTimestamp(entry.timestamp)}
+                                </time>
+                                <span
+                                    className={`rounded px-2 py-0.5 text-xs font-medium uppercase ${levelBadgeClass(entry.level)}`}
+                                >
+                                    {entry.level}
+                                </span>
+                                {entry.guildId ? (
+                                    <span className="rounded bg-muted px-2 py-0.5 font-mono text-xs">
+                                        {entry.guildId}
+                                    </span>
+                                ) : null}
+                            </div>
+                            <p className="mt-2 break-words whitespace-pre-wrap">{entry.message}</p>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    )
+}

--- a/src/web/app/admin/errors/page.tsx
+++ b/src/web/app/admin/errors/page.tsx
@@ -1,0 +1,16 @@
+import { ErrorsList } from "./ErrorsList"
+
+/** Admin error history page. */
+export default function AdminErrorsPage() {
+    return (
+        <div className="space-y-4">
+            <div>
+                <h1 className="text-2xl font-semibold">Error history</h1>
+                <p className="text-sm text-muted-foreground">
+                    Recent warn and error log lines captured in memory (newest first).
+                </p>
+            </div>
+            <ErrorsList />
+        </div>
+    )
+}

--- a/src/web/app/admin/errors/page.tsx
+++ b/src/web/app/admin/errors/page.tsx
@@ -1,4 +1,4 @@
-import { ErrorsList } from "./ErrorsList"
+import { ErrorsList } from "./ErrorsList.js"
 
 /** Admin error history page. */
 export default function AdminErrorsPage() {

--- a/src/web/app/admin/layout.tsx
+++ b/src/web/app/admin/layout.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react"
+import Link from "next/link"
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { resolveAdminAccess } from "@/lib/admin-access"
+import { ServiceDegraded } from "@/components/ServiceDegraded"
+
+export const dynamic = "force-dynamic"
+
+const navLinkClass =
+    "rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+
+/** Admin section layout: owner gate and sub-navigation. */
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+    const h = await headers()
+    const result = await resolveAdminAccess(new Headers(h))
+
+    if (result.ok === false) {
+        if (result.status === 503) {
+            return (
+                <div className="min-h-screen bg-background text-foreground">
+                    <header className="border-b p-4">
+                        <div className="mx-auto flex max-w-6xl items-center justify-between">
+                            <Link href="/" className="font-semibold">
+                                DimbyBot Admin
+                            </Link>
+                        </div>
+                    </header>
+                    <main className="mx-auto w-full max-w-6xl p-4">
+                        <ServiceDegraded
+                            title="Admin is temporarily unavailable"
+                            description="We could not load your session. Please try again later."
+                            detail={result.details}
+                        />
+                    </main>
+                </div>
+            )
+        }
+        redirect("/?error=admin_required")
+    }
+
+    return (
+        <div className="min-h-screen bg-background text-foreground">
+            <header className="border-b p-4">
+                <div className="mx-auto flex max-w-6xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <Link href="/admin" className="font-semibold">
+                            DimbyBot Admin
+                        </Link>
+                        <p className="text-sm text-muted-foreground">Developer tools</p>
+                    </div>
+                    <nav className="flex flex-wrap gap-1">
+                        <Link href="/admin" className={navLinkClass}>
+                            Overview
+                        </Link>
+                        <Link href="/admin/errors" className={navLinkClass}>
+                            Errors
+                        </Link>
+                        <Link href="/admin/database" className={navLinkClass}>
+                            Database
+                        </Link>
+                        <Link href="/dashboard" className={navLinkClass}>
+                            Dashboard
+                        </Link>
+                    </nav>
+                </div>
+            </header>
+            <main className="mx-auto w-full max-w-6xl p-4">{children}</main>
+        </div>
+    )
+}

--- a/src/web/app/admin/page.tsx
+++ b/src/web/app/admin/page.tsx
@@ -15,31 +15,80 @@ function statusPillClass(status: "playing" | "paused" | "idle"): string {
     return "bg-muted text-muted-foreground"
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null
+}
+
+function isAdminMetricsResponse(value: unknown): value is AdminMetricsResponse {
+    if (!isRecord(value)) return false
+    if (typeof value.guildCount !== "number") return false
+    if (typeof value.activePlayers !== "number") return false
+    if (typeof value.nodeCount !== "number") return false
+    if (!Array.isArray(value.guilds) || !Array.isArray(value.players)) return false
+    for (const g of value.guilds) {
+        if (!isRecord(g) || typeof g.guildId !== "string") return false
+        if (g.guildName !== null && typeof g.guildName !== "string") return false
+        if (g.memberCount !== null && typeof g.memberCount !== "number") return false
+    }
+    for (const p of value.players) {
+        if (!isRecord(p)) return false
+        if (typeof p.guildId !== "string") return false
+        if (p.guildName !== null && typeof p.guildName !== "string") return false
+        if (p.status !== "playing" && p.status !== "paused" && p.status !== "idle") return false
+        if (typeof p.queueSize !== "number") return false
+        const ct = p.currentTrack
+        if (ct != null) {
+            if (!isRecord(ct) || typeof ct.title !== "string") return false
+            if (ct.author !== undefined && typeof ct.author !== "string") return false
+            if (ct.uri !== undefined && typeof ct.uri !== "string") return false
+        }
+    }
+    return true
+}
+
 async function loadMetrics(): Promise<
     { ok: true; data: AdminMetricsResponse } | { ok: false; error: string }
 > {
-    const res = await serverFetchBot("/api/admin/metrics")
-    const text = await res.text()
-    if (!text.trim()) {
-        return { ok: false, error: "Empty response from bot API." }
-    }
-    let payload: unknown
     try {
-        payload = JSON.parse(text)
-    } catch {
-        return { ok: false, error: "Bot API returned invalid JSON." }
+        const res = await serverFetchBot("/api/admin/metrics")
+        const text = await res.text()
+        if (!text.trim()) {
+            return { ok: false, error: "Empty response from bot API." }
+        }
+        let payload: unknown
+        try {
+            payload = JSON.parse(text)
+        } catch {
+            return { ok: false, error: "Bot API returned invalid JSON." }
+        }
+
+        if (!isRecord(payload) || typeof payload.ok !== "boolean") {
+            return { ok: false, error: "Invalid response payload" }
+        }
+
+        const typed = payload as unknown as ApiResponse<AdminMetricsResponse>
+        if (!res.ok || typed.ok === false) {
+            const details =
+                typed.ok === false && typed.error?.details
+                    ? String(typed.error.details)
+                    : typed.ok === false
+                      ? typed.error.error
+                      : `HTTP ${res.status}`
+            return { ok: false, error: details }
+        }
+
+        if (typed.ok !== true || !("data" in typed)) {
+            return { ok: false, error: "Invalid response payload" }
+        }
+
+        if (!isAdminMetricsResponse(typed.data)) {
+            return { ok: false, error: "Invalid response payload" }
+        }
+
+        return { ok: true, data: typed.data }
+    } catch (err: unknown) {
+        return { ok: false, error: String(err) }
     }
-    const typed = payload as ApiResponse<AdminMetricsResponse>
-    if (!res.ok || typed.ok === false) {
-        const details =
-            typed.ok === false && typed.error?.details
-                ? String(typed.error.details)
-                : typed.ok === false
-                  ? typed.error.error
-                  : `HTTP ${res.status}`
-        return { ok: false, error: details }
-    }
-    return { ok: true, data: typed.data }
 }
 
 /** Admin overview: active Lavalink players and node count. */

--- a/src/web/app/admin/page.tsx
+++ b/src/web/app/admin/page.tsx
@@ -1,0 +1,185 @@
+import Link from "next/link"
+import { ServiceDegraded } from "@/components/ServiceDegraded"
+import { serverFetchBot } from "@/server/fetch-bot-api"
+import type { AdminMetricsResponse, ApiResponse } from "@/types/web"
+
+export const dynamic = "force-dynamic"
+
+function statusPillClass(status: "playing" | "paused" | "idle"): string {
+    if (status === "playing") {
+        return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
+    }
+    if (status === "paused") {
+        return "bg-amber-500/15 text-amber-800 dark:text-amber-200"
+    }
+    return "bg-muted text-muted-foreground"
+}
+
+async function loadMetrics(): Promise<
+    { ok: true; data: AdminMetricsResponse } | { ok: false; error: string }
+> {
+    const res = await serverFetchBot("/api/admin/metrics")
+    const text = await res.text()
+    if (!text.trim()) {
+        return { ok: false, error: "Empty response from bot API." }
+    }
+    let payload: unknown
+    try {
+        payload = JSON.parse(text)
+    } catch {
+        return { ok: false, error: "Bot API returned invalid JSON." }
+    }
+    const typed = payload as ApiResponse<AdminMetricsResponse>
+    if (!res.ok || typed.ok === false) {
+        const details =
+            typed.ok === false && typed.error?.details
+                ? String(typed.error.details)
+                : typed.ok === false
+                  ? typed.error.error
+                  : `HTTP ${res.status}`
+        return { ok: false, error: details }
+    }
+    return { ok: true, data: typed.data }
+}
+
+/** Admin overview: active Lavalink players and node count. */
+export default async function AdminOverviewPage() {
+    const result = await loadMetrics()
+
+    if (result.ok === false) {
+        return (
+            <ServiceDegraded
+                title="Could not load metrics"
+                description="The bot API did not return player metrics."
+                detail={result.error}
+            />
+        )
+    }
+
+    const { guildCount, guilds, activePlayers, nodeCount, players } = result.data
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-2xl font-semibold">Overview</h1>
+                <p className="text-sm text-muted-foreground">
+                    Servers the bot is in, Lavalink players, and node summary.
+                </p>
+            </div>
+
+            <section className="grid gap-4 sm:grid-cols-3">
+                <div className="rounded-lg border bg-card p-4">
+                    <p className="text-sm text-muted-foreground">Servers</p>
+                    <p className="mt-1 text-3xl font-semibold tabular-nums">{guildCount}</p>
+                </div>
+                <div className="rounded-lg border bg-card p-4">
+                    <p className="text-sm text-muted-foreground">Active players</p>
+                    <p className="mt-1 text-3xl font-semibold tabular-nums">{activePlayers}</p>
+                </div>
+                <div className="rounded-lg border bg-card p-4">
+                    <p className="text-sm text-muted-foreground">Lavalink nodes</p>
+                    <p className="mt-1 text-3xl font-semibold tabular-nums">{nodeCount}</p>
+                </div>
+            </section>
+
+            <section className="space-y-3">
+                <h2 className="text-lg font-medium">Servers</h2>
+                {guilds.length === 0 ? (
+                    <div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+                        No guilds in cache (bot may still be connecting).
+                    </div>
+                ) : (
+                    <ul className="max-h-[min(24rem,50vh)] space-y-1 overflow-y-auto rounded-lg border bg-card p-2 text-sm">
+                        {guilds.map((g) => (
+                            <li
+                                key={g.guildId}
+                                className="flex flex-wrap items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted/50"
+                            >
+                                <div className="min-w-0">
+                                    <Link
+                                        href={`/dashboard/${g.guildId}`}
+                                        className="font-medium text-primary underline-offset-4 hover:underline"
+                                    >
+                                        {g.guildName}
+                                    </Link>
+                                    <p className="font-mono text-xs text-muted-foreground">
+                                        {g.guildId}
+                                    </p>
+                                </div>
+                                {g.memberCount != null ? (
+                                    <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+                                        {g.memberCount.toLocaleString()} members
+                                    </span>
+                                ) : null}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </section>
+
+            <section className="space-y-3">
+                <h2 className="text-lg font-medium">Active Lavalink players</h2>
+                {players.length === 0 ? (
+                    <div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+                        No active players.
+                    </div>
+                ) : (
+                    <ul className="space-y-2">
+                        {players.map((player) => (
+                            <li
+                                key={player.guildId}
+                                className="rounded-lg border bg-card p-4 text-sm"
+                            >
+                                <div className="flex flex-wrap items-start justify-between gap-2">
+                                    <div>
+                                        <p className="font-medium">
+                                            {player.guildName ?? `Guild ${player.guildId}`}
+                                        </p>
+                                        <p className="font-mono text-xs text-muted-foreground">
+                                            {player.guildId}
+                                        </p>
+                                    </div>
+                                    <span
+                                        className={`rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${statusPillClass(player.status)}`}
+                                    >
+                                        {player.status}
+                                    </span>
+                                </div>
+                                <p className="mt-2 text-muted-foreground">
+                                    Queue: {player.queueSize}
+                                    {player.currentTrack ? (
+                                        <>
+                                            {" "}
+                                            · Now: {player.currentTrack.title}
+                                            {player.currentTrack.author
+                                                ? ` — ${player.currentTrack.author}`
+                                                : ""}
+                                        </>
+                                    ) : (
+                                        " · No current track"
+                                    )}
+                                </p>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </section>
+
+            <p className="text-sm text-muted-foreground">
+                <Link
+                    href="/admin/errors"
+                    className="text-primary underline-offset-4 hover:underline"
+                >
+                    View error history
+                </Link>
+                {" · "}
+                <Link
+                    href="/admin/database"
+                    className="text-primary underline-offset-4 hover:underline"
+                >
+                    Database tools
+                </Link>
+            </p>
+        </div>
+    )
+}

--- a/src/web/app/admin/page.tsx
+++ b/src/web/app/admin/page.tsx
@@ -139,29 +139,34 @@ export default async function AdminOverviewPage() {
                     </div>
                 ) : (
                     <ul className="max-h-[min(24rem,50vh)] space-y-1 overflow-y-auto rounded-lg border bg-card p-2 text-sm">
-                        {guilds.map((g) => (
-                            <li
-                                key={g.guildId}
-                                className="flex flex-wrap items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted/50"
-                            >
-                                <div className="min-w-0">
-                                    <Link
-                                        href={`/dashboard/${g.guildId}`}
-                                        className="font-medium text-primary underline-offset-4 hover:underline"
-                                    >
-                                        {g.guildName}
-                                    </Link>
-                                    <p className="font-mono text-xs text-muted-foreground">
-                                        {g.guildId}
-                                    </p>
-                                </div>
-                                {g.memberCount != null ? (
-                                    <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
-                                        {g.memberCount.toLocaleString()} members
-                                    </span>
-                                ) : null}
-                            </li>
-                        ))}
+                        {guilds.map((g) => {
+                            const guildDisplayName = g.guildName ?? `Guild ${g.guildId}`
+                            return (
+                                <li
+                                    key={g.guildId}
+                                    className="flex flex-wrap items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted/50"
+                                >
+                                    <div className="min-w-0">
+                                        <Link
+                                            href={`/dashboard/${g.guildId}`}
+                                            className="font-medium text-primary underline-offset-4 hover:underline"
+                                            aria-label={`Open dashboard for ${guildDisplayName}`}
+                                            title={guildDisplayName}
+                                        >
+                                            {guildDisplayName}
+                                        </Link>
+                                        <p className="font-mono text-xs text-muted-foreground">
+                                            {g.guildId}
+                                        </p>
+                                    </div>
+                                    {g.memberCount != null ? (
+                                        <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+                                            {g.memberCount.toLocaleString()} members
+                                        </span>
+                                    ) : null}
+                                </li>
+                            )
+                        })}
                     </ul>
                 )}
             </section>

--- a/src/web/app/api/admin/database/cleanup/route.ts
+++ b/src/web/app/api/admin/database/cleanup/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server"
+import { guardAdminAccess } from "@/lib/admin-access"
+import { proxyBotApi } from "@/server/bot-api-proxy"
+
+export async function POST(request: Request): Promise<Response> {
+    try {
+        const denied = await guardAdminAccess()
+        if (denied) return denied
+        return await proxyBotApi(request)
+    } catch (error: unknown) {
+        const safeMessage = (error instanceof Error ? error.message : String(error)).slice(0, 500)
+        console.error(`[api/admin/database/cleanup] POST proxy failed: ${safeMessage}`)
+        return NextResponse.json(
+            { ok: false, error: "Internal Server Error", details: { code: "INTERNAL_ERROR" } },
+            { status: 500 }
+        )
+    }
+}

--- a/src/web/app/api/admin/database/stats/route.ts
+++ b/src/web/app/api/admin/database/stats/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server"
+import { guardAdminAccess } from "@/lib/admin-access"
+import { proxyBotApi } from "@/server/bot-api-proxy"
+
+export async function GET(request: Request): Promise<Response> {
+    try {
+        const denied = await guardAdminAccess()
+        if (denied) return denied
+        return await proxyBotApi(request)
+    } catch (error: unknown) {
+        const safeMessage = (error instanceof Error ? error.message : String(error)).slice(0, 500)
+        console.error(`[api/admin/database/stats] GET proxy failed: ${safeMessage}`)
+        return NextResponse.json(
+            { ok: false, error: "Internal Server Error", details: { code: "INTERNAL_ERROR" } },
+            { status: 500 }
+        )
+    }
+}

--- a/src/web/app/api/admin/errors/route.ts
+++ b/src/web/app/api/admin/errors/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server"
+import { guardAdminAccess } from "@/lib/admin-access"
+import { proxyBotApi } from "@/server/bot-api-proxy"
+
+export async function GET(request: Request): Promise<Response> {
+    try {
+        const denied = await guardAdminAccess()
+        if (denied) return denied
+        return await proxyBotApi(request)
+    } catch (error: unknown) {
+        const safeMessage = (error instanceof Error ? error.message : String(error)).slice(0, 500)
+        console.error(`[api/admin/errors] GET proxy failed: ${safeMessage}`)
+        return NextResponse.json(
+            { ok: false, error: "Internal Server Error", details: { code: "INTERNAL_ERROR" } },
+            { status: 500 }
+        )
+    }
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+    try {
+        const denied = await guardAdminAccess()
+        if (denied) return denied
+        return await proxyBotApi(request)
+    } catch (error: unknown) {
+        const safeMessage = (error instanceof Error ? error.message : String(error)).slice(0, 500)
+        console.error(`[api/admin/errors] DELETE proxy failed: ${safeMessage}`)
+        return NextResponse.json(
+            { ok: false, error: "Internal Server Error", details: { code: "INTERNAL_ERROR" } },
+            { status: 500 }
+        )
+    }
+}

--- a/src/web/app/api/admin/metrics/route.ts
+++ b/src/web/app/api/admin/metrics/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
-import { guardAdminAccess } from "@/lib/admin-access"
-import { proxyBotApi } from "@/server/bot-api-proxy"
+import { guardAdminAccess } from "@/lib/admin-access.js"
+import { proxyBotApi } from "@/server/bot-api-proxy.js"
 
 export async function GET(request: Request): Promise<Response> {
     try {

--- a/src/web/app/api/admin/metrics/route.ts
+++ b/src/web/app/api/admin/metrics/route.ts
@@ -11,7 +11,13 @@ export async function GET(request: Request): Promise<Response> {
         const safeMessage = (error instanceof Error ? error.message : String(error)).slice(0, 500)
         console.error(`[api/admin/metrics] GET proxy failed: ${safeMessage}`)
         return NextResponse.json(
-            { ok: false, error: "Internal Server Error", details: { code: "INTERNAL_ERROR" } },
+            {
+                ok: false,
+                error: {
+                    error: safeMessage,
+                    details: "PROXY_ERROR",
+                },
+            },
             { status: 500 }
         )
     }

--- a/src/web/app/api/admin/metrics/route.ts
+++ b/src/web/app/api/admin/metrics/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server"
+import { guardAdminAccess } from "@/lib/admin-access"
+import { proxyBotApi } from "@/server/bot-api-proxy"
+
+export async function GET(request: Request): Promise<Response> {
+    try {
+        const denied = await guardAdminAccess()
+        if (denied) return denied
+        return await proxyBotApi(request)
+    } catch (error: unknown) {
+        const safeMessage = (error instanceof Error ? error.message : String(error)).slice(0, 500)
+        console.error(`[api/admin/metrics] GET proxy failed: ${safeMessage}`)
+        return NextResponse.json(
+            { ok: false, error: "Internal Server Error", details: { code: "INTERNAL_ERROR" } },
+            { status: 500 }
+        )
+    }
+}

--- a/src/web/lib/admin-access.ts
+++ b/src/web/lib/admin-access.ts
@@ -33,7 +33,19 @@ export async function resolveAdminAccess(reqHeaders: Headers): Promise<AdminAcce
         return { ok: false, status: 401, error: "Unauthorized" }
     }
 
-    const discordUserId = await resolveDiscordUserSnowflake(session.user.id, reqHeaders)
+    let discordUserId: string | null
+    try {
+        discordUserId = await resolveDiscordUserSnowflake(session.user.id, reqHeaders)
+    } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err)
+        console.error("[admin-access] resolveDiscordUserSnowflake failed:", msg)
+        return {
+            ok: false,
+            status: 403,
+            error: "Discord account required",
+            details: `${msg} — Sign in with Discord, or sign out and sign in again.`,
+        }
+    }
     if (!discordUserId) {
         return {
             ok: false,

--- a/src/web/lib/admin-access.ts
+++ b/src/web/lib/admin-access.ts
@@ -43,7 +43,7 @@ export async function resolveAdminAccess(reqHeaders: Headers): Promise<AdminAcce
             ok: false,
             status: 403,
             error: "Discord account required",
-            details: `${msg} — Sign in with Discord, or sign out and sign in again.`,
+            details: "Sign in with Discord, or sign out and sign in again.",
         }
     }
     if (!discordUserId) {

--- a/src/web/lib/admin-access.ts
+++ b/src/web/lib/admin-access.ts
@@ -1,0 +1,81 @@
+import { headers } from "next/headers"
+import { NextResponse } from "next/server"
+import { auth } from "@/auth"
+import type { AuthenticatedSession } from "@/lib/api-auth"
+import { resolveDiscordUserSnowflake } from "../../shared/discord-user-id.js"
+import { getCachedOwnerId } from "../../shared/permissions.js"
+
+export type AdminAccessResult =
+    | { ok: true; session: AuthenticatedSession; discordUserId: string }
+    | { ok: false; status: number; error: string; details?: string }
+
+/**
+ * Validates the Better Auth session and restricts access to the bot owner (`OWNER_ID`).
+ */
+export async function resolveAdminAccess(reqHeaders: Headers): Promise<AdminAccessResult> {
+    let session: AuthenticatedSession | null
+    try {
+        session = (await auth.api.getSession({
+            headers: reqHeaders,
+        })) as AuthenticatedSession | null
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        console.error("[admin-access] getSession failed:", message)
+        return {
+            ok: false,
+            status: 503,
+            error: "Service Unavailable",
+            details: "Could not load your session. Please try again later.",
+        }
+    }
+
+    if (!session?.user?.id) {
+        return { ok: false, status: 401, error: "Unauthorized" }
+    }
+
+    const discordUserId = await resolveDiscordUserSnowflake(session.user.id, reqHeaders)
+    if (!discordUserId) {
+        return {
+            ok: false,
+            status: 403,
+            error: "Discord account required",
+            details:
+                "We could not resolve your Discord user id. Sign in with Discord, or sign out and sign in again.",
+        }
+    }
+
+    const ownerId = getCachedOwnerId()
+    if (!ownerId || discordUserId !== ownerId) {
+        return {
+            ok: false,
+            status: 403,
+            error: "Forbidden",
+            details: "Developer access required.",
+        }
+    }
+
+    return { ok: true, session, discordUserId }
+}
+
+/** Returns a JSON error response when access is denied; `null` when the caller may proceed. */
+export async function guardAdminAccess(): Promise<NextResponse | null> {
+    try {
+        const h = await headers()
+        const headerRecord = new Headers(h)
+        const result = await resolveAdminAccess(headerRecord)
+        if (result.ok === false) {
+            return NextResponse.json(
+                { ok: false, error: result.error, details: result.details },
+                { status: result.status }
+            )
+        }
+        return null
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        console.error("[admin-access] guardAdminAccess failed:", message)
+        return NextResponse.json(
+            { ok: false, error: "Internal error", details: { code: "INTERNAL_ERROR" } },
+            { status: 500 }
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add owner-gated admin REST routes on the bot (`/api/admin/*`) with metrics, in-memory error history, and Prisma session/verification cleanup.
- Add Next.js `/admin` UI with proxy API routes, plus `requireDeveloperAccess` / `getCachedOwnerId` shared guard and Logger integration with `errorHistory`.
- Fix bot HTTP server to forward all `/api/*` paths to Express (admin routes were previously 404).
- Extend admin metrics with a full guild/server list from the Discord.js cache (not only Lavalink players).

## Test plan

- [ ] Set `OWNER_ID` on both bot and `src/web/.env` when running web on the host; sign in with Discord and open `/admin`.
- [ ] Confirm overview shows server list, player/node stats, and `/api/admin/metrics` succeeds (not 404).
- [ ] Smoke-test errors list and database stats/cleanup (dry run + optional real delete in dev).
