### PR TITLE
feat: user playlists and dashboard player UX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,9 @@ RUN apk add --no-cache dos2unix \
     && dos2unix entrypoint.sh healthcheck.sh \
     && chmod +x entrypoint.sh healthcheck.sh \
     && apk del dos2unix \
-    && chown -R node:node /app
+    && chown -R node:node /app/dist /app/prisma \
+    && chown node:node /app/package.json /app/yarn.lock /app/prisma.config.ts \
+        /app/entrypoint.sh /app/healthcheck.sh
 
 # Default non-root; entrypoint still supports `docker run --user 0` for one-time volume chown + su-exec.
 USER node

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -40,9 +40,10 @@ RUN yarn db:generate
 COPY --chmod=755 entrypoint.sh /usr/local/bin/dimbybot-entrypoint.sh
 COPY --chmod=755 entrypoint.dev.sh /usr/local/bin/dimbybot-dev-entrypoint.sh
 
+# Do not `chown -R` all of `/app` (node_modules has 100k+ files and rebuilds take minutes).
+# `entrypoint.dev.sh` fixes ownership of writable paths at container start.
 RUN addgroup -S devuser && adduser -S devuser -G devuser \
-    && mkdir -p /app/dist \
-    && chown -R devuser:devuser /app
+    && mkdir -p /app/dist
 
 # Runtime environment (see Dockerfile in repo root for the full list):
 # Autoplay: Spotify API on the bot (compose / .env):

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,6 +44,9 @@ services:
             - CHOKIDAR_USEPOLLING=true
             - WATCHPACK_POLLING=true
             - WATCHPACK_POLLING_INTERVAL=1000
+            # `tsc -w` does not use Chokidar; polling avoids missed saves from the host (esp. Windows).
+            - TSC_WATCHFILE=PriorityPollingInterval
+            - TSC_WATCHDIRECTORY=DynamicPriorityPolling
 
     lavalink: # Add the lavalink service definition for development
         build:

--- a/entrypoint.dev.sh
+++ b/entrypoint.dev.sh
@@ -5,4 +5,11 @@ set -e
 # the volume as root-owned and `devuser` hits EACCES on mkdir/emit. Normalize ownership on start.
 mkdir -p /app/dist
 chown -R devuser:devuser /app/dist
+# Prisma client writes (e.g. `yarn db:generate` in dev) — small trees only, not all of node_modules.
+if [ -d /app/node_modules/.prisma ]; then
+    chown -R devuser:devuser /app/node_modules/.prisma
+fi
+if [ -d /app/node_modules/@prisma ]; then
+    chown -R devuser:devuser /app/node_modules/@prisma
+fi
 exec su-exec devuser /usr/local/bin/dimbybot-entrypoint.sh "$@"

--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
         ],
         "ext": "js,json",
         "delay": 1000,
+        "legacyWatch": true,
+        "watchOptions": {
+            "usePolling": true,
+            "interval": 1000
+        },
         "exec": "node dist/server.js"
     }
 }

--- a/prisma/migrations/20260519120000_add_user_playlists/migration.sql
+++ b/prisma/migrations/20260519120000_add_user_playlists/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "Playlist" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Playlist_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PlaylistTrack" (
+    "id" SERIAL NOT NULL,
+    "playlistId" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "uri" TEXT NOT NULL,
+    "author" TEXT NOT NULL,
+    "duration" INTEGER NOT NULL,
+    "addedAt" TIMESTAMP(3) NOT NULL,
+    "position" INTEGER NOT NULL,
+
+    CONSTRAINT "PlaylistTrack_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Playlist_userId_idx" ON "Playlist"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Playlist_userId_name_key" ON "Playlist"("userId", "name");
+
+-- CreateIndex
+CREATE INDEX "PlaylistTrack_playlistId_idx" ON "PlaylistTrack"("playlistId");
+
+-- AddForeignKey
+ALTER TABLE "PlaylistTrack" ADD CONSTRAINT "PlaylistTrack_playlistId_fkey" FOREIGN KEY ("playlistId") REFERENCES "Playlist"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260519120000_add_user_playlists/migration.sql
+++ b/prisma/migrations/20260519120000_add_user_playlists/migration.sql
@@ -32,5 +32,8 @@ CREATE UNIQUE INDEX "Playlist_userId_name_key" ON "Playlist"("userId", "name");
 -- CreateIndex
 CREATE INDEX "PlaylistTrack_playlistId_idx" ON "PlaylistTrack"("playlistId");
 
+-- CreateIndex
+CREATE UNIQUE INDEX "PlaylistTrack_playlistId_position_key" ON "PlaylistTrack"("playlistId", "position");
+
 -- AddForeignKey
 ALTER TABLE "PlaylistTrack" ADD CONSTRAINT "PlaylistTrack_playlistId_fkey" FOREIGN KEY ("playlistId") REFERENCES "Playlist"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260520120000_playlist_track_thumbnail/migration.sql
+++ b/prisma/migrations/20260520120000_playlist_track_thumbnail/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PlaylistTrack" ADD COLUMN "thumbnailUrl" TEXT;

--- a/prisma/migrations/20260521120000_playlist_track_position_unique/migration.sql
+++ b/prisma/migrations/20260521120000_playlist_track_position_unique/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "PlaylistTrack_playlistId_position_key" ON "PlaylistTrack"("playlistId", "position");

--- a/prisma/migrations/20260521120000_playlist_track_position_unique/migration.sql
+++ b/prisma/migrations/20260521120000_playlist_track_position_unique/migration.sql
@@ -1,2 +1,2 @@
--- CreateIndex
-CREATE UNIQUE INDEX "PlaylistTrack_playlistId_position_key" ON "PlaylistTrack"("playlistId", "position");
+-- Index already created in 20260519120000_add_user_playlists; idempotent for DBs that lack it.
+CREATE UNIQUE INDEX IF NOT EXISTS "PlaylistTrack_playlistId_position_key" ON "PlaylistTrack"("playlistId", "position");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,7 @@ model PlaylistTrack {
   addedAt       DateTime
   position      Int
 
+  @@unique([playlistId, position])
   @@index([playlistId], name: "PlaylistTrack_playlistId_idx")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,33 @@ model DownloadMetadata {
   @@index([guildId], name: "DownloadMetadata_guildId_idx")
 }
 
+model Playlist {
+  id        Int             @id @default(autoincrement())
+  name      String
+  userId    String
+  createdAt DateTime        @default(now())
+  updatedAt DateTime        @updatedAt
+  tracks    PlaylistTrack[]
+
+  @@unique([userId, name])
+  @@index([userId], name: "Playlist_userId_idx")
+}
+
+model PlaylistTrack {
+  id            Int      @id @default(autoincrement())
+  playlistId    Int
+  playlist      Playlist @relation(fields: [playlistId], references: [id], onDelete: Cascade)
+  title         String
+  uri           String
+  author        String
+  duration      Int
+  thumbnailUrl  String?
+  addedAt       DateTime
+  position      Int
+
+  @@index([playlistId], name: "PlaylistTrack_playlistId_idx")
+}
+
 model User {
   id            String    @id
   name          String

--- a/src/botApi/createBotApiApp.ts
+++ b/src/botApi/createBotApiApp.ts
@@ -2,6 +2,7 @@ import express from "express"
 import { isBotApiVerbose } from "../util/botApiVerboseEnv.js"
 import { incomingMessageToHeaders } from "./httpUtil.js"
 import { guildListGET } from "./handlers/guildList.js"
+import { voiceContextGET } from "./handlers/voiceContext.js"
 import { playerGET, playerPOST } from "./handlers/player.js"
 import { playerPlayPOST } from "./handlers/playerPlay.js"
 import { queueDELETE, queueGET, queuePOST } from "./handlers/queue.js"
@@ -11,6 +12,17 @@ import { adminMetricsGET } from "./handlers/admin/metrics.js"
 import { adminErrorsDELETE, adminErrorsGET } from "./handlers/admin/errors.js"
 import { adminDbCleanupPOST, adminDbStatsGET } from "./handlers/admin/database.js"
 import { BotClientNotInitializedError } from "../lib/botClientRegistry.js"
+import {
+    playlistTrackMovePATCH,
+    playlistTracksDELETE,
+    playlistTracksFromQueryPOST,
+    playlistTracksPOST,
+    playlistsDELETE,
+    playlistsDetailGET,
+    playlistsGET,
+    playlistsPOST,
+} from "./handlers/playlists.js"
+import { playerPlaylistPlayPOST } from "./handlers/playlistPlay.js"
 
 /** Redacts credentials and long base64-like blobs from bot API error strings before JSON responses. */
 function redactBotApiErrorText(text: string): string {
@@ -74,6 +86,15 @@ export function createBotApiApp(): express.Express {
         }
     })
 
+    app.get("/api/guilds/voice-context", async (req, res, next) => {
+        try {
+            const r = await voiceContextGET(incomingMessageToHeaders(req))
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
     app.get("/api/guilds/:guildId/dashboard-permissions", async (req, res, next) => {
         try {
             const r = await dashboardPermissionsGET(
@@ -107,6 +128,19 @@ export function createBotApiApp(): express.Express {
     app.post("/api/guilds/:guildId/player/play", async (req, res, next) => {
         try {
             const r = await playerPlayPOST(
+                incomingMessageToHeaders(req),
+                req.params.guildId,
+                req.body
+            )
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.post("/api/guilds/:guildId/player/play-playlist", async (req, res, next) => {
+        try {
+            const r = await playerPlaylistPlayPOST(
                 incomingMessageToHeaders(req),
                 req.params.guildId,
                 req.body
@@ -169,6 +203,101 @@ export function createBotApiApp(): express.Express {
                 req.params.guildId,
                 req.params.index,
                 req.body
+            )
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.get("/api/playlists", async (req, res, next) => {
+        try {
+            const r = await playlistsGET(incomingMessageToHeaders(req))
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.post("/api/playlists", async (req, res, next) => {
+        try {
+            const r = await playlistsPOST(incomingMessageToHeaders(req), req.body)
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.get("/api/playlists/:playlistId", async (req, res, next) => {
+        try {
+            const r = await playlistsDetailGET(
+                incomingMessageToHeaders(req),
+                req.params.playlistId
+            )
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.delete("/api/playlists/:playlistId", async (req, res, next) => {
+        try {
+            const r = await playlistsDELETE(
+                incomingMessageToHeaders(req),
+                req.params.playlistId
+            )
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.post("/api/playlists/:playlistId/tracks", async (req, res, next) => {
+        try {
+            const r = await playlistTracksPOST(
+                incomingMessageToHeaders(req),
+                req.params.playlistId,
+                req.body
+            )
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.post("/api/playlists/:playlistId/tracks/from-query", async (req, res, next) => {
+        try {
+            const r = await playlistTracksFromQueryPOST(
+                incomingMessageToHeaders(req),
+                req.params.playlistId,
+                req.body
+            )
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.patch("/api/playlists/:playlistId/tracks/:position", async (req, res, next) => {
+        try {
+            const r = await playlistTrackMovePATCH(
+                incomingMessageToHeaders(req),
+                req.params.playlistId,
+                req.params.position,
+                req.body
+            )
+            res.status(r.status).json(r.body)
+        } catch (error) {
+            next(error)
+        }
+    })
+
+    app.delete("/api/playlists/:playlistId/tracks/:position", async (req, res, next) => {
+        try {
+            const r = await playlistTracksDELETE(
+                incomingMessageToHeaders(req),
+                req.params.playlistId,
+                req.params.position
             )
             res.status(r.status).json(r.body)
         } catch (error) {

--- a/src/botApi/handlers/guildList.ts
+++ b/src/botApi/handlers/guildList.ts
@@ -2,6 +2,8 @@ import { auth } from "../../shared/auth-node.js"
 import { fetchDiscordUserGuilds } from "../../util/discordUserGuilds.js"
 import { DISCORD_BOT_INVITE_PERMISSIONS } from "../../shared/discordBotPermissions.js"
 import { getAuthenticatedSession } from "../../shared/api-auth.js"
+import { resolveDiscordUserSnowflake } from "../../shared/discord-user-id.js"
+import { snapshotGuildListPlayer } from "../../shared/player-state.js"
 import { tryGetBotClient } from "../../lib/botClientRegistry.js"
 import type { ApiResponse } from "../../types/index.js"
 import type { GuildListResponse } from "../../types/web.js"
@@ -112,16 +114,31 @@ export async function guildListGET(
         }
     }
 
+    const discordUserId = await resolveDiscordUserSnowflake(
+        sessionResult.session.user.id,
+        headers
+    )
+
     const userGuilds = discordGuilds.guilds
     const botGuilds = botClient.guilds.cache
     const mutualGuilds = userGuilds
         .filter((guild) => botGuilds.has(guild.id))
-        .map((guild) => ({
-            id: guild.id,
-            name: guild.name,
-            iconUrl: discordGuildIconUrl(guild.id, guild.icon),
-            memberCount: botGuilds.get(guild.id)?.memberCount ?? null,
-        }))
+        .map((guild) => {
+            const lavalinkPlayer = botClient.lavalink.getPlayer(guild.id)
+            const player = snapshotGuildListPlayer(
+                guild.id,
+                discordUserId ?? undefined,
+                lavalinkPlayer,
+                botClient
+            )
+            return {
+                id: guild.id,
+                name: guild.name,
+                iconUrl: discordGuildIconUrl(guild.id, guild.icon),
+                memberCount: botGuilds.get(guild.id)?.memberCount ?? null,
+                player,
+            }
+        })
 
     const clientId = process.env.CLIENT_ID?.trim() || ""
     const botInviteUrl = clientId

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -1,7 +1,7 @@
 import { resolveWebRequesterDiscordId } from "../resolveWebRequesterId.js"
 import { WebPermission } from "../../shared/permissions.js"
 import type { ApiResponse } from "../../types/index.js"
-import type { PlayerStateResponse, PlaylistPlayResponse } from "../../types/web.js"
+import type { PlaylistPlayResponse } from "../../types/web.js"
 import { requirePermissions } from "../../shared/api-auth.js"
 import { getBotClient } from "../../lib/botClientRegistry.js"
 import { toPlayerStateResponse } from "../../shared/player-state.js"
@@ -10,7 +10,6 @@ import { searchAndEnqueue } from "./searchAndEnqueue.js"
 import {
     clearUpcomingQueue,
     enqueueResolvedPlaylistTracks,
-    pickPlayerForPlaylistSearch,
     resolveStoredPlaylistTracks,
 } from "../../util/playlistQueue.js"
 
@@ -46,8 +45,8 @@ export async function playerPlaylistPlayPOST(
         const playlistId =
             typeof body.playlistId === "number"
                 ? body.playlistId
-                : typeof body.playlistId === "string"
-                  ? Number.parseInt(body.playlistId, 10)
+                : typeof body.playlistId === "string" && /^[1-9]\d*$/.test(body.playlistId.trim())
+                  ? Number.parseInt(body.playlistId.trim(), 10)
                   : NaN
         if (!Number.isFinite(playlistId) || playlistId < 1) {
             return {
@@ -100,15 +99,15 @@ export async function playerPlaylistPlayPOST(
             client,
             guildId,
             requester.requesterId,
-            playlist.tracks[0]!.uri,
-            guard
+            "",
+            guard,
+            { connectOnly: true }
         )
         if (voiceSetup.ok === false) {
             return { status: voiceSetup.status, body: { ok: false, error: voiceSetup.error } }
         }
 
         const player = voiceSetup.player
-        await clearUpcomingQueue(player)
         const { resolved, failed } = await resolveStoredPlaylistTracks(
             player,
             playlist.tracks,

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -1,0 +1,166 @@
+import { resolveWebRequesterDiscordId } from "../resolveWebRequesterId.js"
+import { WebPermission } from "../../shared/permissions.js"
+import type { ApiResponse } from "../../types/index.js"
+import type { PlayerStateResponse, PlaylistPlayResponse } from "../../types/web.js"
+import { requirePermissions } from "../../shared/api-auth.js"
+import { getBotClient } from "../../lib/botClientRegistry.js"
+import { toPlayerStateResponse } from "../../shared/player-state.js"
+import { getPlaylistById } from "../../repositories/playlistRepository.js"
+import { searchAndEnqueue } from "./searchAndEnqueue.js"
+import {
+    clearUpcomingQueue,
+    enqueueResolvedPlaylistTracks,
+    pickPlayerForPlaylistSearch,
+    resolveStoredPlaylistTracks,
+} from "../../util/playlistQueue.js"
+
+export async function playerPlaylistPlayPOST(
+    headers: Headers,
+    guildId: string,
+    rawBody: unknown
+): Promise<{ status: number; body: ApiResponse<PlaylistPlayResponse> }> {
+    try {
+        const guard = await requirePermissions(headers, guildId, [WebPermission.MANAGE_QUEUE])
+        if (guard.ok === false) {
+            return {
+                status: guard.status,
+                body: { ok: false, error: { error: guard.error, details: guard.details } },
+            }
+        }
+
+        const requester = resolveWebRequesterDiscordId(rawBody, guard.discordUserId)
+        if (requester.ok === false) {
+            return {
+                status: requester.status,
+                body: {
+                    ok: false,
+                    error: { error: requester.error, details: requester.details },
+                },
+            }
+        }
+
+        const body = (typeof rawBody === "object" && rawBody !== null ? rawBody : {}) as {
+            playlistId?: unknown
+            shuffle?: unknown
+        }
+        const playlistId =
+            typeof body.playlistId === "number"
+                ? body.playlistId
+                : typeof body.playlistId === "string"
+                  ? Number.parseInt(body.playlistId, 10)
+                  : NaN
+        if (!Number.isFinite(playlistId) || playlistId < 1) {
+            return {
+                status: 400,
+                body: {
+                    ok: false,
+                    error: { error: "Bad request", details: "playlistId is required." },
+                },
+            }
+        }
+
+        const shuffle = body.shuffle === true
+
+        const playlist = await getPlaylistById(playlistId)
+        if (!playlist) {
+            return {
+                status: 404,
+                body: {
+                    ok: false,
+                    error: { error: "Not found", details: "Playlist not found." },
+                },
+            }
+        }
+        if (playlist.userId !== guard.discordUserId) {
+            return {
+                status: 403,
+                body: {
+                    ok: false,
+                    error: { error: "Forbidden", details: "You do not own this playlist." },
+                },
+            }
+        }
+        if (playlist.tracks.length === 0) {
+            return {
+                status: 400,
+                body: {
+                    ok: false,
+                    error: { error: "Bad request", details: "Playlist has no tracks." },
+                },
+            }
+        }
+
+        const client = getBotClient()
+        const requesterPayload = {
+            id: requester.requesterId,
+            username: guard.session.user?.name ?? "web-user",
+        }
+
+        const voiceSetup = await searchAndEnqueue(
+            client,
+            guildId,
+            requester.requesterId,
+            playlist.tracks[0]!.uri,
+            guard
+        )
+        if (voiceSetup.ok === false) {
+            return { status: voiceSetup.status, body: { ok: false, error: voiceSetup.error } }
+        }
+
+        const player = voiceSetup.player
+        await clearUpcomingQueue(player)
+        const { resolved, failed } = await resolveStoredPlaylistTracks(
+            player,
+            playlist.tracks,
+            requesterPayload
+        )
+
+        if (resolved.length === 0) {
+            return {
+                status: 404,
+                body: {
+                    ok: false,
+                    error: {
+                        error: "No matches found.",
+                        details: "Could not resolve any tracks from this playlist.",
+                    },
+                },
+            }
+        }
+
+        await clearUpcomingQueue(player)
+        const enqueue = await enqueueResolvedPlaylistTracks(
+            player,
+            resolved,
+            requester.requesterId,
+            shuffle
+        )
+
+        const state = await toPlayerStateResponse(guildId, requester.requesterId, player)
+
+        return {
+            status: 200,
+            body: {
+                ok: true,
+                data: {
+                    state,
+                    playlistId: playlist.id,
+                    playlistName: playlist.name,
+                    queued: enqueue.queued,
+                    failed,
+                    shuffle,
+                },
+            },
+        }
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        console.error("[playerPlaylistPlayPOST] unhandled error", { guildId, message })
+        return {
+            status: 500,
+            body: {
+                ok: false,
+                error: { error: "Internal server error.", details: "An internal error occurred." },
+            },
+        }
+    }
+}

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -42,13 +42,33 @@ export async function playerPlaylistPlayPOST(
             playlistId?: unknown
             shuffle?: unknown
         }
-        const playlistId =
-            typeof body.playlistId === "number"
-                ? body.playlistId
-                : typeof body.playlistId === "string" && /^[1-9]\d*$/.test(body.playlistId.trim())
-                  ? Number.parseInt(body.playlistId.trim(), 10)
-                  : NaN
-        if (!Number.isFinite(playlistId) || playlistId < 1) {
+        let playlistId: number
+        if (typeof body.playlistId === "number") {
+            if (!Number.isFinite(body.playlistId) || !Number.isInteger(body.playlistId) || body.playlistId < 1) {
+                return {
+                    status: 400,
+                    body: {
+                        ok: false,
+                        error: { error: "Bad request", details: "playlistId is required." },
+                    },
+                }
+            }
+            playlistId = body.playlistId
+        } else if (
+            typeof body.playlistId === "string" &&
+            /^[1-9]\d*$/.test(body.playlistId.trim())
+        ) {
+            playlistId = Number.parseInt(body.playlistId.trim(), 10)
+        } else {
+            return {
+                status: 400,
+                body: {
+                    ok: false,
+                    error: { error: "Bad request", details: "playlistId is required." },
+                },
+            }
+        }
+        if (!Number.isInteger(playlistId) || playlistId < 1) {
             return {
                 status: 400,
                 body: {

--- a/src/botApi/handlers/playlists.ts
+++ b/src/botApi/handlers/playlists.ts
@@ -1,0 +1,621 @@
+import { getAuthenticatedSession } from "../../shared/api-auth.js"
+import { resolveDiscordUserSnowflake } from "../../shared/discord-user-id.js"
+import type { ApiResponse } from "../../types/index.js"
+import type {
+    AddPlaylistTrackBody,
+    AddTracksFromQueryResponse,
+    PlaylistData,
+    PlaylistListResponse,
+    PlaylistTrackData,
+} from "../../types/web.js"
+import {
+    PlaylistDuplicateNameError,
+    PlaylistTrackNotFoundError,
+    addTrackToPlaylist,
+    addTracksToPlaylist,
+    createPlaylist,
+    deletePlaylist,
+    getPlaylistById,
+    getUserPlaylists,
+    movePlaylistTrack,
+    removeTrackFromPlaylist,
+} from "../../repositories/playlistRepository.js"
+import { getBotClient } from "../../lib/botClientRegistry.js"
+import {
+    pickPlayerForPlaylistSearch,
+    searchTracksForPlaylist,
+} from "../../util/playlistQueue.js"
+
+type AuthOk = { ok: true; discordUserId: string }
+type AuthFail = { ok: false; status: number; body: ApiResponse<never> }
+
+async function resolvePlaylistUser(headers: Headers): Promise<AuthOk | AuthFail> {
+    const sessionResult = await getAuthenticatedSession(headers)
+    if (sessionResult.ok === false) {
+        return {
+            ok: false,
+            status: sessionResult.status,
+            body: {
+                ok: false,
+                error: { error: sessionResult.error, details: sessionResult.details },
+            },
+        }
+    }
+
+    const discordUserId = await resolveDiscordUserSnowflake(
+        sessionResult.session.user.id,
+        headers
+    )
+    if (!discordUserId) {
+        return {
+            ok: false,
+            status: 403,
+            body: {
+                ok: false,
+                error: {
+                    error: "Discord account required",
+                    details: "Could not resolve your Discord user id.",
+                },
+            },
+        }
+    }
+
+    return { ok: true, discordUserId }
+}
+
+function parsePlaylistId(playlistId: string): number | null {
+    const id = Number.parseInt(playlistId, 10)
+    if (!Number.isFinite(id) || id < 1) return null
+    return id
+}
+
+function parsePosition(position: string): number | null {
+    const pos = Number.parseInt(position, 10)
+    if (!Number.isFinite(pos) || pos < 1) return null
+    return pos
+}
+
+async function requireOwnedPlaylist(
+    discordUserId: string,
+    playlistId: number
+): Promise<
+    | { ok: true; playlist: PlaylistData }
+    | { ok: false; status: number; body: ApiResponse<never> }
+> {
+    const playlist = await getPlaylistById(playlistId)
+    if (!playlist) {
+        return {
+            ok: false,
+            status: 404,
+            body: {
+                ok: false,
+                error: { error: "Not found", details: "Playlist not found." },
+            },
+        }
+    }
+    if (playlist.userId !== discordUserId) {
+        return {
+            ok: false,
+            status: 403,
+            body: {
+                ok: false,
+                error: { error: "Forbidden", details: "You do not own this playlist." },
+            },
+        }
+    }
+    return { ok: true, playlist }
+}
+
+function parseTrackBody(raw: unknown): AddPlaylistTrackBody | null {
+    if (!raw || typeof raw !== "object") return null
+    const b = raw as Record<string, unknown>
+    if (typeof b.title !== "string" || !b.title.trim()) return null
+    if (typeof b.uri !== "string" || !b.uri.trim()) return null
+    if (typeof b.author !== "string") return null
+    if (typeof b.duration !== "number" || !Number.isFinite(b.duration) || b.duration < 0) {
+        return null
+    }
+    if (typeof b.addedAt !== "string" || !b.addedAt.trim()) return null
+    const added = new Date(b.addedAt)
+    if (Number.isNaN(added.getTime())) return null
+    const thumbnailUrl =
+        typeof b.thumbnailUrl === "string" && b.thumbnailUrl.trim()
+            ? b.thumbnailUrl.trim()
+            : null
+    return {
+        title: b.title.trim(),
+        uri: b.uri.trim(),
+        author: b.author.trim() || "Unknown",
+        duration: Math.floor(b.duration),
+        thumbnailUrl,
+        addedAt: b.addedAt,
+    }
+}
+
+export async function playlistsGET(
+    headers: Headers
+): Promise<{ status: number; body: ApiResponse<PlaylistListResponse> }> {
+    const auth = await resolvePlaylistUser(headers)
+    if (auth.ok === false) {
+        return { status: auth.status, body: auth.body }
+    }
+
+    try {
+        const playlists = await getUserPlaylists(auth.discordUserId)
+        return {
+            status: 200,
+            body: { ok: true, data: { playlists } },
+        }
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+            status: 500,
+            body: {
+                ok: false,
+                error: { error: "internal_error", details: message },
+            },
+        }
+    }
+}
+
+export async function playlistsPOST(
+    headers: Headers,
+    rawBody: unknown
+): Promise<{ status: number; body: ApiResponse<PlaylistData> }> {
+    const auth = await resolvePlaylistUser(headers)
+    if (auth.ok === false) {
+        return { status: auth.status, body: auth.body }
+    }
+
+    if (!rawBody || typeof rawBody !== "object") {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Expected JSON body with name." },
+            },
+        }
+    }
+    const name = (rawBody as { name?: unknown }).name
+    if (typeof name !== "string" || !name.trim()) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Playlist name is required." },
+            },
+        }
+    }
+
+    try {
+        const playlist = await createPlaylist(auth.discordUserId, name.trim())
+        return { status: 201, body: { ok: true, data: playlist } }
+    } catch (error: unknown) {
+        if (error instanceof PlaylistDuplicateNameError) {
+            return {
+                status: 409,
+                body: {
+                    ok: false,
+                    error: { error: "Conflict", details: error.message },
+                },
+            }
+        }
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+            status: 500,
+            body: {
+                ok: false,
+                error: { error: "internal_error", details: message },
+            },
+        }
+    }
+}
+
+export async function playlistsDetailGET(
+    headers: Headers,
+    playlistIdParam: string
+): Promise<{ status: number; body: ApiResponse<PlaylistData> }> {
+    const auth = await resolvePlaylistUser(headers)
+    if (auth.ok === false) {
+        return { status: auth.status, body: auth.body }
+    }
+
+    const playlistId = parsePlaylistId(playlistIdParam)
+    if (playlistId === null) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Invalid playlist id." },
+            },
+        }
+    }
+
+    const owned = await requireOwnedPlaylist(auth.discordUserId, playlistId)
+    if (owned.ok === false) {
+        return { status: owned.status, body: owned.body }
+    }
+
+    return { status: 200, body: { ok: true, data: owned.playlist } }
+}
+
+export async function playlistsDELETE(
+    headers: Headers,
+    playlistIdParam: string
+): Promise<{ status: number; body: ApiResponse<{ deleted: true }> }> {
+    const auth = await resolvePlaylistUser(headers)
+    if (auth.ok === false) {
+        return { status: auth.status, body: auth.body }
+    }
+
+    const playlistId = parsePlaylistId(playlistIdParam)
+    if (playlistId === null) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Invalid playlist id." },
+            },
+        }
+    }
+
+    const owned = await requireOwnedPlaylist(auth.discordUserId, playlistId)
+    if (owned.ok === false) {
+        return { status: owned.status, body: owned.body }
+    }
+
+    try {
+        await deletePlaylist(auth.discordUserId, owned.playlist.name)
+        return {
+            status: 200,
+            body: { ok: true, data: { deleted: true } },
+        }
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+            status: 500,
+            body: {
+                ok: false,
+                error: { error: "internal_error", details: message },
+            },
+        }
+    }
+}
+
+export async function playlistTracksPOST(
+    headers: Headers,
+    playlistIdParam: string,
+    rawBody: unknown
+): Promise<{ status: number; body: ApiResponse<PlaylistTrackData> }> {
+    const auth = await resolvePlaylistUser(headers)
+    if (auth.ok === false) {
+        return { status: auth.status, body: auth.body }
+    }
+
+    const playlistId = parsePlaylistId(playlistIdParam)
+    if (playlistId === null) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Invalid playlist id." },
+            },
+        }
+    }
+
+    const owned = await requireOwnedPlaylist(auth.discordUserId, playlistId)
+    if (owned.ok === false) {
+        return { status: owned.status, body: owned.body }
+    }
+
+    const body = parseTrackBody(rawBody)
+    if (!body) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: {
+                    error: "Bad request",
+                    details: "Invalid track body (title, uri, author, duration, addedAt).",
+                },
+            },
+        }
+    }
+
+    try {
+        const track = await addTrackToPlaylist(playlistId, {
+            title: body.title,
+            uri: body.uri,
+            author: body.author,
+            duration: body.duration,
+            thumbnailUrl: body.thumbnailUrl,
+            addedAt: new Date(body.addedAt),
+        })
+        return { status: 201, body: { ok: true, data: track } }
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+            status: 500,
+            body: {
+                ok: false,
+                error: { error: "internal_error", details: message },
+            },
+        }
+    }
+}
+
+export async function playlistTracksFromQueryPOST(
+    headers: Headers,
+    playlistIdParam: string,
+    rawBody: unknown
+): Promise<{ status: number; body: ApiResponse<AddTracksFromQueryResponse> }> {
+    const auth = await resolvePlaylistUser(headers)
+    if (auth.ok === false) {
+        return { status: auth.status, body: auth.body }
+    }
+
+    const playlistId = parsePlaylistId(playlistIdParam)
+    if (playlistId === null) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Invalid playlist id." },
+            },
+        }
+    }
+
+    const owned = await requireOwnedPlaylist(auth.discordUserId, playlistId)
+    if (owned.ok === false) {
+        return { status: owned.status, body: owned.body }
+    }
+
+    if (!rawBody || typeof rawBody !== "object") {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Expected JSON body with query." },
+            },
+        }
+    }
+    const body = rawBody as { query?: unknown; guildId?: unknown }
+    const query = typeof body.query === "string" ? body.query.trim() : ""
+    if (!query) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "query is required." },
+            },
+        }
+    }
+    const preferredGuildId =
+        typeof body.guildId === "string" && body.guildId.trim() ? body.guildId.trim() : undefined
+
+    const client = getBotClient()
+    const player = pickPlayerForPlaylistSearch(client.lavalink, preferredGuildId)
+    if (!player) {
+        return {
+            status: 503,
+            body: {
+                ok: false,
+                error: {
+                    error: "Search unavailable",
+                    details:
+                        "The bot is not connected in any voice channel. Join a server voice channel and play a song, or paste a direct track URL.",
+                },
+            },
+        }
+    }
+
+    const requester = { id: auth.discordUserId, username: "web-user" }
+    const found = await searchTracksForPlaylist(player, query, requester)
+    if (found.ok === false) {
+        return {
+            status: 404,
+            body: {
+                ok: false,
+                error: { error: "Not found", details: found.error },
+            },
+        }
+    }
+
+    try {
+        const addedAt = new Date()
+        const tracks = await addTracksToPlaylist(
+            playlistId,
+            found.tracks.map((t) => ({
+                title: t.title,
+                uri: t.uri,
+                author: t.author,
+                duration: t.duration,
+                thumbnailUrl: t.thumbnailUrl,
+                addedAt,
+            }))
+        )
+        return {
+            status: 201,
+            body: { ok: true, data: { added: tracks.length, tracks } },
+        }
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+            status: 500,
+            body: {
+                ok: false,
+                error: { error: "internal_error", details: message },
+            },
+        }
+    }
+}
+
+export async function playlistTrackMovePATCH(
+    headers: Headers,
+    playlistIdParam: string,
+    positionParam: string,
+    rawBody: unknown
+): Promise<{ status: number; body: ApiResponse<PlaylistData> }> {
+    const auth = await resolvePlaylistUser(headers)
+    if (auth.ok === false) {
+        return { status: auth.status, body: auth.body }
+    }
+
+    const playlistId = parsePlaylistId(playlistIdParam)
+    if (playlistId === null) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Invalid playlist id." },
+            },
+        }
+    }
+
+    const fromPosition = parsePosition(positionParam)
+    if (fromPosition === null) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Invalid track position." },
+            },
+        }
+    }
+
+    const owned = await requireOwnedPlaylist(auth.discordUserId, playlistId)
+    if (owned.ok === false) {
+        return { status: owned.status, body: owned.body }
+    }
+
+    if (!rawBody || typeof rawBody !== "object") {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Expected JSON body with newPosition." },
+            },
+        }
+    }
+    const newPositionRaw = (rawBody as { newPosition?: unknown }).newPosition
+    const newPosition =
+        typeof newPositionRaw === "number"
+            ? newPositionRaw
+            : typeof newPositionRaw === "string"
+              ? Number.parseInt(newPositionRaw, 10)
+              : NaN
+    if (!Number.isFinite(newPosition) || newPosition < 1) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "newPosition must be a positive integer." },
+            },
+        }
+    }
+
+    try {
+        await movePlaylistTrack(playlistId, fromPosition, Math.floor(newPosition))
+        const updated = await getPlaylistById(playlistId)
+        if (!updated) {
+            return {
+                status: 404,
+                body: {
+                    ok: false,
+                    error: { error: "Not found", details: "Playlist not found." },
+                },
+            }
+        }
+        return { status: 200, body: { ok: true, data: updated } }
+    } catch (error: unknown) {
+        if (error instanceof PlaylistTrackNotFoundError) {
+            return {
+                status: 404,
+                body: {
+                    ok: false,
+                    error: { error: "Not found", details: error.message },
+                },
+            }
+        }
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+            status: 500,
+            body: {
+                ok: false,
+                error: { error: "internal_error", details: message },
+            },
+        }
+    }
+}
+
+export async function playlistTracksDELETE(
+    headers: Headers,
+    playlistIdParam: string,
+    positionParam: string
+): Promise<{ status: number; body: ApiResponse<{ removed: true }> }> {
+    const auth = await resolvePlaylistUser(headers)
+    if (auth.ok === false) {
+        return { status: auth.status, body: auth.body }
+    }
+
+    const playlistId = parsePlaylistId(playlistIdParam)
+    if (playlistId === null) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Invalid playlist id." },
+            },
+        }
+    }
+
+    const position = parsePosition(positionParam)
+    if (position === null) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: { error: "Bad request", details: "Invalid track position." },
+            },
+        }
+    }
+
+    const owned = await requireOwnedPlaylist(auth.discordUserId, playlistId)
+    if (owned.ok === false) {
+        return { status: owned.status, body: owned.body }
+    }
+
+    const hasPosition = owned.playlist.tracks.some((t) => t.position === position)
+    if (!hasPosition) {
+        return {
+            status: 404,
+            body: {
+                ok: false,
+                error: { error: "Not found", details: `No track at position ${position}.` },
+            },
+        }
+    }
+
+    try {
+        await removeTrackFromPlaylist(playlistId, position)
+        return { status: 200, body: { ok: true, data: { removed: true } } }
+    } catch (error: unknown) {
+        if (error instanceof PlaylistTrackNotFoundError) {
+            return {
+                status: 404,
+                body: {
+                    ok: false,
+                    error: { error: "Not found", details: error.message },
+                },
+            }
+        }
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+            status: 500,
+            body: {
+                ok: false,
+                error: { error: "internal_error", details: message },
+            },
+        }
+    }
+}

--- a/src/botApi/handlers/playlists.ts
+++ b/src/botApi/handlers/playlists.ts
@@ -31,37 +31,42 @@ type AuthOk = { ok: true; discordUserId: string }
 type AuthFail = { ok: false; status: number; body: ApiResponse<never> }
 
 async function resolvePlaylistUser(headers: Headers): Promise<AuthOk | AuthFail> {
-    const sessionResult = await getAuthenticatedSession(headers)
-    if (sessionResult.ok === false) {
-        return {
-            ok: false,
-            status: sessionResult.status,
-            body: {
+    try {
+        const sessionResult = await getAuthenticatedSession(headers)
+        if (sessionResult.ok === false) {
+            return {
                 ok: false,
-                error: { error: sessionResult.error, details: sessionResult.details },
-            },
-        }
-    }
-
-    const discordUserId = await resolveDiscordUserSnowflake(
-        sessionResult.session.user.id,
-        headers
-    )
-    if (!discordUserId) {
-        return {
-            ok: false,
-            status: 403,
-            body: {
-                ok: false,
-                error: {
-                    error: "Discord account required",
-                    details: "Could not resolve your Discord user id.",
+                status: sessionResult.status,
+                body: {
+                    ok: false,
+                    error: { error: sessionResult.error, details: sessionResult.details },
                 },
-            },
+            }
         }
-    }
 
-    return { ok: true, discordUserId }
+        const discordUserId = await resolveDiscordUserSnowflake(
+            sessionResult.session.user.id,
+            headers
+        )
+        if (!discordUserId) {
+            return {
+                ok: false,
+                status: 403,
+                body: {
+                    ok: false,
+                    error: {
+                        error: "Discord account required",
+                        details: "Could not resolve your Discord user id.",
+                    },
+                },
+            }
+        }
+
+        return { ok: true, discordUserId }
+    } catch (error: unknown) {
+        logPlaylistsHandlerError("resolvePlaylistUser", error)
+        return { ok: false, status: 500, body: internalErrorBody() }
+    }
 }
 
 const STRICT_POSITIVE_INT = /^[1-9]\d*$/
@@ -115,28 +120,33 @@ async function requireOwnedPlaylist(
     | { ok: true; playlist: PlaylistData }
     | { ok: false; status: number; body: ApiResponse<never> }
 > {
-    const playlist = await getPlaylistById(playlistId)
-    if (!playlist) {
-        return {
-            ok: false,
-            status: 404,
-            body: {
+    try {
+        const playlist = await getPlaylistById(playlistId)
+        if (!playlist) {
+            return {
                 ok: false,
-                error: { error: "Not found", details: "Playlist not found." },
-            },
+                status: 404,
+                body: {
+                    ok: false,
+                    error: { error: "Not found", details: "Playlist not found." },
+                },
+            }
         }
-    }
-    if (playlist.userId !== discordUserId) {
-        return {
-            ok: false,
-            status: 403,
-            body: {
+        if (playlist.userId !== discordUserId) {
+            return {
                 ok: false,
-                error: { error: "Forbidden", details: "You do not own this playlist." },
-            },
+                status: 403,
+                body: {
+                    ok: false,
+                    error: { error: "Forbidden", details: "You do not own this playlist." },
+                },
+            }
         }
+        return { ok: true, playlist }
+    } catch (error: unknown) {
+        logPlaylistsHandlerError("requireOwnedPlaylist", error)
+        return { ok: false, status: 500, body: internalErrorBody() }
     }
-    return { ok: true, playlist }
 }
 
 function parseTrackBody(raw: unknown): AddPlaylistTrackBody | null {
@@ -504,13 +514,37 @@ export async function playlistTrackMovePATCH(
         }
     }
     const newPositionRaw = (rawBody as { newPosition?: unknown }).newPosition
-    const newPosition =
-        typeof newPositionRaw === "number"
-            ? newPositionRaw
-            : typeof newPositionRaw === "string"
-              ? Number.parseInt(newPositionRaw, 10)
-              : NaN
-    if (!Number.isFinite(newPosition) || newPosition < 1) {
+    let newPosition: number
+    if (typeof newPositionRaw === "number") {
+        if (!Number.isInteger(newPositionRaw) || newPositionRaw < 1) {
+            return {
+                status: 400,
+                body: {
+                    ok: false,
+                    error: {
+                        error: "Bad request",
+                        details: "newPosition must be a positive integer.",
+                    },
+                },
+            }
+        }
+        newPosition = newPositionRaw
+    } else if (typeof newPositionRaw === "string") {
+        const parsed = parseStrictPositiveInt(newPositionRaw)
+        if (parsed === null) {
+            return {
+                status: 400,
+                body: {
+                    ok: false,
+                    error: {
+                        error: "Bad request",
+                        details: "newPosition must be a positive integer.",
+                    },
+                },
+            }
+        }
+        newPosition = parsed
+    } else {
         return {
             status: 400,
             body: {
@@ -521,7 +555,7 @@ export async function playlistTrackMovePATCH(
     }
 
     try {
-        await movePlaylistTrack(playlistId, fromPosition, Math.floor(newPosition))
+        await movePlaylistTrack(playlistId, fromPosition, newPosition)
         const updated = await getPlaylistById(playlistId)
         if (!updated) {
             return {

--- a/src/botApi/handlers/playlists.ts
+++ b/src/botApi/handlers/playlists.ts
@@ -7,6 +7,7 @@ import type {
     PlaylistData,
     PlaylistListResponse,
     PlaylistTrackData,
+    SerializedPlaylistTrackData,
 } from "../../types/web.js"
 import {
     PlaylistDuplicateNameError,
@@ -63,16 +64,48 @@ async function resolvePlaylistUser(headers: Headers): Promise<AuthOk | AuthFail>
     return { ok: true, discordUserId }
 }
 
+const STRICT_POSITIVE_INT = /^[1-9]\d*$/
+
+function parseStrictPositiveInt(value: string): number | null {
+    const trimmed = value.trim()
+    if (!STRICT_POSITIVE_INT.test(trimmed)) return null
+    const n = Number.parseInt(trimmed, 10)
+    if (!Number.isFinite(n) || n < 1) return null
+    return n
+}
+
 function parsePlaylistId(playlistId: string): number | null {
-    const id = Number.parseInt(playlistId, 10)
-    if (!Number.isFinite(id) || id < 1) return null
-    return id
+    return parseStrictPositiveInt(playlistId)
 }
 
 function parsePosition(position: string): number | null {
-    const pos = Number.parseInt(position, 10)
-    if (!Number.isFinite(pos) || pos < 1) return null
-    return pos
+    return parseStrictPositiveInt(position)
+}
+
+function logPlaylistsHandlerError(handler: string, error: unknown): void {
+    console.error(`[playlists:${handler}]`, error)
+}
+
+function internalErrorBody(): ApiResponse<never> {
+    return {
+        ok: false,
+        error: { error: "internal_error", details: "Internal server error." },
+    }
+}
+
+function serializePlaylistTracksForApi(
+    tracks: PlaylistTrackData[]
+): SerializedPlaylistTrackData[] {
+    return tracks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        uri: t.uri,
+        author: t.author,
+        duration: t.duration,
+        thumbnailUrl: t.thumbnailUrl,
+        addedAt: t.addedAt.toISOString(),
+        position: t.position,
+    }))
 }
 
 async function requireOwnedPlaylist(
@@ -147,14 +180,8 @@ export async function playlistsGET(
             body: { ok: true, data: { playlists } },
         }
     } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error)
-        return {
-            status: 500,
-            body: {
-                ok: false,
-                error: { error: "internal_error", details: message },
-            },
-        }
+        logPlaylistsHandlerError("playlistsGET", error)
+        return { status: 500, body: internalErrorBody() }
     }
 }
 
@@ -200,14 +227,8 @@ export async function playlistsPOST(
                 },
             }
         }
-        const message = error instanceof Error ? error.message : String(error)
-        return {
-            status: 500,
-            body: {
-                ok: false,
-                error: { error: "internal_error", details: message },
-            },
-        }
+        logPlaylistsHandlerError("playlistsPOST", error)
+        return { status: 500, body: internalErrorBody() }
     }
 }
 
@@ -271,14 +292,8 @@ export async function playlistsDELETE(
             body: { ok: true, data: { deleted: true } },
         }
     } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error)
-        return {
-            status: 500,
-            body: {
-                ok: false,
-                error: { error: "internal_error", details: message },
-            },
-        }
+        logPlaylistsHandlerError("playlistsDELETE", error)
+        return { status: 500, body: internalErrorBody() }
     }
 }
 
@@ -333,14 +348,8 @@ export async function playlistTracksPOST(
         })
         return { status: 201, body: { ok: true, data: track } }
     } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error)
-        return {
-            status: 500,
-            body: {
-                ok: false,
-                error: { error: "internal_error", details: message },
-            },
-        }
+        logPlaylistsHandlerError("playlistTracksPOST", error)
+        return { status: 500, body: internalErrorBody() }
     }
 }
 
@@ -436,17 +445,14 @@ export async function playlistTracksFromQueryPOST(
         )
         return {
             status: 201,
-            body: { ok: true, data: { added: tracks.length, tracks } },
-        }
-    } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error)
-        return {
-            status: 500,
             body: {
-                ok: false,
-                error: { error: "internal_error", details: message },
+                ok: true,
+                data: { added: tracks.length, tracks: serializePlaylistTracksForApi(tracks) },
             },
         }
+    } catch (error: unknown) {
+        logPlaylistsHandlerError("playlistTracksFromQueryPOST", error)
+        return { status: 500, body: internalErrorBody() }
     }
 }
 
@@ -537,14 +543,8 @@ export async function playlistTrackMovePATCH(
                 },
             }
         }
-        const message = error instanceof Error ? error.message : String(error)
-        return {
-            status: 500,
-            body: {
-                ok: false,
-                error: { error: "internal_error", details: message },
-            },
-        }
+        logPlaylistsHandlerError("playlistTrackMovePATCH", error)
+        return { status: 500, body: internalErrorBody() }
     }
 }
 
@@ -609,13 +609,7 @@ export async function playlistTracksDELETE(
                 },
             }
         }
-        const message = error instanceof Error ? error.message : String(error)
-        return {
-            status: 500,
-            body: {
-                ok: false,
-                error: { error: "internal_error", details: message },
-            },
-        }
+        logPlaylistsHandlerError("playlistTracksDELETE", error)
+        return { status: 500, body: internalErrorBody() }
     }
 }

--- a/src/botApi/handlers/playlists.ts
+++ b/src/botApi/handlers/playlists.ts
@@ -1,13 +1,18 @@
 import { getAuthenticatedSession } from "../../shared/api-auth.js"
 import { resolveDiscordUserSnowflake } from "../../shared/discord-user-id.js"
-import type { ApiResponse } from "../../types/index.js"
+import type {
+    ApiResponse,
+    PlaylistData as DomainPlaylistData,
+    PlaylistTrackData as DomainPlaylistTrackData,
+    PlaylistSummary as DomainPlaylistSummary,
+} from "../../types/index.js"
 import type {
     AddPlaylistTrackBody,
     AddTracksFromQueryResponse,
     PlaylistData,
     PlaylistListResponse,
     PlaylistTrackData,
-    SerializedPlaylistTrackData,
+    PlaylistSummary,
 } from "../../types/web.js"
 import {
     PlaylistDuplicateNameError,
@@ -23,6 +28,7 @@ import {
 } from "../../repositories/playlistRepository.js"
 import { getBotClient } from "../../lib/botClientRegistry.js"
 import {
+    isPlaylistSearchTransientFailure,
     pickPlayerForPlaylistSearch,
     searchTracksForPlaylist,
 } from "../../util/playlistQueue.js"
@@ -98,26 +104,49 @@ function internalErrorBody(): ApiResponse<never> {
     }
 }
 
-function serializePlaylistTracksForApi(
-    tracks: PlaylistTrackData[]
-): SerializedPlaylistTrackData[] {
-    return tracks.map((t) => ({
-        id: t.id,
-        title: t.title,
-        uri: t.uri,
-        author: t.author,
-        duration: t.duration,
-        thumbnailUrl: t.thumbnailUrl,
-        addedAt: t.addedAt.toISOString(),
-        position: t.position,
-    }))
+function serializePlaylistTrackForApi(track: DomainPlaylistTrackData): PlaylistTrackData {
+    return {
+        id: track.id,
+        title: track.title,
+        uri: track.uri,
+        author: track.author,
+        duration: track.duration,
+        thumbnailUrl: track.thumbnailUrl,
+        addedAt: track.addedAt.toISOString(),
+        position: track.position,
+    }
+}
+
+function serializePlaylistTracksForApi(tracks: DomainPlaylistTrackData[]): PlaylistTrackData[] {
+    return tracks.map(serializePlaylistTrackForApi)
+}
+
+function serializePlaylistForApi(playlist: DomainPlaylistData): PlaylistData {
+    return {
+        id: playlist.id,
+        name: playlist.name,
+        userId: playlist.userId,
+        createdAt: playlist.createdAt.toISOString(),
+        updatedAt: playlist.updatedAt.toISOString(),
+        tracks: serializePlaylistTracksForApi(playlist.tracks),
+    }
+}
+
+function serializePlaylistSummaryForApi(summary: DomainPlaylistSummary): PlaylistSummary {
+    return {
+        id: summary.id,
+        name: summary.name,
+        trackCount: summary.trackCount,
+        totalDuration: summary.totalDuration,
+        createdAt: summary.createdAt.toISOString(),
+    }
 }
 
 async function requireOwnedPlaylist(
     discordUserId: string,
     playlistId: number
 ): Promise<
-    | { ok: true; playlist: PlaylistData }
+    | { ok: true; playlist: DomainPlaylistData }
     | { ok: false; status: number; body: ApiResponse<never> }
 > {
     try {
@@ -187,7 +216,10 @@ export async function playlistsGET(
         const playlists = await getUserPlaylists(auth.discordUserId)
         return {
             status: 200,
-            body: { ok: true, data: { playlists } },
+            body: {
+                ok: true,
+                data: { playlists: playlists.map(serializePlaylistSummaryForApi) },
+            },
         }
     } catch (error: unknown) {
         logPlaylistsHandlerError("playlistsGET", error)
@@ -226,7 +258,7 @@ export async function playlistsPOST(
 
     try {
         const playlist = await createPlaylist(auth.discordUserId, name.trim())
-        return { status: 201, body: { ok: true, data: playlist } }
+        return { status: 201, body: { ok: true, data: serializePlaylistForApi(playlist) } }
     } catch (error: unknown) {
         if (error instanceof PlaylistDuplicateNameError) {
             return {
@@ -267,7 +299,7 @@ export async function playlistsDetailGET(
         return { status: owned.status, body: owned.body }
     }
 
-    return { status: 200, body: { ok: true, data: owned.playlist } }
+    return { status: 200, body: { ok: true, data: serializePlaylistForApi(owned.playlist) } }
 }
 
 export async function playlistsDELETE(
@@ -356,7 +388,7 @@ export async function playlistTracksPOST(
             thumbnailUrl: body.thumbnailUrl,
             addedAt: new Date(body.addedAt),
         })
-        return { status: 201, body: { ok: true, data: track } }
+        return { status: 201, body: { ok: true, data: serializePlaylistTrackForApi(track) } }
     } catch (error: unknown) {
         logPlaylistsHandlerError("playlistTracksPOST", error)
         return { status: 500, body: internalErrorBody() }
@@ -431,6 +463,15 @@ export async function playlistTracksFromQueryPOST(
     const requester = { id: auth.discordUserId, username: "web-user" }
     const found = await searchTracksForPlaylist(player, query, requester)
     if (found.ok === false) {
+        if (isPlaylistSearchTransientFailure(found.error)) {
+            return {
+                status: 503,
+                body: {
+                    ok: false,
+                    error: { error: "Search failed", details: found.error },
+                },
+            }
+        }
         return {
             status: 404,
             body: {
@@ -566,7 +607,7 @@ export async function playlistTrackMovePATCH(
                 },
             }
         }
-        return { status: 200, body: { ok: true, data: updated } }
+        return { status: 200, body: { ok: true, data: serializePlaylistForApi(updated) } }
     } catch (error: unknown) {
         if (error instanceof PlaylistTrackNotFoundError) {
             return {

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -24,6 +24,11 @@ export type SearchAndEnqueueSuccess = {
 
 export type SearchAndEnqueueResult = SearchAndEnqueueSuccess | SearchAndEnqueueFailure
 
+export type SearchAndEnqueueOptions = {
+    /** Connect the player to the requester's VC without searching or enqueueing. */
+    connectOnly?: boolean
+}
+
 function isMemberFetchNotFound(error: unknown): boolean {
     if (!error || typeof error !== "object") return false
     const maybe = error as {
@@ -49,7 +54,8 @@ export async function searchAndEnqueue(
     guildId: string,
     requesterId: string,
     query: string,
-    guard: SearchAndEnqueueGuard
+    guard: SearchAndEnqueueGuard,
+    options?: SearchAndEnqueueOptions
 ): Promise<SearchAndEnqueueResult> {
     const guild = client.guilds.cache.get(guildId)
     if (!guild) {
@@ -213,6 +219,10 @@ export async function searchAndEnqueue(
                 details: message,
             },
         }
+    }
+
+    if (options?.connectOnly) {
+        return { ok: true, player, playbackStarted: false }
     }
 
     const requesterName =

--- a/src/botApi/handlers/voiceContext.ts
+++ b/src/botApi/handlers/voiceContext.ts
@@ -1,0 +1,122 @@
+import { getAuthenticatedSession } from "../../shared/api-auth.js"
+import { resolveDiscordUserSnowflake } from "../../shared/discord-user-id.js"
+import { isPlayer, summarizeVoiceForWeb } from "../../shared/player-state.js"
+import { getBotClient, tryGetBotClient } from "../../lib/botClientRegistry.js"
+import type { ApiResponse } from "../../types/index.js"
+import type { VoiceContextResponse } from "../../types/web.js"
+
+function discordGuildIconUrl(guildId: string, icon: string | null | undefined): string | null {
+    if (!icon) return null
+    return `https://cdn.discordapp.com/icons/${guildId}/${icon}.png?size=128`
+}
+
+function isActivePlayerSession(player: unknown): boolean {
+    if (!isPlayer(player)) return false
+    if (player.playing || player.paused) return true
+    if (player.queue?.current) return true
+    return (player.queue?.tracks?.length ?? 0) > 0
+}
+
+/** Guild where the viewer shares a VC with the bot and the bot has an active player session. */
+export async function voiceContextGET(
+    headers: Headers
+): Promise<{ status: number; body: ApiResponse<VoiceContextResponse> }> {
+    const sessionResult = await getAuthenticatedSession(headers)
+    if (sessionResult.ok === false) {
+        return {
+            status: sessionResult.status,
+            body: {
+                ok: false,
+                error: { error: sessionResult.error, details: sessionResult.details },
+            },
+        }
+    }
+
+    const discordUserId = await resolveDiscordUserSnowflake(
+        sessionResult.session.user.id,
+        headers
+    )
+    if (!discordUserId) {
+        return {
+            status: 403,
+            body: {
+                ok: false,
+                error: {
+                    error: "Discord account required",
+                    details: "Could not resolve your Discord user id.",
+                },
+            },
+        }
+    }
+
+    const client = tryGetBotClient()
+    if (!client) {
+        return {
+            status: 503,
+            body: {
+                ok: false,
+                error: {
+                    error: "Bot is starting up",
+                    details: "The Discord bot is not connected yet.",
+                },
+            },
+        }
+    }
+
+    type Candidate = {
+        guildId: string
+        guildName: string
+        guildIconUrl: string | null
+        status: "playing" | "paused" | "idle"
+        currentTrackTitle: string | null
+        priority: number
+    }
+
+    const candidates: Candidate[] = []
+    const bot = getBotClient()
+
+    for (const player of bot.lavalink.players.values()) {
+        const guildId = player.guildId
+        const voice = summarizeVoiceForWeb(guildId, discordUserId, player, client)
+        if (!voice.inVoiceWithBot || !isActivePlayerSession(player)) {
+            continue
+        }
+
+        const guild = client.guilds.cache.get(guildId)
+        const status = player.playing ? "playing" : player.paused ? "paused" : "idle"
+        const priority = status === "playing" ? 0 : status === "paused" ? 1 : 2
+        const current = player.queue?.current ?? null
+        const currentTrackTitle =
+            current && typeof current.info?.title === "string" ? current.info.title : null
+
+        candidates.push({
+            guildId,
+            guildName: guild?.name ?? "Server",
+            guildIconUrl: discordGuildIconUrl(guildId, guild?.icon ?? null),
+            status,
+            currentTrackTitle,
+            priority,
+        })
+    }
+
+    candidates.sort((a, b) => a.priority - b.priority)
+    const best = candidates[0] ?? null
+
+    return {
+        status: 200,
+        body: {
+            ok: true,
+            data: {
+                activeGuild: best
+                    ? {
+                          guildId: best.guildId,
+                          guildName: best.guildName,
+                          guildIconUrl: best.guildIconUrl,
+                          status: best.status,
+                          currentTrackTitle: best.currentTrackTitle,
+                      }
+                    : null,
+            },
+        },
+    }
+}

--- a/src/commands/music/Playlist.ts
+++ b/src/commands/music/Playlist.ts
@@ -116,6 +116,7 @@ export default {
         const userId = interaction.user.id
         const subcommand = interaction.options.getSubcommand()
 
+        try {
         if (subcommand === "create") {
             const name = interaction.options.getString("name", true)
             const existing = await getPlaylist(userId, name)
@@ -240,10 +241,17 @@ export default {
                 })
             }
             const info = current.info
+            const uri = typeof info.uri === "string" ? info.uri.trim() : ""
+            if (!uri) {
+                return interaction.reply({
+                    content: "The current track has no URL and cannot be saved to a playlist.",
+                    ephemeral: true,
+                })
+            }
             await addTracksToPlaylist(playlist.id, [
                 {
                     title: info.title ?? "Unknown",
-                    uri: info.uri ?? "",
+                    uri,
                     author: info.author ?? "Unknown",
                     duration: info.duration ?? 0,
                     thumbnailUrl: thumbnailFromLavalinkTrack(current),
@@ -251,7 +259,7 @@ export default {
                 },
             ])
             return interaction.reply({
-                content: `Added **[${info.title}](${info.uri})** to **${name}**.`,
+                content: `Added **[${info.title}](${uri})** to **${name}**.`,
                 ephemeral: true,
             })
         }
@@ -352,6 +360,14 @@ export default {
         }
 
         return interaction.reply({ content: "Unknown subcommand.", ephemeral: true })
+        } catch (err: unknown) {
+            console.error("[Playlist command] execute failed", err)
+            const content = "An error occurred while processing your request."
+            if (interaction.deferred || interaction.replied) {
+                return interaction.editReply({ content })
+            }
+            return interaction.reply({ content, ephemeral: true })
+        }
     },
 }
 

--- a/src/commands/music/Playlist.ts
+++ b/src/commands/music/Playlist.ts
@@ -1,0 +1,478 @@
+import {
+    SlashCommandBuilder,
+    EmbedBuilder,
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    ComponentType,
+    type ButtonInteraction,
+    type ChatInputCommandInteraction,
+} from "discord.js"
+import type BotClient from "../../lib/BotClient.js"
+import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import { formatDuration } from "../../util/formatDuration.js"
+import {
+    addTracksToPlaylist,
+    createPlaylist,
+    deletePlaylist,
+    getPlaylist,
+    getUserPlaylists,
+    removeTrackFromPlaylist,
+} from "../../repositories/playlistRepository.js"
+import {
+    enqueueResolvedPlaylistTracks,
+    pickPlayerForPlaylistSearch,
+    resolveStoredPlaylistTracks,
+    searchTracksForPlaylist,
+} from "../../util/playlistQueue.js"
+import { thumbnailFromLavalinkTrack } from "../../util/trackThumbnail.js"
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName("playlist")
+        .setDescription("Manage your personal playlists")
+        .addSubcommand((sub) =>
+            sub
+                .setName("create")
+                .setDescription("Create a new playlist")
+                .addStringOption((opt) =>
+                    opt.setName("name").setDescription("Playlist name").setRequired(true)
+                )
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName("delete")
+                .setDescription("Delete a playlist")
+                .addStringOption((opt) =>
+                    opt.setName("name").setDescription("Playlist name").setRequired(true)
+                )
+        )
+        .addSubcommand((sub) => sub.setName("list").setDescription("List your playlists"))
+        .addSubcommand((sub) =>
+            sub
+                .setName("view")
+                .setDescription("View tracks in a playlist")
+                .addStringOption((opt) =>
+                    opt.setName("name").setDescription("Playlist name").setRequired(true)
+                )
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName("add")
+                .setDescription("Add a track to a playlist")
+                .addStringOption((opt) =>
+                    opt.setName("name").setDescription("Playlist name").setRequired(true)
+                )
+                .addStringOption((opt) =>
+                    opt
+                        .setName("query")
+                        .setDescription("Song to search for (defaults to now playing)")
+                        .setRequired(false)
+                )
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName("remove")
+                .setDescription("Remove a track from a playlist")
+                .addStringOption((opt) =>
+                    opt.setName("name").setDescription("Playlist name").setRequired(true)
+                )
+                .addIntegerOption((opt) =>
+                    opt
+                        .setName("index")
+                        .setDescription("Track index (1-based)")
+                        .setRequired(true)
+                        .setMinValue(1)
+                )
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName("play")
+                .setDescription("Queue all tracks from a playlist")
+                .addStringOption((opt) =>
+                    opt.setName("name").setDescription("Playlist name").setRequired(true)
+                )
+                .addBooleanOption((opt) =>
+                    opt.setName("shuffle").setDescription("Shuffle before queuing").setRequired(false)
+                )
+        ),
+
+    async execute(interaction: ChatInputCommandInteraction, client: BotClient): Promise<unknown> {
+        const guild = interaction.guild
+        if (!guild) {
+            return interaction.reply({
+                content: "Use this command in a server.",
+                ephemeral: true,
+            })
+        }
+        const member = guildMemberFromInteraction(interaction)
+        if (!member) {
+            return interaction.reply({
+                content: "Could not resolve your member profile. Try again.",
+                ephemeral: true,
+            })
+        }
+
+        const userId = interaction.user.id
+        const subcommand = interaction.options.getSubcommand()
+
+        if (subcommand === "create") {
+            const name = interaction.options.getString("name", true)
+            const existing = await getPlaylist(userId, name)
+            if (existing) {
+                return interaction.reply({
+                    content: `You already have a playlist named **${name}**.`,
+                    ephemeral: true,
+                })
+            }
+            await createPlaylist(userId, name)
+            return interaction.reply({
+                content: `Created playlist **${name}**.`,
+                ephemeral: true,
+            })
+        }
+
+        if (subcommand === "delete") {
+            const name = interaction.options.getString("name", true)
+            const existing = await getPlaylist(userId, name)
+            if (!existing) {
+                return interaction.reply({
+                    content: `No playlist named **${name}** found.`,
+                    ephemeral: true,
+                })
+            }
+            await deletePlaylist(userId, name)
+            return interaction.reply({
+                content: `Deleted playlist **${name}**.`,
+                ephemeral: true,
+            })
+        }
+
+        if (subcommand === "list") {
+            const playlists = await getUserPlaylists(userId)
+            if (playlists.length === 0) {
+                return interaction.reply({
+                    content:
+                        "You don't have any playlists yet. Use `/playlist create` to make one!",
+                    ephemeral: true,
+                })
+            }
+            const embed = new EmbedBuilder()
+                .setColor(0x0099ff)
+                .setTitle("Your Playlists")
+                .setDescription(
+                    playlists
+                        .map(
+                            (p) =>
+                                `**${p.name}** — ${p.trackCount} track${p.trackCount === 1 ? "" : "s"}`
+                        )
+                        .join("\n")
+                )
+                .setTimestamp()
+            return interaction.reply({ embeds: [embed], ephemeral: true })
+        }
+
+        if (subcommand === "view") {
+            const name = interaction.options.getString("name", true)
+            const playlist = await getPlaylist(userId, name)
+            if (!playlist) {
+                return interaction.reply({
+                    content: `No playlist named **${name}** found.`,
+                    ephemeral: true,
+                })
+            }
+            return showPaginatedPlaylistView(interaction, client, playlist.name, playlist.tracks)
+        }
+
+        if (subcommand === "add") {
+            const name = interaction.options.getString("name", true)
+            const query = interaction.options.getString("query")
+            const playlist = await getPlaylist(userId, name)
+            if (!playlist) {
+                return interaction.reply({
+                    content: `No playlist named **${name}** found.`,
+                    ephemeral: true,
+                })
+            }
+
+            if (query) {
+                await interaction.deferReply({ ephemeral: true })
+                const player = pickPlayerForPlaylistSearch(client.lavalink, guild.id)
+                if (!player) {
+                    return interaction.editReply({
+                        content:
+                            "The bot is not in a voice channel anywhere. Join voice in a server with the bot, or try again later.",
+                    })
+                }
+                const found = await searchTracksForPlaylist(player, query, interaction.user)
+                if (found.ok === false) {
+                    return interaction.editReply({ content: found.error })
+                }
+                const addedAt = new Date()
+                const added = await addTracksToPlaylist(
+                    playlist.id,
+                    found.tracks.map((t) => ({
+                        title: t.title,
+                        uri: t.uri,
+                        author: t.author,
+                        duration: t.duration,
+                        thumbnailUrl: t.thumbnailUrl,
+                        addedAt,
+                    }))
+                )
+                if (added.length === 1) {
+                    const t = added[0]!
+                    return interaction.editReply({
+                        content: `Added **[${t.title}](${t.uri})** to **${name}**.`,
+                    })
+                }
+                return interaction.editReply({
+                    content: `Added **${added.length}** tracks to **${name}**.`,
+                })
+            }
+
+            const player = client.lavalink.players.get(guild.id)
+            const current = player?.queue.current
+            if (!current) {
+                return interaction.reply({
+                    content: "Nothing is playing. Provide a `query` or start playback first.",
+                    ephemeral: true,
+                })
+            }
+            const info = current.info
+            await addTracksToPlaylist(playlist.id, [
+                {
+                    title: info.title ?? "Unknown",
+                    uri: info.uri ?? "",
+                    author: info.author ?? "Unknown",
+                    duration: info.duration ?? 0,
+                    thumbnailUrl: thumbnailFromLavalinkTrack(current),
+                    addedAt: new Date(),
+                },
+            ])
+            return interaction.reply({
+                content: `Added **[${info.title}](${info.uri})** to **${name}**.`,
+                ephemeral: true,
+            })
+        }
+
+        if (subcommand === "remove") {
+            const name = interaction.options.getString("name", true)
+            const index = interaction.options.getInteger("index", true)
+            const playlist = await getPlaylist(userId, name)
+            if (!playlist) {
+                return interaction.reply({
+                    content: `No playlist named **${name}** found.`,
+                    ephemeral: true,
+                })
+            }
+            if (index < 1 || index > playlist.tracks.length) {
+                return interaction.reply({
+                    content: `Invalid index. Choose between 1 and ${playlist.tracks.length}.`,
+                    ephemeral: true,
+                })
+            }
+            const track = playlist.tracks[index - 1]!
+            await removeTrackFromPlaylist(playlist.id, track.position)
+            return interaction.reply({
+                content: `Removed **${track.title}** from **${name}**.`,
+                ephemeral: true,
+            })
+        }
+
+        if (subcommand === "play") {
+            const name = interaction.options.getString("name", true)
+            const shuffle = interaction.options.getBoolean("shuffle") ?? false
+            const playlist = await getPlaylist(userId, name)
+            if (!playlist) {
+                return interaction.reply({
+                    content: `No playlist named **${name}** found.`,
+                    ephemeral: true,
+                })
+            }
+            if (playlist.tracks.length === 0) {
+                return interaction.reply({
+                    content: `**${name}** has no tracks.`,
+                    ephemeral: true,
+                })
+            }
+
+            const voiceChannel = member.voice.channel
+            if (!voiceChannel) {
+                return interaction.reply({
+                    content: "Join a voice channel first!",
+                    ephemeral: true,
+                })
+            }
+
+            let player = client.lavalink.getPlayer(guild.id)
+            if (!player) {
+                player = await client.lavalink.createPlayer({
+                    guildId: guild.id,
+                    voiceChannelId: voiceChannel.id,
+                    textChannelId: interaction.channelId,
+                    selfDeaf: true,
+                    volume: 100,
+                })
+            }
+
+            if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+                return interaction.reply({
+                    content: "You need to be in the same voice channel as the bot!",
+                    ephemeral: true,
+                })
+            }
+
+            await interaction.deferReply()
+
+            const { resolved, failed } = await resolveStoredPlaylistTracks(
+                player,
+                playlist.tracks,
+                interaction.user
+            )
+
+            if (resolved.length === 0) {
+                return interaction.editReply({
+                    content: `Could not resolve any tracks from **${name}**.`,
+                })
+            }
+
+            const enqueue = await enqueueResolvedPlaylistTracks(
+                player,
+                resolved,
+                interaction.user.id,
+                shuffle
+            )
+
+            const failPart =
+                failed > 0 ? ` ${failed} track${failed === 1 ? "" : "s"} could not be resolved.` : ""
+            return interaction.editReply({
+                content: `Queued ${enqueue.queued} track${enqueue.queued === 1 ? "" : "s"} from **${name}**.${failPart}`,
+            })
+        }
+
+        return interaction.reply({ content: "Unknown subcommand.", ephemeral: true })
+    },
+}
+
+async function showPaginatedPlaylistView(
+    interaction: ChatInputCommandInteraction,
+    client: BotClient,
+    playlistName: string,
+    tracks: Array<{
+        title: string
+        uri: string
+        duration: number
+        position: number
+    }>
+): Promise<unknown> {
+    const itemsPerPage = 10
+    const totalPages = Math.ceil(tracks.length / itemsPerPage) || 1
+    let currentPage = 1
+
+    const totalDurationMs = tracks.reduce((acc, t) => acc + t.duration, 0)
+    const totalDuration = formatDuration(totalDurationMs)
+
+    const generateEmbed = (page: number) => {
+        const start = (page - 1) * itemsPerPage
+        const end = start + itemsPerPage
+        const pageTracks = tracks.slice(start, end)
+
+        const embed = new EmbedBuilder()
+            .setColor(0x0099ff)
+            .setTitle(`Playlist: ${playlistName}`)
+            .setDescription(`**Total Duration:** \`${totalDuration}\``)
+            .setTimestamp()
+            .setFooter({ text: `Page ${page}/${totalPages}` })
+
+        if (pageTracks.length > 0) {
+            let fieldValue = pageTracks
+                .map(
+                    (track, i) =>
+                        `**${start + i + 1}.** [${track.title}](${track.uri}) - \`${formatDuration(track.duration)}\``
+                )
+                .join("\n")
+            if (fieldValue.length > 1024) {
+                fieldValue = fieldValue.substring(0, 1021) + "..."
+            }
+            embed.addFields([{ name: "Tracks", value: fieldValue }])
+        } else {
+            embed.addFields([{ name: "Tracks", value: "_This playlist is empty._" }])
+        }
+
+        return embed
+    }
+
+    const generateButtons = (page: number) =>
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+                .setCustomId("prev_page")
+                .setLabel("Previous")
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(page === 1),
+            new ButtonBuilder()
+                .setCustomId("next_page")
+                .setLabel("Next")
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(page === totalPages)
+        )
+
+    const message = await interaction.reply({
+        embeds: [generateEmbed(currentPage)],
+        components: totalPages > 1 ? [generateButtons(currentPage)] : [],
+        fetchReply: true,
+        ephemeral: true,
+    })
+
+    if (totalPages <= 1) {
+        return message
+    }
+
+    const collector = message.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        time: 60000,
+        filter: (i: ButtonInteraction) => i.user.id === interaction.user.id,
+    })
+
+    collector.on("collect", async (i) => {
+        try {
+            await i.deferUpdate()
+            if (i.customId === "prev_page") currentPage--
+            else if (i.customId === "next_page") currentPage++
+            await interaction.editReply({
+                embeds: [generateEmbed(currentPage)],
+                components: [generateButtons(currentPage)],
+            })
+        } catch (error: unknown) {
+            client.error("Playlist view: pagination failed:", error)
+        }
+    })
+
+    collector.on("end", async (_collected, reason) => {
+        if (reason === "time") {
+            try {
+                await interaction.editReply({
+                    embeds: [generateEmbed(currentPage)],
+                    components: [
+                        new ActionRowBuilder<ButtonBuilder>().addComponents(
+                            new ButtonBuilder()
+                                .setCustomId("prev_page")
+                                .setLabel("Previous")
+                                .setStyle(ButtonStyle.Primary)
+                                .setDisabled(true),
+                            new ButtonBuilder()
+                                .setCustomId("next_page")
+                                .setLabel("Next")
+                                .setStyle(ButtonStyle.Primary)
+                                .setDisabled(true)
+                        ),
+                    ],
+                })
+            } catch (error: unknown) {
+                client.error("Playlist view: failed to disable buttons:", error)
+            }
+        }
+    })
+
+    return message
+}

--- a/src/commands/music/Playlist.ts
+++ b/src/commands/music/Playlist.ts
@@ -291,25 +291,26 @@ export default {
         if (subcommand === "play") {
             const name = interaction.options.getString("name", true)
             const shuffle = interaction.options.getBoolean("shuffle") ?? false
-            const playlist = await getPlaylist(userId, name)
-            if (!playlist) {
-                return interaction.reply({
-                    content: `No playlist named **${name}** found.`,
-                    ephemeral: true,
-                })
-            }
-            if (playlist.tracks.length === 0) {
-                return interaction.reply({
-                    content: `**${name}** has no tracks.`,
-                    ephemeral: true,
-                })
-            }
 
             const voiceChannel = member.voice.channel
             if (!voiceChannel) {
                 return interaction.reply({
                     content: "Join a voice channel first!",
                     ephemeral: true,
+                })
+            }
+
+            await interaction.deferReply({ ephemeral: true })
+
+            const playlist = await getPlaylist(userId, name)
+            if (!playlist) {
+                return interaction.editReply({
+                    content: `No playlist named **${name}** found.`,
+                })
+            }
+            if (playlist.tracks.length === 0) {
+                return interaction.editReply({
+                    content: `**${name}** has no tracks.`,
                 })
             }
 
@@ -325,13 +326,10 @@ export default {
             }
 
             if (player.connected && player.voiceChannelId !== voiceChannel.id) {
-                return interaction.reply({
+                return interaction.editReply({
                     content: "You need to be in the same voice channel as the bot!",
-                    ephemeral: true,
                 })
             }
-
-            await interaction.deferReply()
 
             const { resolved, failed } = await resolveStoredPlaylistTracks(
                 player,

--- a/src/repositories/playlistRepository.ts
+++ b/src/repositories/playlistRepository.ts
@@ -269,13 +269,16 @@ export async function movePlaylistTrack(
         }
         reordered.splice(toPosition - 1, 0, moved)
         for (let i = 0; i < reordered.length; i++) {
-            const row = reordered[i]!
-            if (row.position !== i + 1) {
-                await tx.playlistTrack.update({
-                    where: { id: row.id },
-                    data: { position: i + 1 },
-                })
-            }
+            await tx.playlistTrack.update({
+                where: { id: reordered[i]!.id },
+                data: { position: -(i + 1) },
+            })
+        }
+        for (let i = 0; i < reordered.length; i++) {
+            await tx.playlistTrack.update({
+                where: { id: reordered[i]!.id },
+                data: { position: i + 1 },
+            })
         }
         await tx.playlist.update({
             where: { id: playlistId },

--- a/src/repositories/playlistRepository.ts
+++ b/src/repositories/playlistRepository.ts
@@ -1,0 +1,287 @@
+import { Prisma } from "@prisma/client"
+import { getPrismaClient } from "../lib/database.js"
+import type {
+    PlaylistData,
+    PlaylistSummary,
+    PlaylistTrackData,
+    PlaylistTrackInput,
+} from "../types/index.js"
+
+export class PlaylistDuplicateNameError extends Error {
+    constructor(name: string) {
+        super(`A playlist named "${name}" already exists.`)
+        this.name = "PlaylistDuplicateNameError"
+    }
+}
+
+export class PlaylistNotFoundError extends Error {
+    constructor() {
+        super("Playlist not found.")
+        this.name = "PlaylistNotFoundError"
+    }
+}
+
+export class PlaylistTrackNotFoundError extends Error {
+    constructor(position: number) {
+        super(`No track at position ${position}.`)
+        this.name = "PlaylistTrackNotFoundError"
+    }
+}
+
+function toPlaylistTrackData(row: {
+    id: number
+    title: string
+    uri: string
+    author: string
+    duration: number
+    thumbnailUrl: string | null
+    addedAt: Date
+    position: number
+}): PlaylistTrackData {
+    return {
+        id: row.id,
+        title: row.title,
+        uri: row.uri,
+        author: row.author,
+        duration: row.duration,
+        thumbnailUrl: row.thumbnailUrl,
+        addedAt: row.addedAt,
+        position: row.position,
+    }
+}
+
+function toPlaylistData(row: {
+    id: number
+    name: string
+    userId: string
+    createdAt: Date
+    updatedAt: Date
+    tracks: Array<{
+        id: number
+        title: string
+        uri: string
+        author: string
+        duration: number
+        thumbnailUrl: string | null
+        addedAt: Date
+        position: number
+    }>
+}): PlaylistData {
+    return {
+        id: row.id,
+        name: row.name,
+        userId: row.userId,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        tracks: row.tracks.map(toPlaylistTrackData),
+    }
+}
+
+function toPlaylistSummary(row: {
+    id: number
+    name: string
+    createdAt: Date
+    _count: { tracks: number }
+    tracks: Array<{ duration: number }>
+}): PlaylistSummary {
+    const totalDuration = row.tracks.reduce((acc, t) => acc + t.duration, 0)
+    return {
+        id: row.id,
+        name: row.name,
+        trackCount: row._count.tracks,
+        totalDuration,
+        createdAt: row.createdAt,
+    }
+}
+
+const playlistWithTracksInclude = {
+    tracks: { orderBy: { position: "asc" as const } },
+} as const
+
+/** Returns all playlists for a user with track counts and total duration. */
+export async function getUserPlaylists(userId: string): Promise<PlaylistSummary[]> {
+    const prisma = getPrismaClient()
+    const rows = await prisma.playlist.findMany({
+        where: { userId },
+        orderBy: { createdAt: "asc" },
+        include: {
+            _count: { select: { tracks: true } },
+            tracks: { select: { duration: true } },
+        },
+    })
+    return rows.map(toPlaylistSummary)
+}
+
+/** Returns a single playlist by user and name, with tracks ordered by position. */
+export async function getPlaylist(userId: string, name: string): Promise<PlaylistData | null> {
+    const prisma = getPrismaClient()
+    const row = await prisma.playlist.findUnique({
+        where: { userId_name: { userId, name } },
+        include: playlistWithTracksInclude,
+    })
+    return row ? toPlaylistData(row) : null
+}
+
+/** Returns a playlist by id with tracks ordered by position. */
+export async function getPlaylistById(playlistId: number): Promise<PlaylistData | null> {
+    const prisma = getPrismaClient()
+    const row = await prisma.playlist.findUnique({
+        where: { id: playlistId },
+        include: playlistWithTracksInclude,
+    })
+    return row ? toPlaylistData(row) : null
+}
+
+/** Creates an empty playlist for the user. */
+export async function createPlaylist(userId: string, name: string): Promise<PlaylistData> {
+    const prisma = getPrismaClient()
+    try {
+        const row = await prisma.playlist.create({
+            data: { userId, name },
+            include: playlistWithTracksInclude,
+        })
+        return toPlaylistData(row)
+    } catch (err: unknown) {
+        if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+            throw new PlaylistDuplicateNameError(name)
+        }
+        throw err
+    }
+}
+
+/** Deletes a playlist and cascades to its tracks. */
+export async function deletePlaylist(userId: string, name: string): Promise<void> {
+    const prisma = getPrismaClient()
+    const result = await prisma.playlist.deleteMany({
+        where: { userId, name },
+    })
+    if (result.count === 0) {
+        throw new PlaylistNotFoundError()
+    }
+}
+
+/** Returns tracks for a playlist ordered by position. */
+export async function getPlaylistTracks(playlistId: number): Promise<PlaylistTrackData[]> {
+    const prisma = getPrismaClient()
+    const rows = await prisma.playlistTrack.findMany({
+        where: { playlistId },
+        orderBy: { position: "asc" },
+    })
+    return rows.map(toPlaylistTrackData)
+}
+
+/** Appends a track with the next available position. */
+export async function addTrackToPlaylist(
+    playlistId: number,
+    trackData: PlaylistTrackInput
+): Promise<PlaylistTrackData> {
+    const rows = await addTracksToPlaylist(playlistId, [trackData])
+    return rows[0]!
+}
+
+/** Appends multiple tracks in order with consecutive positions. */
+export async function addTracksToPlaylist(
+    playlistId: number,
+    tracksData: PlaylistTrackInput[]
+): Promise<PlaylistTrackData[]> {
+    if (tracksData.length === 0) return []
+    const prisma = getPrismaClient()
+    return prisma.$transaction(async (tx) => {
+        const agg = await tx.playlistTrack.aggregate({
+            where: { playlistId },
+            _max: { position: true },
+        })
+        let nextPosition = (agg._max.position ?? 0) + 1
+        const created: PlaylistTrackData[] = []
+        for (const trackData of tracksData) {
+            const row = await tx.playlistTrack.create({
+                data: {
+                    playlistId,
+                    title: trackData.title,
+                    uri: trackData.uri,
+                    author: trackData.author,
+                    duration: trackData.duration,
+                    thumbnailUrl: trackData.thumbnailUrl ?? null,
+                    addedAt: trackData.addedAt,
+                    position: nextPosition,
+                },
+            })
+            nextPosition += 1
+            created.push(toPlaylistTrackData(row))
+        }
+        await tx.playlist.update({
+            where: { id: playlistId },
+            data: { updatedAt: new Date() },
+        })
+        return created
+    })
+}
+
+/** Moves a track from one 1-based position to another and renumbers the playlist. */
+export async function movePlaylistTrack(
+    playlistId: number,
+    fromPosition: number,
+    toPosition: number
+): Promise<void> {
+    if (fromPosition === toPosition) return
+    const prisma = getPrismaClient()
+    await prisma.$transaction(async (tx) => {
+        const rows = await tx.playlistTrack.findMany({
+            where: { playlistId },
+            orderBy: { position: "asc" },
+        })
+        if (rows.length === 0) {
+            throw new PlaylistTrackNotFoundError(fromPosition)
+        }
+        const fromIdx = rows.findIndex((r) => r.position === fromPosition)
+        if (fromIdx === -1) {
+            throw new PlaylistTrackNotFoundError(fromPosition)
+        }
+        if (toPosition < 1 || toPosition > rows.length) {
+            throw new PlaylistTrackNotFoundError(toPosition)
+        }
+        const reordered = [...rows]
+        const [moved] = reordered.splice(fromIdx, 1)
+        if (!moved) {
+            throw new PlaylistTrackNotFoundError(fromPosition)
+        }
+        reordered.splice(toPosition - 1, 0, moved)
+        for (let i = 0; i < reordered.length; i++) {
+            const row = reordered[i]!
+            if (row.position !== i + 1) {
+                await tx.playlistTrack.update({
+                    where: { id: row.id },
+                    data: { position: i + 1 },
+                })
+            }
+        }
+        await tx.playlist.update({
+            where: { id: playlistId },
+            data: { updatedAt: new Date() },
+        })
+    })
+}
+
+/** Removes the track at the given position and reorders remaining tracks. */
+export async function removeTrackFromPlaylist(
+    playlistId: number,
+    position: number
+): Promise<void> {
+    const prisma = getPrismaClient()
+    await prisma.$transaction(async (tx) => {
+        const deleted = await tx.playlistTrack.deleteMany({
+            where: { playlistId, position },
+        })
+        if (deleted.count === 0) {
+            throw new PlaylistTrackNotFoundError(position)
+        }
+        await tx.playlistTrack.updateMany({
+            where: { playlistId, position: { gt: position } },
+            data: { position: { decrement: 1 } },
+        })
+        await tx.playlist.update({
+            where: { id: playlistId },
+            data: { updatedAt: new Date() },
+        })
+    })
+}

--- a/src/repositories/playlistRepository.ts
+++ b/src/repositories/playlistRepository.ts
@@ -179,12 +179,14 @@ export async function addTrackToPlaylist(
     return rows[0]!
 }
 
-/** Appends multiple tracks in order with consecutive positions. */
-export async function addTracksToPlaylist(
+function isUniqueConstraintError(error: unknown): boolean {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002"
+}
+
+async function appendTracksInTransaction(
     playlistId: number,
     tracksData: PlaylistTrackInput[]
 ): Promise<PlaylistTrackData[]> {
-    if (tracksData.length === 0) return []
     const prisma = getPrismaClient()
     return prisma.$transaction(async (tx) => {
         const agg = await tx.playlistTrack.aggregate({
@@ -215,6 +217,26 @@ export async function addTracksToPlaylist(
         })
         return created
     })
+}
+
+/** Appends multiple tracks in order with consecutive positions. */
+export async function addTracksToPlaylist(
+    playlistId: number,
+    tracksData: PlaylistTrackInput[]
+): Promise<PlaylistTrackData[]> {
+    if (tracksData.length === 0) return []
+    const maxAttempts = 4
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+            return await appendTracksInTransaction(playlistId, tracksData)
+        } catch (error: unknown) {
+            if (!isUniqueConstraintError(error) || attempt === maxAttempts - 1) {
+                throw error
+            }
+            await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)))
+        }
+    }
+    return []
 }
 
 /** Moves a track from one 1-based position to another and renumbers the playlist. */

--- a/src/shared/player-state.ts
+++ b/src/shared/player-state.ts
@@ -438,6 +438,54 @@ export function resolveInVoiceWithBot(guildId: string, userId: string, player?: 
     return summarizeVoiceForWeb(guildId, userId, player).inVoiceWithBot
 }
 
+/** Compact player row for `GET /api/guilds` (no requester name resolution). */
+export function snapshotGuildListPlayer(
+    guildId: string,
+    discordUserId: string | undefined,
+    lavalinkPlayer: unknown,
+    clientArg?: VoiceSummaryClient | null
+): {
+    status: "playing" | "paused" | "idle"
+    botInVoiceChannel: boolean
+    inVoiceWithBot: boolean
+    currentTrackTitle: string | null
+    currentTrackAuthor: string | null
+    queueCount: number
+} | null {
+    const p = isPlayer(lavalinkPlayer) ? lavalinkPlayer : null
+    const voice = summarizeVoiceForWeb(
+        guildId,
+        discordUserId ?? "",
+        p,
+        clientArg
+    )
+    if (!p && !voice.botInVoiceChannel) {
+        return null
+    }
+
+    const status: "playing" | "paused" | "idle" = p
+        ? p.playing
+            ? "playing"
+            : p.paused
+              ? "paused"
+              : "idle"
+        : "idle"
+    const current = p?.queue?.current ?? null
+    const currentTrackTitle =
+        current && typeof current.info?.title === "string" ? current.info.title : null
+    const currentTrackAuthor =
+        current && typeof current.info?.author === "string" ? current.info.author : null
+
+    return {
+        status,
+        botInVoiceChannel: voice.botInVoiceChannel,
+        inVoiceWithBot: discordUserId ? voice.inVoiceWithBot : false,
+        currentTrackTitle,
+        currentTrackAuthor,
+        queueCount: p?.queue?.tracks?.length ?? 0,
+    }
+}
+
 export async function toPlayerStateResponse(
     guildId: string,
     userId: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -180,6 +180,47 @@ export interface ApiFailurePayload {
 
 export type ApiResponse<T> = ApiSuccessPayload<T> | ApiFailurePayload
 
+/** Single track row in a user playlist. */
+export interface PlaylistTrackData {
+    id: number
+    title: string
+    uri: string
+    author: string
+    duration: number
+    thumbnailUrl: string | null
+    addedAt: Date
+    position: number
+}
+
+/** Full user playlist with ordered tracks. */
+export interface PlaylistData {
+    id: number
+    name: string
+    userId: string
+    createdAt: Date
+    updatedAt: Date
+    tracks: PlaylistTrackData[]
+}
+
+/** Playlist list entry for list views. */
+export interface PlaylistSummary {
+    id: number
+    name: string
+    trackCount: number
+    totalDuration: number
+    createdAt: Date
+}
+
+/** Input for adding a track (no id/position yet). */
+export interface PlaylistTrackInput {
+    title: string
+    uri: string
+    author: string
+    duration: number
+    thumbnailUrl?: string | null
+    addedAt: Date
+}
+
 /** Tracks a user who left voice while RRQ is active and has queued tracks. */
 export interface DisconnectedRRQUser {
     userId: string

--- a/src/types/web.ts
+++ b/src/types/web.ts
@@ -13,16 +13,41 @@ export interface StatusPayload {
     botApi: { ok: boolean; message?: string }
 }
 
+/** Active bot player snapshot for a guild on the dashboard server list. */
+export interface GuildListPlayerSummary {
+    status: "playing" | "paused" | "idle"
+    botInVoiceChannel: boolean
+    inVoiceWithBot: boolean
+    currentTrackTitle: string | null
+    currentTrackAuthor: string | null
+    queueCount: number
+}
+
 export interface GuildListItem {
     id: string
     name: string
     iconUrl: string | null
     memberCount: number | null
+    /** Present when the bot has a player session or is connected to voice in this guild. */
+    player: GuildListPlayerSummary | null
 }
 
 export interface GuildListResponse {
     guilds: GuildListItem[]
     botInviteUrl?: string
+}
+
+/** Guild where the signed-in user shares a VC with an active bot player session. */
+export interface ActivePlayerGuildContext {
+    guildId: string
+    guildName: string
+    guildIconUrl: string | null
+    status: "playing" | "paused" | "idle"
+    currentTrackTitle: string | null
+}
+
+export interface VoiceContextResponse {
+    activeGuild: ActivePlayerGuildContext | null
 }
 
 /**
@@ -202,4 +227,49 @@ export type AdminDbCleanupTarget = "sessions" | "verifications" | "all"
 export interface AdminDbCleanupResponse {
     dryRun: boolean
     deleted: { sessions?: number; verifications?: number }
+}
+
+export type {
+    PlaylistData,
+    PlaylistSummary,
+    PlaylistTrackData,
+} from "./index.js"
+
+import type { PlaylistSummary, PlaylistTrackData } from "./index.js"
+
+export interface PlaylistListResponse {
+    playlists: PlaylistSummary[]
+}
+
+export interface AddPlaylistTrackBody {
+    title: string
+    uri: string
+    author: string
+    duration: number
+    thumbnailUrl?: string | null
+    addedAt: string
+}
+
+export interface AddPlaylistTrackFromQueryBody {
+    query: string
+    /** Prefer Lavalink search via this guild's player when set. */
+    guildId?: string
+}
+
+export interface AddTracksFromQueryResponse {
+    added: number
+    tracks: PlaylistTrackData[]
+}
+
+export interface ReorderPlaylistTrackBody {
+    newPosition: number
+}
+
+export interface PlaylistPlayResponse {
+    state: PlayerStateResponse
+    playlistId: number
+    playlistName: string
+    queued: number
+    failed: number
+    shuffle: boolean
 }

--- a/src/types/web.ts
+++ b/src/types/web.ts
@@ -235,7 +235,7 @@ export type {
     PlaylistTrackData,
 } from "./index.js"
 
-import type { PlaylistSummary, PlaylistTrackData } from "./index.js"
+import type { PlaylistSummary } from "./index.js"
 
 export interface PlaylistListResponse {
     playlists: PlaylistSummary[]

--- a/src/types/web.ts
+++ b/src/types/web.ts
@@ -256,9 +256,21 @@ export interface AddPlaylistTrackFromQueryBody {
     guildId?: string
 }
 
+/** Playlist track as returned in JSON API responses (`addedAt` is ISO string). */
+export interface SerializedPlaylistTrackData {
+    id: number
+    title: string
+    uri: string
+    author: string
+    duration: number
+    thumbnailUrl: string | null
+    addedAt: string
+    position: number
+}
+
 export interface AddTracksFromQueryResponse {
     added: number
-    tracks: PlaylistTrackData[]
+    tracks: SerializedPlaylistTrackData[]
 }
 
 export interface ReorderPlaylistTrackBody {

--- a/src/types/web.ts
+++ b/src/types/web.ts
@@ -229,13 +229,36 @@ export interface AdminDbCleanupResponse {
     deleted: { sessions?: number; verifications?: number }
 }
 
-export type {
-    PlaylistData,
-    PlaylistSummary,
-    PlaylistTrackData,
-} from "./index.js"
+/** Playlist track in JSON API responses (`addedAt` is ISO string). */
+export interface PlaylistTrackData {
+    id: number
+    title: string
+    uri: string
+    author: string
+    duration: number
+    thumbnailUrl: string | null
+    addedAt: string
+    position: number
+}
 
-import type { PlaylistSummary } from "./index.js"
+/** Full playlist in JSON API responses. */
+export interface PlaylistData {
+    id: number
+    name: string
+    userId: string
+    createdAt: string
+    updatedAt: string
+    tracks: PlaylistTrackData[]
+}
+
+/** Playlist list entry in JSON API responses. */
+export interface PlaylistSummary {
+    id: number
+    name: string
+    trackCount: number
+    totalDuration: number
+    createdAt: string
+}
 
 export interface PlaylistListResponse {
     playlists: PlaylistSummary[]
@@ -256,21 +279,12 @@ export interface AddPlaylistTrackFromQueryBody {
     guildId?: string
 }
 
-/** Playlist track as returned in JSON API responses (`addedAt` is ISO string). */
-export interface SerializedPlaylistTrackData {
-    id: number
-    title: string
-    uri: string
-    author: string
-    duration: number
-    thumbnailUrl: string | null
-    addedAt: string
-    position: number
-}
+/** @deprecated Alias for {@link PlaylistTrackData} in add-from-query responses. */
+export type SerializedPlaylistTrackData = PlaylistTrackData
 
 export interface AddTracksFromQueryResponse {
     added: number
-    tracks: SerializedPlaylistTrackData[]
+    tracks: PlaylistTrackData[]
 }
 
 export interface ReorderPlaylistTrackBody {

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -1,0 +1,198 @@
+import type { Player, Track } from "lavalink-client"
+import type { PlaylistTrackData } from "../types/index.js"
+import { thumbnailFromLavalinkTrack } from "./trackThumbnail.js"
+import {
+    isRRQActive,
+    rebalancePlayerQueueRoundRobin,
+    stampRequesterUserIdOnTracks,
+} from "./rrqDisconnect.js"
+import { startPlaybackIfNeeded } from "./musicManager.js"
+
+export function shuffleArray<T>(items: T[]): T[] {
+    const arr = [...items]
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        const tmp = arr[i]
+        arr[i] = arr[j]!
+        arr[j] = tmp!
+    }
+    return arr
+}
+
+function isResolvedTrack(track: unknown): track is Track {
+    return (
+        Boolean(track) &&
+        typeof track === "object" &&
+        "info" in track &&
+        typeof (track as Track).info?.uri === "string"
+    )
+}
+
+/** Resolves stored playlist URIs via Lavalink search (one result per row). */
+export async function resolveStoredPlaylistTracks(
+    player: Player,
+    storedTracks: Pick<PlaylistTrackData, "uri">[],
+    requester: unknown
+): Promise<{ resolved: Track[]; failed: number }> {
+    const resolved: Track[] = []
+    let failed = 0
+    for (const stored of storedTracks) {
+        try {
+            const res = await player.search(stored.uri, requester)
+            const first = res?.tracks?.[0]
+            if (isResolvedTrack(first)) {
+                resolved.push(first)
+            } else {
+                failed++
+            }
+        } catch {
+            failed++
+        }
+    }
+    return { resolved, failed }
+}
+
+export type EnqueuePlaylistResult = {
+    queued: number
+    failed: number
+    playbackStarted: boolean
+    playbackError?: string
+}
+
+/** Removes all upcoming tracks (keeps current if playing). */
+export async function clearUpcomingQueue(player: Player): Promise<void> {
+    const size = player.queue.tracks.length
+    if (size > 0) {
+        await player.queue.splice(0, size)
+    }
+}
+
+/** Adds resolved tracks to the player queue and starts playback when idle. */
+export async function enqueueResolvedPlaylistTracks(
+    player: Player,
+    tracks: Track[],
+    requesterId: string,
+    shuffle: boolean
+): Promise<EnqueuePlaylistResult> {
+    if (tracks.length === 0) {
+        return { queued: 0, failed: 0, playbackStarted: false }
+    }
+    const toQueue = shuffle ? shuffleArray(tracks) : tracks
+    stampRequesterUserIdOnTracks(toQueue, requesterId)
+    player.queue.add(toQueue)
+    if (isRRQActive(player)) {
+        await rebalancePlayerQueueRoundRobin(player)
+    }
+    let playbackStarted = false
+    let playbackError: string | undefined
+    if (!player.playing) {
+        try {
+            await startPlaybackIfNeeded(player)
+            playbackStarted = true
+        } catch (error: unknown) {
+            playbackError = error instanceof Error ? error.message : String(error)
+        }
+    } else {
+        playbackStarted = true
+    }
+    return {
+        queued: toQueue.length,
+        failed: 0,
+        playbackStarted,
+        playbackError,
+    }
+}
+
+export type PlaylistTrackSearchHit = {
+    title: string
+    uri: string
+    author: string
+    duration: number
+    thumbnailUrl: string | null
+}
+
+function isExternalPlaylistLoadType(loadType: string | undefined): boolean {
+    return loadType === "playlist" || loadType === "PLAYLIST_LOADED"
+}
+
+function trackToSearchHit(track: Track, fallbackUri: string): PlaylistTrackSearchHit {
+    const info = track.info
+    return {
+        title: info.title ?? "Unknown",
+        uri: info.uri ?? fallbackUri,
+        author: info.author ?? "Unknown",
+        duration: info.duration ?? 0,
+        thumbnailUrl: thumbnailFromLavalinkTrack(track),
+    }
+}
+
+/** Resolves a query or URL to one or more tracks for saving in a user playlist. */
+export async function searchTracksForPlaylist(
+    player: Player,
+    query: string,
+    requester: unknown
+): Promise<{ ok: true; tracks: PlaylistTrackSearchHit[] } | { ok: false; error: string }> {
+    const trimmed = query.trim()
+    if (!trimmed) {
+        return { ok: false, error: "Enter a search query or URL." }
+    }
+    let res
+    try {
+        res = await player.search(trimmed, requester)
+    } catch {
+        return { ok: false, error: "Search failed." }
+    }
+    if (!res?.tracks?.length) {
+        return { ok: false, error: "No tracks found." }
+    }
+
+    if (isExternalPlaylistLoadType(res.loadType as string | undefined)) {
+        const tracks: PlaylistTrackSearchHit[] = []
+        for (const candidate of res.tracks) {
+            if (isResolvedTrack(candidate)) {
+                tracks.push(trackToSearchHit(candidate, trimmed))
+            }
+        }
+        if (tracks.length === 0) {
+            return { ok: false, error: "Could not resolve any tracks from that playlist." }
+        }
+        return { ok: true, tracks }
+    }
+
+    const first = res.tracks[0]
+    if (!isResolvedTrack(first)) {
+        return { ok: false, error: "Could not resolve that track." }
+    }
+    return { ok: true, tracks: [trackToSearchHit(first, trimmed)] }
+}
+
+/** @deprecated Prefer {@link searchTracksForPlaylist}. */
+export async function searchTrackForPlaylist(
+    player: Player,
+    query: string,
+    requester: unknown
+): Promise<
+    | { ok: true; title: string; uri: string; author: string; duration: number }
+    | { ok: false; error: string }
+> {
+    const result = await searchTracksForPlaylist(player, query, requester)
+    if (result.ok === false) return result
+    return { ok: true, ...result.tracks[0]! }
+}
+
+type LavalinkPlayerAccess = {
+    getPlayer(guildId: string): Player | undefined
+    players: Map<string, Player>
+}
+
+/** Prefers the guild player, otherwise any active player (for search-only operations). */
+export function pickPlayerForPlaylistSearch(
+    lavalink: LavalinkPlayerAccess,
+    preferredGuildId?: string
+): Player | undefined {
+    if (preferredGuildId) {
+        const inGuild = lavalink.getPlayer(preferredGuildId)
+        if (inGuild) return inGuild
+    }
+    return lavalink.players.values().next().value
+}

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -152,6 +152,14 @@ function trackToSearchHit(track: Track, fallbackUri: string): PlaylistTrackSearc
     }
 }
 
+/** Lavalink/search threw; distinct from empty or unresolvable results. */
+export const PLAYLIST_SEARCH_TRANSIENT_ERROR = "Search failed."
+
+/** True when callers should retry (5xx), not treat as a missing track (404). */
+export function isPlaylistSearchTransientFailure(error: string): boolean {
+    return error === PLAYLIST_SEARCH_TRANSIENT_ERROR
+}
+
 /** Resolves a query or URL to one or more tracks for saving in a user playlist. */
 export async function searchTracksForPlaylist(
     player: Player,
@@ -166,7 +174,7 @@ export async function searchTracksForPlaylist(
     try {
         res = await player.search(trimmed, requester)
     } catch {
-        return { ok: false, error: "Search failed." }
+        return { ok: false, error: PLAYLIST_SEARCH_TRANSIENT_ERROR }
     }
     if (!res?.tracks?.length) {
         return { ok: false, error: "No tracks found." }

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -92,8 +92,6 @@ export async function enqueueResolvedPlaylistTracks(
         } catch (error: unknown) {
             playbackError = error instanceof Error ? error.message : String(error)
         }
-    } else {
-        playbackStarted = true
     }
     return {
         queued: toQueue.length,

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -28,28 +28,56 @@ function isResolvedTrack(track: unknown): track is Track {
     )
 }
 
-/** Resolves stored playlist URIs via Lavalink search (one result per row). */
+/** Parallel Lavalink lookups when loading saved playlists into the queue. */
+const PLAYLIST_RESOLVE_CONCURRENCY = 6
+
+async function resolveStoredTrackAtIndex(
+    player: Player,
+    uri: string,
+    requester: unknown
+): Promise<Track | null> {
+    try {
+        const res = await player.search(uri, requester)
+        const first = res?.tracks?.[0]
+        return isResolvedTrack(first) ? first : null
+    } catch {
+        return null
+    }
+}
+
+/** Resolves stored playlist URIs via Lavalink (parallel, preserves track order). */
 export async function resolveStoredPlaylistTracks(
     player: Player,
     storedTracks: Pick<PlaylistTrackData, "uri">[],
     requester: unknown
 ): Promise<{ resolved: Track[]; failed: number }> {
-    const resolved: Track[] = []
-    let failed = 0
-    for (const stored of storedTracks) {
-        try {
-            const res = await player.search(stored.uri, requester)
-            const first = res?.tracks?.[0]
-            if (isResolvedTrack(first)) {
-                resolved.push(first)
-            } else {
-                failed++
-            }
-        } catch {
-            failed++
+    if (storedTracks.length === 0) {
+        return { resolved: [], failed: 0 }
+    }
+
+    const slots: (Track | null)[] = new Array(storedTracks.length).fill(null)
+    let nextIndex = 0
+
+    async function worker(): Promise<void> {
+        while (true) {
+            const i = nextIndex++
+            if (i >= storedTracks.length) return
+            slots[i] = await resolveStoredTrackAtIndex(
+                player,
+                storedTracks[i]!.uri,
+                requester
+            )
         }
     }
-    return { resolved, failed }
+
+    const workerCount = Math.min(PLAYLIST_RESOLVE_CONCURRENCY, storedTracks.length)
+    await Promise.all(Array.from({ length: workerCount }, () => worker()))
+
+    const resolved: Track[] = []
+    for (const track of slots) {
+        if (track) resolved.push(track)
+    }
+    return { resolved, failed: storedTracks.length - resolved.length }
 }
 
 export type EnqueuePlaylistResult = {

--- a/src/util/trackThumbnail.ts
+++ b/src/util/trackThumbnail.ts
@@ -1,0 +1,26 @@
+import type { Track } from "lavalink-client"
+
+/** Lavalink artwork URL or YouTube fallback from resolved track info. */
+export function thumbnailFromLavalinkTrack(track: Track): string | null {
+    const info = track.info
+    if (info.artworkUrl) {
+        return info.artworkUrl
+    }
+    if (info.identifier && info.sourceName === "youtube") {
+        return `https://img.youtube.com/vi/${info.identifier}/hqdefault.jpg`
+    }
+    return thumbnailUrlFromUri(info.uri ?? "")
+}
+
+/** Best-effort thumbnail when only a stored URI is available (e.g. legacy playlist rows). */
+export function thumbnailUrlFromUri(uri: string): string | null {
+    const trimmed = uri.trim()
+    if (!trimmed) return null
+    const match = trimmed.match(
+        /(?:youtube\.com\/(?:watch\?.*v=|embed\/|v\/)|youtu\.be\/|music\.youtube\.com\/watch\?.*v=)([a-zA-Z0-9_-]{11})/
+    )
+    if (match?.[1]) {
+        return `https://img.youtube.com/vi/${match[1]}/hqdefault.jpg`
+    }
+    return null
+}

--- a/src/util/trackThumbnail.ts
+++ b/src/util/trackThumbnail.ts
@@ -17,7 +17,7 @@ export function thumbnailUrlFromUri(uri: string): string | null {
     const trimmed = uri.trim()
     if (!trimmed) return null
     const match = trimmed.match(
-        /(?:youtube\.com\/(?:watch\?.*v=|embed\/|v\/)|youtu\.be\/|music\.youtube\.com\/watch\?.*v=)([a-zA-Z0-9_-]{11})/
+        /(?:youtube\.com\/(?:watch\?.*v=|embed\/|v\/|shorts\/)|youtu\.be\/|music\.youtube\.com\/watch\?.*v=)([a-zA-Z0-9_-]{11})/
     )
     if (match?.[1]) {
         return `https://img.youtube.com/vi/${match[1]}/hqdefault.jpg`

--- a/src/web/.env.example
+++ b/src/web/.env.example
@@ -85,6 +85,9 @@ API_PROXY_TARGET=http://localhost:3001
 # BOT_API_PROXY_TIMEOUT_MS — optional; forward timeout for dashboard → bot HTTP (ms).
 #
 # BOT_API_PROXY_TIMEOUT_MS=
+#
+# Playlist queue loads use a longer per-request timeout from the web server (see
+# playlistPlayTimeoutMs in lib/playlist-play-timeout.ts). Large playlists resolve tracks in parallel on the bot.
 
 ################################################################################
 # Verbose logging — dashboard → bot HTTP (`src/web/server/bot-api-verbose.ts`)

--- a/src/web/app/api/guilds/voice-context/route.ts
+++ b/src/web/app/api/guilds/voice-context/route.ts
@@ -21,7 +21,8 @@ export async function GET(request: Request) {
     try {
         return await proxyBotApi(request)
     } catch (error: unknown) {
-        console.error("[api/guilds/voice-context] GET proxy failed", error)
+        const message = error instanceof Error ? error.message.slice(0, 200) : "unknown"
+        console.error("[api/guilds/voice-context] GET proxy failed:", message)
         return NextResponse.json({ error: "Bot API temporarily unavailable" }, { status: 503 })
     }
 }

--- a/src/web/app/api/guilds/voice-context/route.ts
+++ b/src/web/app/api/guilds/voice-context/route.ts
@@ -1,0 +1,27 @@
+import { headers } from "next/headers"
+import { NextResponse } from "next/server"
+import { auth } from "@/auth"
+import type { AuthenticatedSession } from "@/lib/api-auth"
+import { proxyBotApi } from "@/server/bot-api-proxy"
+
+export async function GET(request: Request) {
+    let session: AuthenticatedSession | null
+    try {
+        session = (await auth.api.getSession({
+            headers: await headers(),
+        })) as AuthenticatedSession | null
+    } catch {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    if (!session?.user?.id) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    try {
+        return await proxyBotApi(request)
+    } catch (error: unknown) {
+        console.error("[api/guilds/voice-context] GET proxy failed", error)
+        return NextResponse.json({ error: "Bot API temporarily unavailable" }, { status: 503 })
+    }
+}

--- a/src/web/app/dashboard/[guildId]/page.tsx
+++ b/src/web/app/dashboard/[guildId]/page.tsx
@@ -3,6 +3,8 @@ import { WEB_PERMISSION } from "@/lib/web-permission-keys"
 import { getGuildDashboardSnapshotAction } from "@/server/dashboard-permissions.actions"
 import { PlayerPanel } from "@/components/PlayerPanel"
 
+export const maxDuration = 300
+
 interface GuildPageProps {
     params: Promise<{ guildId: string }>
 }

--- a/src/web/app/playlists/[playlistId]/page.tsx
+++ b/src/web/app/playlists/[playlistId]/page.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { getPlaylistAction } from "@/lib/actions/playlist.actions"
+import { PlaylistTrackList } from "@/components/PlaylistTrackList"
+import type { PlaylistTrackData } from "@/types/web"
+
+export const dynamic = "force-dynamic"
+
+type PageProps = {
+    params: Promise<{ playlistId: string }>
+    searchParams: Promise<{ guildId?: string }>
+}
+
+function parseTracks(raw: unknown): PlaylistTrackData[] {
+    if (!Array.isArray(raw)) return []
+    return raw
+        .map((entry) => {
+            if (!entry || typeof entry !== "object") return null
+            const t = entry as Record<string, unknown>
+            const id = typeof t.id === "number" ? t.id : null
+            const position = typeof t.position === "number" ? t.position : null
+            const duration = typeof t.duration === "number" ? t.duration : null
+            const title = typeof t.title === "string" ? t.title : null
+            const uri = typeof t.uri === "string" ? t.uri : null
+            const author = typeof t.author === "string" ? t.author : null
+            const thumbnailUrl =
+                typeof t.thumbnailUrl === "string" && t.thumbnailUrl.trim()
+                    ? t.thumbnailUrl.trim()
+                    : null
+            if (
+                id === null ||
+                position === null ||
+                duration === null ||
+                !title ||
+                !uri ||
+                author === null
+            ) {
+                return null
+            }
+            const addedAt =
+                t.addedAt instanceof Date
+                    ? t.addedAt
+                    : typeof t.addedAt === "string"
+                      ? new Date(t.addedAt)
+                      : new Date()
+            return {
+                id,
+                title,
+                uri,
+                author,
+                duration,
+                thumbnailUrl,
+                addedAt,
+                position,
+            }
+        })
+        .filter((t): t is PlaylistTrackData => t !== null)
+}
+
+export default async function PlaylistDetailPage({ params, searchParams }: PageProps) {
+    const { playlistId: playlistIdParam } = await params
+    const { guildId } = await searchParams
+    const guildIdTrimmed =
+        typeof guildId === "string" && /^\d+$/.test(guildId.trim()) ? guildId.trim() : undefined
+    const playlistId = Number.parseInt(playlistIdParam, 10)
+    if (!Number.isFinite(playlistId) || playlistId < 1) {
+        notFound()
+    }
+
+    const result = await getPlaylistAction(playlistId)
+    if (result.ok === false) {
+        return (
+            <div className="space-y-4">
+                <p className="text-destructive">{result.error}</p>
+                <Link href="/playlists" className="text-primary underline-offset-4 hover:underline">
+                    Back to playlists
+                </Link>
+            </div>
+        )
+    }
+
+    const playlist = result.data
+    const tracks = parseTracks(playlist.tracks)
+
+    return (
+        <PlaylistTrackList
+            playlistId={playlist.id}
+            playlistName={playlist.name}
+            tracks={tracks}
+            guildId={guildIdTrimmed}
+        />
+    )
+}

--- a/src/web/app/playlists/[playlistId]/page.tsx
+++ b/src/web/app/playlists/[playlistId]/page.tsx
@@ -62,6 +62,9 @@ export default async function PlaylistDetailPage({ params, searchParams }: PageP
     const { guildId } = await searchParams
     const guildIdTrimmed =
         typeof guildId === "string" && /^\d+$/.test(guildId.trim()) ? guildId.trim() : undefined
+    if (!/^\d+$/.test(playlistIdParam)) {
+        notFound()
+    }
     const playlistId = Number.parseInt(playlistIdParam, 10)
     if (!Number.isFinite(playlistId) || playlistId < 1) {
         notFound()

--- a/src/web/app/playlists/[playlistId]/page.tsx
+++ b/src/web/app/playlists/[playlistId]/page.tsx
@@ -38,11 +38,11 @@ function parseTracks(raw: unknown): PlaylistTrackData[] {
                 return null
             }
             const addedAt =
-                t.addedAt instanceof Date
+                typeof t.addedAt === "string"
                     ? t.addedAt
-                    : typeof t.addedAt === "string"
-                      ? new Date(t.addedAt)
-                      : new Date()
+                    : t.addedAt instanceof Date
+                      ? t.addedAt.toISOString()
+                      : new Date().toISOString()
             return {
                 id,
                 title,

--- a/src/web/app/playlists/layout.tsx
+++ b/src/web/app/playlists/layout.tsx
@@ -7,11 +7,9 @@ import { ServiceDegraded } from "@/components/ServiceDegraded"
 import { GoToNowPlayingButton } from "@/components/GoToNowPlayingButton"
 import { UserHeader } from "@/components/UserHeader"
 
-/** Session read uses `headers()`; avoid any static/CDN caching of personalized HTML. */
 export const dynamic = "force-dynamic"
 
-/** Dashboard layout wrapper: shared header, invite link, and session gate for dashboard routes. */
-export default async function DashboardLayout({ children }: { children: ReactNode }) {
+export default async function PlaylistsLayout({ children }: { children: ReactNode }) {
     const sessionResult = await readSessionSafe()
 
     if (sessionResult.ok === false) {
@@ -32,7 +30,7 @@ export default async function DashboardLayout({ children }: { children: ReactNod
                 </header>
                 <main className="mx-auto w-full max-w-6xl p-4">
                     <ServiceDegraded
-                        title="Dashboard is temporarily unavailable"
+                        title="Playlists are temporarily unavailable"
                         description="We could not load your session. Please try again later."
                         detail="Please try again later or contact support if this persists."
                         supportReference={sessionResult.correlationId}

--- a/src/web/app/playlists/page.tsx
+++ b/src/web/app/playlists/page.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link"
+import { getPlaylistsAction } from "@/lib/actions/playlist.actions"
+import { CreatePlaylistForm } from "@/components/CreatePlaylistForm"
+import { PlaylistDiscordHelp } from "@/components/PlaylistDiscordHelp"
+import { formatDurationMs } from "@/lib/format-duration"
+
+export const dynamic = "force-dynamic"
+
+export default async function PlaylistsPage() {
+    const result = await getPlaylistsAction()
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-2xl font-semibold">Your Playlists</h1>
+                <p className="text-sm text-muted-foreground">
+                    Personal playlists follow your Discord account across servers.
+                </p>
+            </div>
+
+            <section className="rounded border bg-card p-4 text-card-foreground">
+                <h2 className="mb-3 text-lg font-medium">Create Playlist</h2>
+                <CreatePlaylistForm />
+            </section>
+
+            <PlaylistDiscordHelp />
+
+            {result.ok === false ? (
+                <div className="rounded border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+                    {result.error}
+                </div>
+            ) : result.data.playlists.length === 0 ? (
+                <div className="rounded border bg-card p-4 text-card-foreground">
+                    <p>You do not have any playlists yet. Create one above or use</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        <code className="rounded bg-muted px-1">/playlist create</code> in Discord.
+                    </p>
+                </div>
+            ) : (
+                <div className="grid gap-3 md:grid-cols-2">
+                    {result.data.playlists.map((playlist) => (
+                        <Link
+                            key={playlist.id}
+                            href={`/playlists/${playlist.id}`}
+                            className="block rounded border bg-card p-4 no-underline hover:bg-accent hover:text-accent-foreground"
+                        >
+                            <div className="font-semibold">{playlist.name}</div>
+                            <p className="mt-1 text-sm text-muted-foreground">
+                                {playlist.trackCount} track
+                                {playlist.trackCount === 1 ? "" : "s"} ·{" "}
+                                {formatDurationMs(playlist.totalDuration)}
+                            </p>
+                        </Link>
+                    ))}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/web/components/AddToPlaylistMenu.tsx
+++ b/src/web/components/AddToPlaylistMenu.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { toast } from "sonner"
+import {
+    addTrackToPlaylistAction,
+    createPlaylistAction,
+    getPlaylistsAction,
+} from "@/lib/actions/playlist.actions"
+import { Button } from "@/components/ui/button"
+import type { PlaylistSummary } from "@/types/web"
+
+export interface AddToPlaylistTrack {
+    title: string
+    uri: string
+    author: string
+    durationMs: number
+    thumbnailUrl?: string | null
+}
+
+interface AddToPlaylistMenuProps {
+    track: AddToPlaylistTrack
+    disabled?: boolean
+}
+
+export function AddToPlaylistMenu({ track, disabled = false }: AddToPlaylistMenuProps) {
+    const [open, setOpen] = useState(false)
+    const [playlists, setPlaylists] = useState<PlaylistSummary[] | null>(null)
+    const [loading, setLoading] = useState(false)
+    const [busy, setBusy] = useState(false)
+    const rootRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!open) return
+        let cancelled = false
+        setLoading(true)
+        void getPlaylistsAction().then((result) => {
+            if (cancelled) return
+            setLoading(false)
+            if (result.ok === true) {
+                setPlaylists(result.data.playlists)
+            } else {
+                toast.error(result.error)
+                setPlaylists([])
+            }
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [open])
+
+    useEffect(() => {
+        if (!open) return
+        const onPointerDown = (event: MouseEvent) => {
+            if (!rootRef.current?.contains(event.target as Node)) {
+                setOpen(false)
+            }
+        }
+        document.addEventListener("mousedown", onPointerDown)
+        return () => document.removeEventListener("mousedown", onPointerDown)
+    }, [open])
+
+    const addToPlaylist = async (playlistId: number, playlistName: string) => {
+        if (!track.uri.trim()) {
+            toast.error("This track has no URL to save.")
+            return
+        }
+        setBusy(true)
+        const result = await addTrackToPlaylistAction(playlistId, {
+            title: track.title,
+            uri: track.uri,
+            author: track.author,
+            duration: track.durationMs,
+            thumbnailUrl: track.thumbnailUrl ?? null,
+            addedAt: new Date().toISOString(),
+        })
+        setBusy(false)
+        if (result.ok === false) {
+            toast.error(result.error)
+            return
+        }
+        toast.success(`Added to ${playlistName}`)
+        setOpen(false)
+    }
+
+    const handleCreateNew = async () => {
+        const name = window.prompt("New playlist name")
+        if (!name?.trim()) return
+        setBusy(true)
+        const created = await createPlaylistAction(name.trim())
+        if (created.ok === false) {
+            setBusy(false)
+            toast.error(created.error)
+            return
+        }
+        await addToPlaylist(created.data.id, created.data.name)
+        setBusy(false)
+        setPlaylists((prev) => [
+            ...(prev ?? []),
+            {
+                id: created.data.id,
+                name: created.data.name,
+                trackCount: 1,
+                totalDuration: track.durationMs,
+                createdAt: created.data.createdAt,
+            },
+        ])
+    }
+
+    return (
+        <div ref={rootRef} className="relative inline-block">
+            <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={disabled || busy}
+                onClick={() => setOpen((v) => !v)}
+            >
+                Add to playlist
+            </Button>
+            {open ? (
+                <div className="absolute right-0 z-50 mt-1 min-w-[12rem] rounded border bg-popover p-1 text-popover-foreground shadow-md">
+                    {loading ? (
+                        <p className="px-2 py-1.5 text-sm text-muted-foreground">Loading…</p>
+                    ) : (
+                        <>
+                            {(playlists ?? []).map((p) => (
+                                <button
+                                    key={p.id}
+                                    type="button"
+                                    className="block w-full rounded px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+                                    disabled={busy}
+                                    onClick={() => {
+                                        void addToPlaylist(p.id, p.name)
+                                    }}
+                                >
+                                    {p.name}
+                                </button>
+                            ))}
+                            <button
+                                type="button"
+                                className="block w-full rounded px-2 py-1.5 text-left text-sm font-medium hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+                                disabled={busy}
+                                onClick={() => {
+                                    void handleCreateNew()
+                                }}
+                            >
+                                Create new…
+                            </button>
+                        </>
+                    )}
+                </div>
+            ) : null}
+        </div>
+    )
+}

--- a/src/web/components/AddTrackToPlaylistForm.tsx
+++ b/src/web/components/AddTrackToPlaylistForm.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { addTrackFromQueryToPlaylistAction } from "@/lib/actions/playlist.actions"
+import { Button } from "@/components/ui/button"
+
+interface AddTrackToPlaylistFormProps {
+    playlistId: number
+    /** When set, prefer Lavalink search via this guild's player. */
+    guildId?: string
+}
+
+export function AddTrackToPlaylistForm({ playlistId, guildId }: AddTrackToPlaylistFormProps) {
+    const router = useRouter()
+    const [query, setQuery] = useState("")
+    const [error, setError] = useState<string | null>(null)
+    const [success, setSuccess] = useState<string | null>(null)
+    const [submitting, setSubmitting] = useState(false)
+
+    return (
+        <form
+            className="flex flex-col gap-2 sm:flex-row sm:items-end"
+            onSubmit={(e) => {
+                e.preventDefault()
+                void (async () => {
+                    const trimmed = query.trim()
+                    if (!trimmed) {
+                        setError("Enter a song name, track URL, or playlist URL.")
+                        return
+                    }
+                    setSubmitting(true)
+                    setError(null)
+                    setSuccess(null)
+                    const result = await addTrackFromQueryToPlaylistAction(playlistId, {
+                        query: trimmed,
+                        guildId,
+                    })
+                    setSubmitting(false)
+                    if (result.ok === false) {
+                        setError(result.error)
+                        return
+                    }
+                    setQuery("")
+                    setSuccess(
+                        result.data.added === 1
+                            ? "Added 1 track."
+                            : `Added ${result.data.added} tracks from playlist.`
+                    )
+                    router.refresh()
+                })()
+            }}
+        >
+            <div className="flex-1">
+                <label htmlFor="add-track-query" className="mb-1 block text-sm font-medium">
+                    Add song or playlist link
+                </label>
+                <input
+                    id="add-track-query"
+                    type="text"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    className="w-full rounded border bg-background px-3 py-2 text-sm"
+                    placeholder="Song name, track URL, or YouTube playlist URL"
+                    disabled={submitting}
+                />
+            </div>
+            <Button type="submit" disabled={submitting}>
+                {submitting ? "Adding…" : "Add"}
+            </Button>
+            {error ? (
+                <p className="text-sm text-destructive sm:basis-full" role="alert">
+                    {error}
+                </p>
+            ) : null}
+            {success ? (
+                <p className="text-sm text-green-600 dark:text-green-400 sm:basis-full" role="status">
+                    {success}
+                </p>
+            ) : null}
+        </form>
+    )
+}

--- a/src/web/components/CreatePlaylistForm.tsx
+++ b/src/web/components/CreatePlaylistForm.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { createPlaylistAction } from "@/lib/actions/playlist.actions"
+import { Button } from "@/components/ui/button"
+
+export function CreatePlaylistForm() {
+    const router = useRouter()
+    const [name, setName] = useState("")
+    const [error, setError] = useState<string | null>(null)
+    const [submitting, setSubmitting] = useState(false)
+
+    return (
+        <form
+            className="flex flex-col gap-2 sm:flex-row sm:items-end"
+            onSubmit={(e) => {
+                e.preventDefault()
+                void (async () => {
+                    const trimmed = name.trim()
+                    if (!trimmed) {
+                        setError("Enter a playlist name.")
+                        return
+                    }
+                    setSubmitting(true)
+                    setError(null)
+                    const result = await createPlaylistAction(trimmed)
+                    setSubmitting(false)
+                    if (result.ok === false) {
+                        setError(result.error)
+                        return
+                    }
+                    setName("")
+                    router.refresh()
+                })()
+            }}
+        >
+            <div className="flex-1">
+                <label htmlFor="playlist-name" className="mb-1 block text-sm font-medium">
+                    New playlist name
+                </label>
+                <input
+                    id="playlist-name"
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    className="w-full rounded border bg-background px-3 py-2 text-sm"
+                    placeholder="My favorites"
+                    disabled={submitting}
+                />
+            </div>
+            <Button type="submit" disabled={submitting}>
+                {submitting ? "Creating…" : "Create Playlist"}
+            </Button>
+            {error ? (
+                <p className="text-sm text-destructive sm:basis-full" role="alert">
+                    {error}
+                </p>
+            ) : null}
+        </form>
+    )
+}

--- a/src/web/components/GoToNowPlayingButton.tsx
+++ b/src/web/components/GoToNowPlayingButton.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import Image from "next/image"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Music2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import type { ApiResponse, VoiceContextResponse } from "@/types/web"
+
+const POLL_INTERVAL_MS = 20_000
+
+/** True on `/dashboard/[guildId]` player controls, not the guild list. */
+function isGuildPlayerControlsPage(pathname: string): boolean {
+    return /^\/dashboard\/\d+$/.test(pathname)
+}
+
+export function GoToNowPlayingButton() {
+    const pathname = usePathname()
+    const [activeGuild, setActiveGuild] = useState<VoiceContextResponse["activeGuild"]>(null)
+    const [loaded, setLoaded] = useState(false)
+
+    const refresh = useCallback(async () => {
+        try {
+            const res = await fetch("/api/guilds/voice-context", {
+                credentials: "include",
+                cache: "no-store",
+            })
+            if (!res.ok) {
+                setActiveGuild(null)
+                return
+            }
+            const payload = (await res.json()) as ApiResponse<VoiceContextResponse>
+            if (payload.ok === true) {
+                setActiveGuild(payload.data.activeGuild)
+            } else {
+                setActiveGuild(null)
+            }
+        } catch {
+            setActiveGuild(null)
+        } finally {
+            setLoaded(true)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (isGuildPlayerControlsPage(pathname)) {
+            return
+        }
+        void refresh()
+        const interval = window.setInterval(() => void refresh(), POLL_INTERVAL_MS)
+        const onFocus = () => void refresh()
+        window.addEventListener("focus", onFocus)
+        return () => {
+            window.clearInterval(interval)
+            window.removeEventListener("focus", onFocus)
+        }
+    }, [pathname, refresh])
+
+    if (!loaded || !activeGuild || isGuildPlayerControlsPage(pathname)) {
+        return null
+    }
+
+    const subtitle =
+        activeGuild.currentTrackTitle ??
+        (activeGuild.status === "playing"
+            ? "Now playing"
+            : activeGuild.status === "paused"
+              ? "Paused"
+              : "In voice")
+
+    return (
+        <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex justify-end p-4 sm:bottom-6 sm:right-6">
+            <Button
+                asChild
+                size="lg"
+                className="pointer-events-auto h-auto max-w-[min(100vw-2rem,20rem)] gap-3 px-4 py-3 shadow-lg"
+            >
+                <Link
+                    href={`/dashboard/${activeGuild.guildId}`}
+                    prefetch={false}
+                    aria-label={`Go to now playing in ${activeGuild.guildName}`}
+                >
+                    {activeGuild.guildIconUrl ? (
+                        <Image
+                            src={activeGuild.guildIconUrl}
+                            alt=""
+                            width={32}
+                            height={32}
+                            className="h-8 w-8 shrink-0 rounded-full"
+                            unoptimized
+                        />
+                    ) : (
+                        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-foreground/20">
+                            <Music2 className="h-4 w-4" aria-hidden />
+                        </span>
+                    )}
+                    <span className="min-w-0 text-left">
+                        <span className="block text-sm font-semibold leading-tight">Go to now playing</span>
+                        <span className="block truncate text-xs font-normal opacity-90">
+                            {activeGuild.guildName} · {subtitle}
+                        </span>
+                    </span>
+                </Link>
+            </Button>
+        </div>
+    )
+}

--- a/src/web/components/GuildList.tsx
+++ b/src/web/components/GuildList.tsx
@@ -1,10 +1,37 @@
 import Image from "next/image"
 import Link from "next/link"
 import type { GuildListActionResult } from "@/server/guild.actions"
-import type { GuildListItem } from "@/types/web"
+import type { GuildListItem, GuildListPlayerSummary } from "@/types/web"
 
 type GuildListProps = {
     result: GuildListActionResult
+}
+
+function parsePlayerSummary(raw: unknown): GuildListPlayerSummary | null {
+    if (!raw || typeof raw !== "object") return null
+    const p = raw as Record<string, unknown>
+    const status = p.status
+    if (status !== "playing" && status !== "paused" && status !== "idle") return null
+    const queueCount = p.queueCount
+    if (typeof queueCount !== "number" || !Number.isFinite(queueCount) || queueCount < 0) {
+        return null
+    }
+    const title =
+        typeof p.currentTrackTitle === "string" && p.currentTrackTitle.trim()
+            ? p.currentTrackTitle.trim()
+            : null
+    const author =
+        typeof p.currentTrackAuthor === "string" && p.currentTrackAuthor.trim()
+            ? p.currentTrackAuthor.trim()
+            : null
+    return {
+        status,
+        botInVoiceChannel: Boolean(p.botInVoiceChannel),
+        inVoiceWithBot: Boolean(p.inVoiceWithBot),
+        currentTrackTitle: title,
+        currentTrackAuthor: author,
+        queueCount: Math.floor(queueCount),
+    }
 }
 
 /** Accepts loose API data so a single bad row cannot crash the dashboard. */
@@ -21,7 +48,9 @@ function parseSafeGuildListItem(entry: unknown): GuildListItem | null {
     const iconUrl = typeof iconRaw === "string" ? iconRaw.trim() : null
     const mc = g.memberCount
     const memberCount = typeof mc === "number" && Number.isInteger(mc) && mc >= 0 ? mc : null
-    return { id: idStr, name, iconUrl, memberCount }
+    const player =
+        g.player === null || g.player === undefined ? null : parsePlayerSummary(g.player)
+    return { id: idStr, name, iconUrl, memberCount, player }
 }
 
 function isValidGuildIconUrl(url: string | null | undefined): url is string {
@@ -29,6 +58,36 @@ function isValidGuildIconUrl(url: string | null | undefined): url is string {
     const trimmed = url.trim()
     if (!trimmed) return false
     return /^https:\/\/(?:cdn\.discordapp\.com|images\.discordapp\.net)(?:\/|$)/i.test(trimmed)
+}
+
+function memberCountLabel(memberCount: number | null): string {
+    if (typeof memberCount === "number") {
+        return memberCount === 1 ? "1 member" : `${memberCount} members`
+    }
+    return "Member count unavailable"
+}
+
+function playerStatusLabel(player: GuildListPlayerSummary): string {
+    if (player.status === "playing") return "Playing"
+    if (player.status === "paused") return "Paused"
+    return "Idle"
+}
+
+function playerActivityLine(player: GuildListPlayerSummary): string {
+    const status = playerStatusLabel(player)
+    if (player.currentTrackTitle) {
+        const byArtist = player.currentTrackAuthor
+            ? `${player.currentTrackTitle} — ${player.currentTrackAuthor}`
+            : player.currentTrackTitle
+        return `${status} · ${byArtist}`
+    }
+    if (player.queueCount > 0) {
+        return `${status} · ${player.queueCount} queued`
+    }
+    if (player.botInVoiceChannel) {
+        return `${status} · In voice`
+    }
+    return status
 }
 
 /** Renders the dashboard guild list from a server-loaded result (no client-side refetch race). */
@@ -76,7 +135,7 @@ export function GuildList({ result }: GuildListProps) {
                 <Link
                     href={`/dashboard/${guild.id}`}
                     key={guild.id}
-                    className="flex items-center gap-3 rounded border bg-card p-3 no-underline hover:bg-accent hover:text-accent-foreground"
+                    className="flex items-start gap-3 rounded border bg-card p-3 no-underline hover:bg-accent hover:text-accent-foreground"
                 >
                     {isValidGuildIconUrl(guild.iconUrl) ? (
                         <Image
@@ -84,22 +143,30 @@ export function GuildList({ result }: GuildListProps) {
                             alt={`${guild.name} icon`}
                             width={40}
                             height={40}
-                            className="h-10 w-10 rounded-full"
+                            className="h-10 w-10 shrink-0 rounded-full"
                         />
                     ) : (
-                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted">
                             {guild.name.slice(0, 1)}
                         </div>
                     )}
-                    <div>
-                        <div className="font-medium">{guild.name}</div>
-                        <div className="text-sm text-muted-foreground">
-                            {typeof guild.memberCount === "number"
-                                ? guild.memberCount === 1
-                                    ? "1 member"
-                                    : `${guild.memberCount} members`
-                                : "Member count unavailable"}
+                    <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-medium">{guild.name}</span>
+                            {guild.player?.inVoiceWithBot ? (
+                                <span className="rounded bg-primary/15 px-1.5 py-0.5 text-xs font-medium text-primary">
+                                    In your channel
+                                </span>
+                            ) : null}
                         </div>
+                        <p className="text-sm text-muted-foreground">{memberCountLabel(guild.memberCount)}</p>
+                        {guild.player ? (
+                            <p className="truncate text-sm text-foreground/90">
+                                {playerActivityLine(guild.player)}
+                            </p>
+                        ) : (
+                            <p className="text-sm text-muted-foreground">No active player</p>
+                        )}
                     </div>
                 </Link>
             ))}

--- a/src/web/components/GuildList.tsx
+++ b/src/web/components/GuildList.tsx
@@ -24,10 +24,12 @@ function parsePlayerSummary(raw: unknown): GuildListPlayerSummary | null {
         typeof p.currentTrackAuthor === "string" && p.currentTrackAuthor.trim()
             ? p.currentTrackAuthor.trim()
             : null
+    const botInVoiceChannel = p.botInVoiceChannel === true || p.botInVoiceChannel === "true"
+    const inVoiceWithBot = p.inVoiceWithBot === true || p.inVoiceWithBot === "true"
     return {
         status,
-        botInVoiceChannel: Boolean(p.botInVoiceChannel),
-        inVoiceWithBot: Boolean(p.inVoiceWithBot),
+        botInVoiceChannel,
+        inVoiceWithBot,
         currentTrackTitle: title,
         currentTrackAuthor: author,
         queueCount: Math.floor(queueCount),

--- a/src/web/components/PlayPlaylistMenu.tsx
+++ b/src/web/components/PlayPlaylistMenu.tsx
@@ -30,16 +30,28 @@ export function PlayPlaylistMenu({
         if (!open) return
         let cancelled = false
         setLoading(true)
-        void getPlaylistsAction().then((result) => {
-            if (cancelled) return
-            setLoading(false)
-            if (result.ok === true) {
-                setPlaylists(result.data.playlists)
-            } else {
-                toast.error(result.error)
+        void (async () => {
+            try {
+                const result = await getPlaylistsAction()
+                if (cancelled) return
+                if (result.ok === true) {
+                    setPlaylists(result.data.playlists)
+                } else {
+                    toast.error(result.error)
+                    setPlaylists([])
+                }
+            } catch (error: unknown) {
+                if (cancelled) return
+                const message =
+                    error instanceof Error ? error.message : "Failed to load playlists."
+                toast.error(message)
                 setPlaylists([])
+            } finally {
+                if (!cancelled) {
+                    setLoading(false)
+                }
             }
-        })
+        })()
         return () => {
             cancelled = true
         }
@@ -70,28 +82,34 @@ export function PlayPlaylistMenu({
         const loadingToastId = toast.loading(
             `Loading "${playlist.name}" (${playlist.trackCount} track${playlist.trackCount === 1 ? "" : "s"})…`
         )
-        const result = await playPlaylistInGuildAction(
-            guildId,
-            playlist.id,
-            requesterId,
-            shuffle,
-            playlist.trackCount
-        )
-        toast.dismiss(loadingToastId)
-        setBusy(false)
-        if (result.ok === false) {
-            toast.error(result.error)
-            return
+        try {
+            const result = await playPlaylistInGuildAction(
+                guildId,
+                playlist.id,
+                requesterId,
+                shuffle,
+                playlist.trackCount
+            )
+            if (result.ok === false) {
+                toast.error(result.error)
+                return
+            }
+            const failNote =
+                result.data.failed > 0
+                    ? ` (${result.data.failed} could not be resolved)`
+                    : ""
+            toast.success(
+                `Queued ${result.data.queued} from "${result.data.playlistName}"${failNote}`
+            )
+            setOpen(false)
+            onQueued?.()
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error)
+            toast.error(message || "Failed to queue playlist.")
+        } finally {
+            toast.dismiss(loadingToastId)
+            setBusy(false)
         }
-        const failNote =
-            result.data.failed > 0
-                ? ` (${result.data.failed} could not be resolved)`
-                : ""
-        toast.success(
-            `Queued ${result.data.queued} from "${result.data.playlistName}"${failNote}`
-        )
-        setOpen(false)
-        onQueued?.()
     }
 
     return (

--- a/src/web/components/PlayPlaylistMenu.tsx
+++ b/src/web/components/PlayPlaylistMenu.tsx
@@ -67,12 +67,17 @@ export function PlayPlaylistMenu({
             return
         }
         setBusy(true)
+        const loadingToastId = toast.loading(
+            `Loading "${playlist.name}" (${playlist.trackCount} track${playlist.trackCount === 1 ? "" : "s"})…`
+        )
         const result = await playPlaylistInGuildAction(
             guildId,
             playlist.id,
             requesterId,
-            shuffle
+            shuffle,
+            playlist.trackCount
         )
+        toast.dismiss(loadingToastId)
         setBusy(false)
         if (result.ok === false) {
             toast.error(result.error)

--- a/src/web/components/PlayPlaylistMenu.tsx
+++ b/src/web/components/PlayPlaylistMenu.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { toast } from "sonner"
+import { getPlaylistsAction, playPlaylistInGuildAction } from "@/lib/actions/playlist.actions"
+import { Button } from "@/components/ui/button"
+import type { PlaylistSummary } from "@/types/web"
+
+interface PlayPlaylistMenuProps {
+    guildId: string
+    requesterDiscordUserId: string | undefined
+    disabled?: boolean
+    onQueued?: () => void
+}
+
+export function PlayPlaylistMenu({
+    guildId,
+    requesterDiscordUserId,
+    disabled = false,
+    onQueued,
+}: PlayPlaylistMenuProps) {
+    const [open, setOpen] = useState(false)
+    const [shuffle, setShuffle] = useState(false)
+    const [playlists, setPlaylists] = useState<PlaylistSummary[] | null>(null)
+    const [loading, setLoading] = useState(false)
+    const [busy, setBusy] = useState(false)
+    const rootRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!open) return
+        let cancelled = false
+        setLoading(true)
+        void getPlaylistsAction().then((result) => {
+            if (cancelled) return
+            setLoading(false)
+            if (result.ok === true) {
+                setPlaylists(result.data.playlists)
+            } else {
+                toast.error(result.error)
+                setPlaylists([])
+            }
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [open])
+
+    useEffect(() => {
+        if (!open) return
+        const onPointerDown = (event: MouseEvent) => {
+            if (!rootRef.current?.contains(event.target as Node)) {
+                setOpen(false)
+            }
+        }
+        document.addEventListener("mousedown", onPointerDown)
+        return () => document.removeEventListener("mousedown", onPointerDown)
+    }, [open])
+
+    const playPlaylist = async (playlist: PlaylistSummary) => {
+        const requesterId = requesterDiscordUserId?.trim()
+        if (!requesterId) {
+            toast.error("Missing Discord user id. Refresh or sign in again.")
+            return
+        }
+        if (playlist.trackCount === 0) {
+            toast.error(`"${playlist.name}" is empty.`)
+            return
+        }
+        setBusy(true)
+        const result = await playPlaylistInGuildAction(
+            guildId,
+            playlist.id,
+            requesterId,
+            shuffle
+        )
+        setBusy(false)
+        if (result.ok === false) {
+            toast.error(result.error)
+            return
+        }
+        const failNote =
+            result.data.failed > 0
+                ? ` (${result.data.failed} could not be resolved)`
+                : ""
+        toast.success(
+            `Queued ${result.data.queued} from "${result.data.playlistName}"${failNote}`
+        )
+        setOpen(false)
+        onQueued?.()
+    }
+
+    return (
+        <div ref={rootRef} className="relative inline-block">
+            <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={disabled || busy}
+                onClick={() => setOpen((v) => !v)}
+            >
+                Load playlist
+            </Button>
+            {open ? (
+                <div className="absolute right-0 z-50 mt-1 min-w-[14rem] rounded border bg-popover p-2 text-popover-foreground shadow-md">
+                    <label className="mb-2 flex items-center gap-2 px-1 text-sm">
+                        <input
+                            type="checkbox"
+                            checked={shuffle}
+                            onChange={(e) => setShuffle(e.target.checked)}
+                            disabled={busy}
+                        />
+                        Shuffle
+                    </label>
+                    {loading ? (
+                        <p className="px-2 py-1.5 text-sm text-muted-foreground">Loading…</p>
+                    ) : (playlists ?? []).length === 0 ? (
+                        <p className="px-2 py-1.5 text-sm text-muted-foreground">
+                            No playlists yet.
+                        </p>
+                    ) : (
+                        (playlists ?? []).map((p) => (
+                            <button
+                                key={p.id}
+                                type="button"
+                                className="block w-full rounded px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+                                disabled={busy}
+                                onClick={() => {
+                                    void playPlaylist(p)
+                                }}
+                            >
+                                {p.name}
+                                <span className="ml-1 text-muted-foreground">({p.trackCount})</span>
+                            </button>
+                        ))
+                    )}
+                </div>
+            ) : null}
+        </div>
+    )
+}
+

--- a/src/web/components/PlayerPanel.tsx
+++ b/src/web/components/PlayerPanel.tsx
@@ -16,6 +16,8 @@ import {
 import { WEB_PERMISSION } from "@/lib/web-permission-keys"
 import { getPlayerQueueAction, getPlayerStateAction } from "@/lib/actions/player.actions"
 import { sanitizeHttpUrl } from "@/lib/url-utils"
+import { AddToPlaylistMenu } from "@/components/AddToPlaylistMenu"
+import { PlayPlaylistMenu } from "@/components/PlayPlaylistMenu"
 import { ConnectionStatus } from "@/components/ConnectionStatus"
 import { usePlayerActions } from "@/hooks/usePlayerActions"
 import { usePlayerSocket } from "@/hooks/usePlayerSocket"
@@ -154,10 +156,18 @@ function QueueTrackRow({ track, queueIndex }: QueueTrackRowProps) {
         </>
     )
 
+    const playlistTrack = {
+        title: track.title,
+        uri: track.uri ?? "",
+        author: track.author ?? "Unknown",
+        durationMs: track.durationMs,
+        thumbnailUrl: track.thumbnailUrl ?? null,
+    }
+
     return (
         <li
             ref={liRef}
-            className="rounded border bg-background p-2"
+            className="flex items-start justify-between gap-2 rounded border bg-background p-2"
             tabIndex={safeQueueTrackUrl ? undefined : 0}
             onMouseMove={(event) => scheduleAnchorUpdate(event.clientX, event.clientY)}
             onMouseLeave={() => {
@@ -171,6 +181,7 @@ function QueueTrackRow({ track, queueIndex }: QueueTrackRowProps) {
             onFocus={safeQueueTrackUrl ? undefined : handleRowFocus}
             onBlur={safeQueueTrackUrl ? undefined : handleRowBlur}
         >
+            <div className="min-w-0 flex-1">
             {safeQueueTrackUrl ? (
                 <a
                     href={safeQueueTrackUrl}
@@ -186,6 +197,8 @@ function QueueTrackRow({ track, queueIndex }: QueueTrackRowProps) {
             ) : (
                 rowLine
             )}
+            </div>
+            <AddToPlaylistMenu track={playlistTrack} />
             {popoverLayout ? (
                 <div
                     className="fixed z-50 w-80 -translate-y-1/2 rounded border bg-popover p-3 text-popover-foreground shadow-lg"
@@ -670,6 +683,16 @@ export function PlayerPanel({ guildId, discordUserId, permissionSnapshot }: Play
                                 <div className="text-sm text-muted-foreground">
                                     Requested by: {requesterLabel(nowPlaying)}
                                 </div>
+                                <div className="pt-2">
+                                    <AddToPlaylistMenu
+                                        track={{
+                                            title: nowPlaying.title,
+                                            uri: nowPlaying.uri ?? "",
+                                            author: "Unknown",
+                                            durationMs: nowPlaying.durationMs,
+                                        }}
+                                    />
+                                </div>
                             </div>
                         </div>
                         {playerState ? (
@@ -745,7 +768,31 @@ export function PlayerPanel({ guildId, discordUserId, permissionSnapshot }: Play
 
             {canManageQueue ? (
                 <section className="rounded border bg-card p-4 text-card-foreground">
-                    <h2 className="mb-2 text-lg font-medium">Add Track</h2>
+                    <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                        <h2 className="text-lg font-medium">Add Track</h2>
+                        <PlayPlaylistMenu
+                            guildId={guildId}
+                            requesterDiscordUserId={discordUserId}
+                            disabled={addTrackInputDisabled}
+                            onQueued={() => {
+                                void (async () => {
+                                    const playerResult = await getPlayerStateAction(guildId)
+                                    if (playerResult.ok === true) {
+                                        setBaseState(playerResult.data)
+                                    }
+                                    setQueuePage(1)
+                                    const queueResult = await getPlayerQueueAction(
+                                        guildId,
+                                        1,
+                                        QUEUE_PAGE_SIZE
+                                    )
+                                    if (queueResult.ok === true) {
+                                        applyQueueResponse(queueResult.data)
+                                    }
+                                })()
+                            }}
+                        />
+                    </div>
                     <form
                         className="flex flex-col gap-2 md:flex-row"
                         onSubmit={(event) => {

--- a/src/web/components/PlayerPanel.tsx
+++ b/src/web/components/PlayerPanel.tsx
@@ -163,6 +163,7 @@ function QueueTrackRow({ track, queueIndex }: QueueTrackRowProps) {
         durationMs: track.durationMs,
         thumbnailUrl: track.thumbnailUrl ?? null,
     }
+    const canSaveToPlaylist = Boolean(track.uri?.trim())
 
     return (
         <li
@@ -198,7 +199,7 @@ function QueueTrackRow({ track, queueIndex }: QueueTrackRowProps) {
                 rowLine
             )}
             </div>
-            <AddToPlaylistMenu track={playlistTrack} />
+            {canSaveToPlaylist ? <AddToPlaylistMenu track={playlistTrack} /> : null}
             {popoverLayout ? (
                 <div
                     className="fixed z-50 w-80 -translate-y-1/2 rounded border bg-popover p-3 text-popover-foreground shadow-lg"
@@ -683,16 +684,19 @@ export function PlayerPanel({ guildId, discordUserId, permissionSnapshot }: Play
                                 <div className="text-sm text-muted-foreground">
                                     Requested by: {requesterLabel(nowPlaying)}
                                 </div>
-                                <div className="pt-2">
-                                    <AddToPlaylistMenu
-                                        track={{
-                                            title: nowPlaying.title,
-                                            uri: nowPlaying.uri ?? "",
-                                            author: "Unknown",
-                                            durationMs: nowPlaying.durationMs,
-                                        }}
-                                    />
-                                </div>
+                                {nowPlaying.uri?.trim() ? (
+                                    <div className="pt-2">
+                                        <AddToPlaylistMenu
+                                            track={{
+                                                title: nowPlaying.title,
+                                                uri: nowPlaying.uri!.trim(),
+                                                author: "Unknown",
+                                                durationMs: nowPlaying.durationMs,
+                                                thumbnailUrl: nowPlaying.thumbnailUrl ?? null,
+                                            }}
+                                        />
+                                    </div>
+                                ) : null}
                             </div>
                         </div>
                         {playerState ? (

--- a/src/web/components/PlaylistDiscordHelp.tsx
+++ b/src/web/components/PlaylistDiscordHelp.tsx
@@ -1,0 +1,17 @@
+/** Reminds users that playlist queueing is also available as a Discord slash command. */
+export function PlaylistDiscordHelp() {
+    return (
+        <p className="text-sm text-muted-foreground">
+            In Discord, use the bot slash command{" "}
+            <code className="rounded bg-muted px-1">/playlist play</code> with the{" "}
+            <code className="rounded bg-muted px-1">name</code> option to queue a saved playlist
+            (optional <code className="rounded bg-muted px-1">shuffle</code>). Other subcommands:{" "}
+            <code className="rounded bg-muted px-1">create</code>,{" "}
+            <code className="rounded bg-muted px-1">add</code>,{" "}
+            <code className="rounded bg-muted px-1">list</code>,{" "}
+            <code className="rounded bg-muted px-1">view</code>,{" "}
+            <code className="rounded bg-muted px-1">remove</code>,{" "}
+            <code className="rounded bg-muted px-1">delete</code>.
+        </p>
+    )
+}

--- a/src/web/components/PlaylistTrackList.tsx
+++ b/src/web/components/PlaylistTrackList.tsx
@@ -1,0 +1,228 @@
+﻿"use client"
+
+import { useRouter } from "next/navigation"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { DragEvent } from "react"
+import Link from "next/link"
+import {
+    deletePlaylistAction,
+    movePlaylistTrackAction,
+    removeTrackFromPlaylistAction,
+} from "@/lib/actions/playlist.actions"
+import { formatDurationMs } from "@/lib/format-duration"
+import { AddTrackToPlaylistForm } from "@/components/AddTrackToPlaylistForm"
+import { PlaylistDiscordHelp } from "@/components/PlaylistDiscordHelp"
+import { PlaylistTrackRow } from "@/components/PlaylistTrackRow"
+import { Button } from "@/components/ui/button"
+import type { PlaylistTrackData } from "@/types/web"
+
+export interface PlaylistTrackListProps {
+    playlistId: number
+    playlistName: string
+    tracks: PlaylistTrackData[]
+    guildId?: string
+}
+
+function sortTracks(tracks: PlaylistTrackData[]): PlaylistTrackData[] {
+    return [...tracks].sort((a, b) => a.position - b.position)
+}
+
+export function PlaylistTrackList({
+    playlistId,
+    playlistName,
+    tracks,
+    guildId,
+}: PlaylistTrackListProps) {
+    const router = useRouter()
+    const [confirmDeletePlaylist, setConfirmDeletePlaylist] = useState(false)
+    const [busy, setBusy] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [orderedTracks, setOrderedTracks] = useState(() => sortTracks(tracks))
+    const [dragIndex, setDragIndex] = useState<number | null>(null)
+    const [overIndex, setOverIndex] = useState<number | null>(null)
+    const dragIndexRef = useRef<number | null>(null)
+
+    useEffect(() => {
+        setOrderedTracks(sortTracks(tracks))
+    }, [tracks])
+
+    const totalDurationMs = useMemo(
+        () => orderedTracks.reduce((acc, t) => acc + t.duration, 0),
+        [orderedTracks]
+    )
+
+    const handleDragStart = useCallback((index: number, event: DragEvent<HTMLLIElement>) => {
+        dragIndexRef.current = index
+        setDragIndex(index)
+        event.dataTransfer.effectAllowed = "move"
+        event.dataTransfer.setData("text/plain", String(index))
+    }, [])
+
+    const handleDragOver = useCallback((index: number, event: DragEvent<HTMLLIElement>) => {
+        event.preventDefault()
+        event.dataTransfer.dropEffect = "move"
+        setOverIndex(index)
+    }, [])
+
+    const handleDrop = useCallback(
+        (toIndex: number, event: DragEvent<HTMLLIElement>) => {
+            event.preventDefault()
+            const fromIndex = dragIndexRef.current
+            setOverIndex(null)
+            setDragIndex(null)
+            dragIndexRef.current = null
+
+            if (fromIndex === null || fromIndex === toIndex || busy) return
+
+            const previous = orderedTracks
+            const fromTrack = orderedTracks[fromIndex]
+            if (!fromTrack) return
+
+            const next = [...orderedTracks]
+            next.splice(fromIndex, 1)
+            next.splice(toIndex, 0, fromTrack)
+            setOrderedTracks(next)
+
+            void (async () => {
+                setBusy(true)
+                setError(null)
+                const result = await movePlaylistTrackAction(
+                    playlistId,
+                    fromTrack.position,
+                    toIndex + 1
+                )
+                setBusy(false)
+                if (result.ok === false) {
+                    setError(result.error)
+                    setOrderedTracks(previous)
+                    return
+                }
+                router.refresh()
+            })()
+        },
+        [busy, orderedTracks, playlistId, router]
+    )
+
+    const handleRemove = useCallback(
+        (position: number) => {
+            void (async () => {
+                setBusy(true)
+                setError(null)
+                const result = await removeTrackFromPlaylistAction(playlistId, position)
+                setBusy(false)
+                if (result.ok === false) {
+                    setError(result.error)
+                    return
+                }
+                router.refresh()
+            })()
+        },
+        [playlistId, router]
+    )
+
+    const handleDragEnd = useCallback(() => {
+        dragIndexRef.current = null
+        setDragIndex(null)
+        setOverIndex(null)
+    }, [])
+
+    return (
+        <div className="space-y-6">
+            <section className="rounded border bg-card p-4 text-card-foreground">
+                <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                        <h1 className="text-xl font-semibold">{playlistName}</h1>
+                        <p className="text-sm text-muted-foreground">
+                            {orderedTracks.length} track{orderedTracks.length === 1 ? "" : "s"} ·{" "}
+                            {formatDurationMs(totalDurationMs)}
+                        </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                        <Button variant="outline" size="sm" asChild>
+                            <Link href="/playlists">Back to playlists</Link>
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            size="sm"
+                            disabled={busy}
+                            onClick={() => {
+                                if (!confirmDeletePlaylist) {
+                                    setConfirmDeletePlaylist(true)
+                                    return
+                                }
+                                void (async () => {
+                                    setBusy(true)
+                                    setError(null)
+                                    const result = await deletePlaylistAction(playlistId)
+                                    setBusy(false)
+                                    if (result.ok === false) {
+                                        setError(result.error)
+                                        setConfirmDeletePlaylist(false)
+                                        return
+                                    }
+                                    router.push("/playlists")
+                                })()
+                            }}
+                        >
+                            {confirmDeletePlaylist ? "Confirm delete playlist" : "Delete playlist"}
+                        </Button>
+                        {confirmDeletePlaylist ? (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={busy}
+                                onClick={() => setConfirmDeletePlaylist(false)}
+                            >
+                                Cancel
+                            </Button>
+                        ) : null}
+                    </div>
+                </div>
+                <PlaylistDiscordHelp />
+            </section>
+
+            <section className="rounded border bg-card p-4 text-card-foreground">
+                <h2 className="mb-3 text-lg font-medium">Add a song</h2>
+                <AddTrackToPlaylistForm playlistId={playlistId} guildId={guildId} />
+            </section>
+
+            <section className="rounded border bg-card p-4 text-card-foreground">
+                <h2 className="mb-3 text-lg font-medium">Tracks</h2>
+                <p className="mb-3 text-sm text-muted-foreground">
+                    Drag tracks by the grip handle to reorder. Hover a track for details like the
+                    queue.
+                </p>
+                {error ? (
+                    <p className="mb-3 text-sm text-destructive" role="alert">
+                        {error}
+                    </p>
+                ) : null}
+                {orderedTracks.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No tracks yet. Add songs above or use{" "}
+                        <code className="rounded bg-muted px-1">/playlist add</code> in Discord.
+                    </p>
+                ) : (
+                    <ul className="space-y-2">
+                        {orderedTracks.map((track, index) => (
+                            <PlaylistTrackRow
+                                key={track.id}
+                                track={track}
+                                displayIndex={index + 1}
+                                busy={busy}
+                                isDragging={dragIndex === index}
+                                isDropTarget={overIndex === index && dragIndex !== index}
+                                onRemove={() => handleRemove(track.position)}
+                                onDragStart={(event) => handleDragStart(index, event)}
+                                onDragOver={(event) => handleDragOver(index, event)}
+                                onDragLeave={() => setOverIndex(null)}
+                                onDrop={(event) => handleDrop(index, event)}
+                                onDragEnd={handleDragEnd}
+                            />
+                        ))}
+                    </ul>
+                )}
+            </section>
+        </div>
+    )
+}

--- a/src/web/components/PlaylistTrackList.tsx
+++ b/src/web/components/PlaylistTrackList.tsx
@@ -74,16 +74,19 @@ export function PlaylistTrackList({
 
             if (fromIndex === null || fromIndex === toIndex || busy) return
 
-            const previous = orderedTracks
+            const previous = orderedTracks.map((track) => ({ ...track }))
             const fromTrack = orderedTracks[fromIndex]
             if (!fromTrack) return
+            const originalFromPosition = fromTrack.position
 
-            const next = [...orderedTracks]
-            next.splice(fromIndex, 1)
-            next.splice(toIndex, 0, fromTrack)
-            next.forEach((track, index) => {
-                track.position = index + 1
-            })
+            const reordered = [...orderedTracks]
+            const [moved] = reordered.splice(fromIndex, 1)
+            if (!moved) return
+            reordered.splice(toIndex, 0, moved)
+            const next = reordered.map((track, index) => ({
+                ...track,
+                position: index + 1,
+            }))
             setOrderedTracks(next)
 
             void (async () => {
@@ -91,7 +94,7 @@ export function PlaylistTrackList({
                 setError(null)
                 const result = await movePlaylistTrackAction(
                     playlistId,
-                    fromTrack.position,
+                    originalFromPosition,
                     toIndex + 1
                 )
                 setBusy(false)

--- a/src/web/components/PlaylistTrackList.tsx
+++ b/src/web/components/PlaylistTrackList.tsx
@@ -81,6 +81,9 @@ export function PlaylistTrackList({
             const next = [...orderedTracks]
             next.splice(fromIndex, 1)
             next.splice(toIndex, 0, fromTrack)
+            next.forEach((track, index) => {
+                track.position = index + 1
+            })
             setOrderedTracks(next)
 
             void (async () => {

--- a/src/web/components/PlaylistTrackRow.tsx
+++ b/src/web/components/PlaylistTrackRow.tsx
@@ -1,0 +1,218 @@
+﻿"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import type { DragEvent, FocusEvent } from "react"
+import { GripVertical } from "lucide-react"
+import { formatDurationMs } from "@/lib/format-duration"
+import { playlistTrackThumbnailUrl } from "@/lib/playlist-thumbnail"
+import { sanitizeHttpUrl } from "@/lib/url-utils"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type { PlaylistTrackData } from "@/types/web"
+
+const POPOVER_WIDTH_PX = 320
+const POPOVER_CURSOR_GAP_PX = 10
+
+function clampPopoverPoint(left: number, top: number): { left: number; top: number } {
+    const margin = 8
+    const halfHeightEstimate = 80
+    const maxLeft = window.innerWidth - POPOVER_WIDTH_PX - margin
+    const clampedLeft = Math.max(margin, Math.min(left, maxLeft))
+    const clampedTop = Math.max(
+        halfHeightEstimate + margin,
+        Math.min(top, window.innerHeight - halfHeightEstimate - margin)
+    )
+    return { left: clampedLeft, top: clampedTop }
+}
+
+export interface PlaylistTrackRowProps {
+    track: PlaylistTrackData
+    displayIndex: number
+    busy: boolean
+    isDragging: boolean
+    isDropTarget: boolean
+    onRemove: () => void
+    onDragStart: (event: DragEvent<HTMLLIElement>) => void
+    onDragOver: (event: DragEvent<HTMLLIElement>) => void
+    onDragLeave: () => void
+    onDrop: (event: DragEvent<HTMLLIElement>) => void
+    onDragEnd: () => void
+}
+
+export function PlaylistTrackRow({
+    track,
+    displayIndex,
+    busy,
+    isDragging,
+    isDropTarget,
+    onRemove,
+    onDragStart,
+    onDragOver,
+    onDragLeave,
+    onDrop,
+    onDragEnd,
+}: PlaylistTrackRowProps) {
+    const liRef = useRef<HTMLLIElement>(null)
+    const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null)
+    const hoverRafRef = useRef<number | null>(null)
+    const pendingAnchorRef = useRef<{ x: number; y: number } | null>(null)
+
+    const safeTrackUrl = useMemo(() => sanitizeHttpUrl(track.uri), [track.uri])
+    const safeThumbnailUrl = useMemo(() => playlistTrackThumbnailUrl(track), [track])
+
+    const popoverLayout = anchor
+        ? clampPopoverPoint(anchor.x + POPOVER_CURSOR_GAP_PX, anchor.y)
+        : null
+
+    const clearScheduledAnchorUpdate = () => {
+        if (hoverRafRef.current !== null) {
+            window.cancelAnimationFrame(hoverRafRef.current)
+            hoverRafRef.current = null
+        }
+        pendingAnchorRef.current = null
+    }
+
+    const scheduleAnchorUpdate = (x: number, y: number) => {
+        pendingAnchorRef.current = { x, y }
+        if (hoverRafRef.current !== null) return
+        hoverRafRef.current = window.requestAnimationFrame(() => {
+            hoverRafRef.current = null
+            if (pendingAnchorRef.current) {
+                setAnchor(pendingAnchorRef.current)
+            }
+        })
+    }
+
+    useEffect(() => {
+        return () => {
+            clearScheduledAnchorUpdate()
+        }
+    }, [])
+
+    const handleRowFocus = (event: FocusEvent<HTMLElement>) => {
+        const rect = event.currentTarget.getBoundingClientRect()
+        setAnchor({
+            x: rect.right,
+            y: rect.top + rect.height / 2,
+        })
+    }
+
+    const handleRowBlur = (event: FocusEvent<HTMLElement>) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+            setAnchor(null)
+        }
+    }
+
+    const rowLine = (
+        <>
+            <p className="font-medium">
+                {displayIndex}. {track.title}
+            </p>
+            <p className="text-sm text-muted-foreground">
+                {track.author} · {formatDurationMs(track.duration)}
+            </p>
+        </>
+    )
+
+    const hoverSurfaceClass =
+        "-m-2 block cursor-pointer rounded-sm p-2 text-inherit no-underline decoration-transparent outline-none ring-offset-background transition-colors hover:bg-accent/50 hover:no-underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+
+    return (
+        <li
+            ref={liRef}
+            draggable={!busy}
+            onDragStart={onDragStart}
+            onDragOver={onDragOver}
+            onDragLeave={onDragLeave}
+            onDrop={onDrop}
+            onDragEnd={onDragEnd}
+            className={cn(
+                "flex items-start gap-2 rounded border bg-background p-2 transition-colors",
+                isDragging && "opacity-50",
+                isDropTarget && "border-primary ring-2 ring-ring ring-offset-2 ring-offset-background"
+            )}
+            onMouseMove={(event) => scheduleAnchorUpdate(event.clientX, event.clientY)}
+            onMouseLeave={() => {
+                clearScheduledAnchorUpdate()
+                window.requestAnimationFrame(() => {
+                    if (!liRef.current?.contains(document.activeElement)) {
+                        setAnchor(null)
+                    }
+                })
+            }}
+        >
+            <span
+                className="mt-0.5 shrink-0 cursor-grab touch-none rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground active:cursor-grabbing aria-disabled:opacity-50"
+                aria-label={`Drag to reorder track ${displayIndex}`}
+                aria-disabled={busy}
+            >
+                <GripVertical className="h-4 w-4" aria-hidden />
+            </span>
+            <span className="min-w-0 flex-1">
+                {safeTrackUrl ? (
+                    <a
+                        href={safeTrackUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        draggable={false}
+                        className={hoverSurfaceClass}
+                        aria-label={`Open track source: ${track.title}`}
+                        onFocus={handleRowFocus}
+                        onBlur={handleRowBlur}
+                    >
+                        {rowLine}
+                    </a>
+                ) : (
+                    <span
+                        className={hoverSurfaceClass}
+                        tabIndex={0}
+                        role="button"
+                        onFocus={handleRowFocus}
+                        onBlur={handleRowBlur}
+                    >
+                        {rowLine}
+                    </span>
+                )}
+            </span>
+            <Button
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                disabled={busy}
+                onClick={onRemove}
+            >
+                Remove
+            </Button>
+            {popoverLayout ? (
+                <aside
+                    className="fixed z-50 w-80 -translate-y-1/2 rounded border bg-popover p-3 text-popover-foreground shadow-lg"
+                    style={{ left: popoverLayout.left, top: popoverLayout.top }}
+                >
+                    <div className="flex gap-3">
+                        {safeThumbnailUrl ? (
+                            <img
+                                src={safeThumbnailUrl}
+                                alt="playlist track artwork"
+                                className="h-16 w-16 shrink-0 rounded object-cover"
+                            />
+                        ) : (
+                            <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded bg-muted text-xs text-muted-foreground">
+                                No Art
+                            </div>
+                        )}
+                        <div className="min-w-0 space-y-1 text-sm">
+                            <p className="truncate font-medium">{track.title}</p>
+                            <p className="text-muted-foreground">
+                                Duration: {formatDurationMs(track.duration)}
+                            </p>
+                            <p className="text-muted-foreground">Artist: {track.author}</p>
+                            {safeTrackUrl ? (
+                                <p className="truncate text-muted-foreground">Source: {safeTrackUrl}</p>
+                            ) : null}
+                        </div>
+                    </div>
+                </aside>
+            ) : null}
+        </li>
+    )
+}

--- a/src/web/components/PlaylistTrackRow.tsx
+++ b/src/web/components/PlaylistTrackRow.tsx
@@ -163,15 +163,7 @@ export function PlaylistTrackRow({
                         {rowLine}
                     </a>
                 ) : (
-                    <span
-                        className={hoverSurfaceClass}
-                        tabIndex={0}
-                        role="button"
-                        onFocus={handleRowFocus}
-                        onBlur={handleRowBlur}
-                    >
-                        {rowLine}
-                    </span>
+                    <span className={hoverSurfaceClass}>{rowLine}</span>
                 )}
             </span>
             <Button

--- a/src/web/components/UserHeader.tsx
+++ b/src/web/components/UserHeader.tsx
@@ -23,9 +23,18 @@ export function UserHeader() {
 
     return (
         <div className="flex items-center justify-between">
-            <Link href="/dashboard" prefetch={false} className="font-semibold">
-                DimbyBot Dashboard
-            </Link>
+            <div className="flex items-center gap-4">
+                <Link href="/dashboard" prefetch={false} className="font-semibold">
+                    DimbyBot Dashboard
+                </Link>
+                <Link
+                    href="/playlists"
+                    prefetch={false}
+                    className="text-sm text-muted-foreground hover:text-foreground"
+                >
+                    Playlists
+                </Link>
+            </div>
 
             <div className="flex items-center gap-3">
                 <div className="text-sm text-muted-foreground">

--- a/src/web/lib/actions/playlist.actions.ts
+++ b/src/web/lib/actions/playlist.actions.ts
@@ -47,8 +47,18 @@ async function parseApiResponse<T>(res: Response): Promise<Ok<T> | Err> {
         return { ok: false, error: `Request failed (${res.status}).` }
     }
     if (payload.ok === false) {
-        const msg = payload.error.details || payload.error.error || "Bot API returned an error."
-        return { ok: false, error: msg }
+        const err: unknown = payload.error
+        if (err != null && typeof err === "object") {
+            const errObj = err as { error?: string; details?: string }
+            const msg =
+                [errObj.details, errObj.error].filter(Boolean).join(" — ") ||
+                "Bot API returned an error."
+            return { ok: false, error: msg }
+        }
+        if (typeof err === "string" && err.trim()) {
+            return { ok: false, error: err.trim() }
+        }
+        return { ok: false, error: "Bot API returned an error." }
     }
     if (payload.data === undefined || payload.data === null) {
         return { ok: false, error: "Bot API returned success without data." }

--- a/src/web/lib/actions/playlist.actions.ts
+++ b/src/web/lib/actions/playlist.actions.ts
@@ -1,0 +1,198 @@
+"use server"
+
+import type {
+    AddPlaylistTrackBody,
+    AddPlaylistTrackFromQueryBody,
+    AddTracksFromQueryResponse,
+    ApiResponse,
+    PlaylistData,
+    PlaylistListResponse,
+    PlaylistPlayResponse,
+    PlaylistTrackData,
+} from "@/types/web"
+import { serverFetchBot } from "@/server/fetch-bot-api"
+
+type Ok<T> = { ok: true; data: T }
+type Err = { ok: false; error: string }
+
+async function parseApiResponse<T>(res: Response): Promise<Ok<T> | Err> {
+    const text = await res.text()
+    if (!text.trim()) {
+        return {
+            ok: false,
+            error: res.ok
+                ? "Empty response from bot API."
+                : `Request failed (${res.status}): empty body.`,
+        }
+    }
+    let payload: ApiResponse<T>
+    try {
+        payload = JSON.parse(text) as ApiResponse<T>
+    } catch {
+        return {
+            ok: false,
+            error: res.ok
+                ? "Invalid JSON from bot API."
+                : `Request failed (${res.status}): invalid JSON.`,
+        }
+    }
+    if (!res.ok) {
+        if (payload.ok === false && payload.error && typeof payload.error === "object") {
+            const errObj = payload.error as { error?: string; details?: string }
+            const msg =
+                [errObj.details, errObj.error].filter(Boolean).join(" — ") ||
+                `Request failed (${res.status}).`
+            return { ok: false, error: msg }
+        }
+        return { ok: false, error: `Request failed (${res.status}).` }
+    }
+    if (payload.ok === false) {
+        const msg = payload.error.details || payload.error.error || "Bot API returned an error."
+        return { ok: false, error: msg }
+    }
+    if (payload.data === undefined || payload.data === null) {
+        return { ok: false, error: "Bot API returned success without data." }
+    }
+    return { ok: true, data: payload.data }
+}
+
+export async function getPlaylistsAction(): Promise<Ok<PlaylistListResponse> | Err> {
+    try {
+        const res = await serverFetchBot("/api/playlists")
+        return parseApiResponse<PlaylistListResponse>(res)
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Failed to load playlists."
+        return { ok: false, error: message }
+    }
+}
+
+export async function getPlaylistAction(
+    playlistId: number
+): Promise<Ok<PlaylistData> | Err> {
+    try {
+        const res = await serverFetchBot(`/api/playlists/${playlistId}`)
+        return parseApiResponse<PlaylistData>(res)
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Failed to load playlist."
+        return { ok: false, error: message }
+    }
+}
+
+export async function createPlaylistAction(name: string): Promise<Ok<PlaylistData> | Err> {
+    try {
+        const res = await serverFetchBot("/api/playlists", {
+            method: "POST",
+            body: JSON.stringify({ name }),
+            contentType: "application/json",
+        })
+        return parseApiResponse<PlaylistData>(res)
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Failed to create playlist."
+        return { ok: false, error: message }
+    }
+}
+
+export async function deletePlaylistAction(
+    playlistId: number
+): Promise<Ok<{ deleted: true }> | Err> {
+    try {
+        const res = await serverFetchBot(`/api/playlists/${playlistId}`, {
+            method: "DELETE",
+        })
+        return parseApiResponse<{ deleted: true }>(res)
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Failed to delete playlist."
+        return { ok: false, error: message }
+    }
+}
+
+export async function addTrackToPlaylistAction(
+    playlistId: number,
+    track: AddPlaylistTrackBody
+): Promise<Ok<PlaylistTrackData> | Err> {
+    try {
+        const res = await serverFetchBot(`/api/playlists/${playlistId}/tracks`, {
+            method: "POST",
+            body: JSON.stringify(track),
+            contentType: "application/json",
+        })
+        return parseApiResponse<PlaylistTrackData>(res)
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Failed to add track."
+        return { ok: false, error: message }
+    }
+}
+
+export async function removeTrackFromPlaylistAction(
+    playlistId: number,
+    position: number
+): Promise<Ok<{ removed: true }> | Err> {
+    try {
+        const res = await serverFetchBot(
+            `/api/playlists/${playlistId}/tracks/${position}`,
+            { method: "DELETE" }
+        )
+        return parseApiResponse<{ removed: true }>(res)
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Failed to remove track."
+        return { ok: false, error: message }
+    }
+}
+
+export async function addTrackFromQueryToPlaylistAction(
+    playlistId: number,
+    body: AddPlaylistTrackFromQueryBody
+): Promise<Ok<AddTracksFromQueryResponse> | Err> {
+    try {
+        const res = await serverFetchBot(`/api/playlists/${playlistId}/tracks/from-query`, {
+            method: "POST",
+            body: JSON.stringify(body),
+            contentType: "application/json",
+        })
+        return parseApiResponse<AddTracksFromQueryResponse>(res)
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Failed to add track."
+        return { ok: false, error: message }
+    }
+}
+
+export async function movePlaylistTrackAction(
+    playlistId: number,
+    position: number,
+    newPosition: number
+): Promise<Ok<PlaylistData> | Err> {
+    try {
+        const res = await serverFetchBot(`/api/playlists/${playlistId}/tracks/${position}`, {
+            method: "PATCH",
+            body: JSON.stringify({ newPosition }),
+            contentType: "application/json",
+        })
+        return parseApiResponse<PlaylistData>(res)
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Failed to reorder track."
+        return { ok: false, error: message }
+    }
+}
+
+export async function playPlaylistInGuildAction(
+    guildId: string,
+    playlistId: number,
+    requesterDiscordUserId: string,
+    shuffle = false
+): Promise<Ok<PlaylistPlayResponse> | Err> {
+    try {
+        const res = await serverFetchBot(`/api/guilds/${guildId}/player/play-playlist`, {
+            method: "POST",
+            body: JSON.stringify({
+                playlistId,
+                shuffle,
+                requesterDiscordUserId,
+            }),
+            contentType: "application/json",
+        })
+        return parseApiResponse<PlaylistPlayResponse>(res)
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Failed to queue playlist."
+        return { ok: false, error: message }
+    }
+}

--- a/src/web/lib/actions/playlist.actions.ts
+++ b/src/web/lib/actions/playlist.actions.ts
@@ -10,6 +10,7 @@ import type {
     PlaylistPlayResponse,
     PlaylistTrackData,
 } from "@/types/web"
+import { playlistPlayTimeoutMs } from "@/lib/playlist-play-timeout"
 import { serverFetchBot } from "@/server/fetch-bot-api"
 
 type Ok<T> = { ok: true; data: T }
@@ -188,7 +189,8 @@ export async function playPlaylistInGuildAction(
     guildId: string,
     playlistId: number,
     requesterDiscordUserId: string,
-    shuffle = false
+    shuffle = false,
+    trackCount?: number
 ): Promise<Ok<PlaylistPlayResponse> | Err> {
     try {
         const res = await serverFetchBot(`/api/guilds/${guildId}/player/play-playlist`, {
@@ -199,8 +201,17 @@ export async function playPlaylistInGuildAction(
                 requesterDiscordUserId,
             }),
             contentType: "application/json",
+            timeoutMs: playlistPlayTimeoutMs(trackCount ?? 1),
         })
-        return parseApiResponse<PlaylistPlayResponse>(res)
+        const parsed = await parseApiResponse<PlaylistPlayResponse>(res)
+        if (parsed.ok === false && res.status === 504) {
+            return {
+                ok: false,
+                error:
+                    "The playlist is still loading on the bot but the dashboard timed out. Check the queue — tracks may appear shortly.",
+            }
+        }
+        return parsed
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : "Failed to queue playlist."
         return { ok: false, error: message }

--- a/src/web/lib/format-duration.ts
+++ b/src/web/lib/format-duration.ts
@@ -1,0 +1,17 @@
+/** Formats duration in milliseconds to MM:SS or HH:MM:SS. */
+export function formatDurationMs(ms: number): string {
+    if (ms <= 0 || !Number.isFinite(ms)) {
+        return "00:00"
+    }
+    const totalSeconds = Math.floor(ms / 1000)
+    const hours = Math.floor(totalSeconds / 3600)
+    const minutes = Math.floor((totalSeconds % 3600) / 60)
+    const seconds = totalSeconds % 60
+    const paddedSeconds = seconds.toString().padStart(2, "0")
+    const paddedMinutes = minutes.toString().padStart(2, "0")
+    if (hours > 0) {
+        const paddedHours = hours.toString().padStart(2, "0")
+        return `${paddedHours}:${paddedMinutes}:${paddedSeconds}`
+    }
+    return `${paddedMinutes}:${paddedSeconds}`
+}

--- a/src/web/lib/playlist-play-timeout.ts
+++ b/src/web/lib/playlist-play-timeout.ts
@@ -1,0 +1,7 @@
+/** Scales bot API wait time with playlist size (Lavalink resolves one URI per track). */
+export function playlistPlayTimeoutMs(trackCount: number): number {
+    const count = Number.isFinite(trackCount) && trackCount > 0 ? Math.floor(trackCount) : 1
+    const baseMs = 30_000
+    const perTrackMs = 2_500
+    return Math.min(300_000, baseMs + count * perTrackMs)
+}

--- a/src/web/lib/playlist-thumbnail.ts
+++ b/src/web/lib/playlist-thumbnail.ts
@@ -4,7 +4,7 @@ function thumbnailUrlFromUri(uri: string): string | null {
     const trimmed = uri.trim()
     if (!trimmed) return null
     const match = trimmed.match(
-        /(?:youtube\.com\/(?:watch\?.*v=|embed\/|v\/)|youtu\.be\/|music\.youtube\.com\/watch\?.*v=)([a-zA-Z0-9_-]{11})/
+        /(?:youtube\.com\/(?:watch\?.*v=|embed\/|v\/|shorts\/)|youtu\.be\/|music\.youtube\.com\/watch\?.*v=)([a-zA-Z0-9_-]{11})/
     )
     if (match?.[1]) {
         return `https://img.youtube.com/vi/${match[1]}/hqdefault.jpg`
@@ -17,8 +17,7 @@ export function playlistTrackThumbnailUrl(track: {
     thumbnailUrl: string | null
     uri: string
 }): string | null {
-    if (track.thumbnailUrl) {
-        return sanitizeHttpUrl(track.thumbnailUrl)
-    }
+    const stored = track.thumbnailUrl ? sanitizeHttpUrl(track.thumbnailUrl) : null
+    if (stored) return stored
     return sanitizeHttpUrl(thumbnailUrlFromUri(track.uri))
 }

--- a/src/web/lib/playlist-thumbnail.ts
+++ b/src/web/lib/playlist-thumbnail.ts
@@ -1,0 +1,24 @@
+import { sanitizeHttpUrl } from "@/lib/url-utils"
+
+function thumbnailUrlFromUri(uri: string): string | null {
+    const trimmed = uri.trim()
+    if (!trimmed) return null
+    const match = trimmed.match(
+        /(?:youtube\.com\/(?:watch\?.*v=|embed\/|v\/)|youtu\.be\/|music\.youtube\.com\/watch\?.*v=)([a-zA-Z0-9_-]{11})/
+    )
+    if (match?.[1]) {
+        return `https://img.youtube.com/vi/${match[1]}/hqdefault.jpg`
+    }
+    return null
+}
+
+/** Stored artwork when available; YouTube URI fallback for older rows. */
+export function playlistTrackThumbnailUrl(track: {
+    thumbnailUrl: string | null
+    uri: string
+}): string | null {
+    if (track.thumbnailUrl) {
+        return sanitizeHttpUrl(track.thumbnailUrl)
+    }
+    return sanitizeHttpUrl(thumbnailUrlFromUri(track.uri))
+}

--- a/src/web/server/fetch-bot-api.ts
+++ b/src/web/server/fetch-bot-api.ts
@@ -2,17 +2,26 @@ import { headers } from "next/headers"
 import { getBotApiOrigin } from "@/server/bot-api-origin"
 import { isBotApiVerbose, logBotApiVerbose } from "@/server/bot-api-verbose"
 
-const UPSTREAM_FETCH_TIMEOUT_MS = 10_000
+const DEFAULT_UPSTREAM_FETCH_TIMEOUT_MS = 10_000
+const MAX_UPSTREAM_FETCH_TIMEOUT_MS = 300_000
 
 /**
  * Calls the bot REST API from the Next server using the current request cookies (session).
  */
+function resolveFetchTimeoutMs(timeoutMs?: number): number {
+    if (timeoutMs === undefined) return DEFAULT_UPSTREAM_FETCH_TIMEOUT_MS
+    if (!Number.isFinite(timeoutMs)) return DEFAULT_UPSTREAM_FETCH_TIMEOUT_MS
+    return Math.min(Math.max(Math.floor(timeoutMs), 1000), MAX_UPSTREAM_FETCH_TIMEOUT_MS)
+}
+
 export async function serverFetchBot(
     pathnameAndSearch: string,
     options?: {
         method?: string
         body?: string
         contentType?: string
+        /** Override default 10s timeout (e.g. large playlist queue loads). */
+        timeoutMs?: number
     }
 ): Promise<Response> {
     let origin: string | null
@@ -85,7 +94,10 @@ export async function serverFetchBot(
     const controller = new AbortController()
     let timeoutId: ReturnType<typeof setTimeout> | undefined
     try {
-        timeoutId = setTimeout(() => controller.abort(), UPSTREAM_FETCH_TIMEOUT_MS)
+        timeoutId = setTimeout(
+            () => controller.abort(),
+            resolveFetchTimeoutMs(options?.timeoutMs)
+        )
         const res = await fetch(url, {
             method,
             headers: outHeaders,


### PR DESCRIPTION
## Summary
- Add per-user playlists: Prisma models and migrations, repository layer, `/playlist` Discord command, authenticated bot REST API, and `/playlists` web dashboard (create, view, add tracks from search/URLs, drag reorder, thumbnails).
- Extend the player panel with Add to playlist and Load playlist menus; play saved playlists into the guild queue via API.
- Improve dashboard navigation: guild list cards show live player status (track, queue, voice); floating **Go to now playing** when sharing a VC with an active bot session.
- Speed up Docker builds and dev reload: narrow `chown` to small paths, TypeScript/nodemon polling for bind mounts on Windows.

## Test plan
- [ ] Run Prisma migrations (`yarn prisma migrate deploy` or `migrate dev`)
- [ ] Deploy slash commands (`yarn build` + `yarn deployGlobal`) and restart bot + web
- [ ] Create/list/edit playlists on web; add single tracks and YouTube playlist URLs
- [ ] Drag-reorder tracks; confirm hover popover shows artwork
- [ ] Load playlist from player panel; verify queue clears and enqueues
- [ ] Join VC with bot playing; confirm guild cards and floating shortcut on `/dashboard` and `/playlists`
- [ ] Confirm shortcut hidden on `/dashboard/[guildId]`