### PR TITLE
Harden dashboard auth against phishing heuristics

### DIFF
--- a/src/shared/auth-base-config.ts
+++ b/src/shared/auth-base-config.ts
@@ -70,11 +70,20 @@ export function getBetterAuthBaseConfig() {
     const betterAuthUrl = getRequiredEnv("BETTER_AUTH_URL")
     const discordOAuthClientId = getRequiredEnv("CLIENT_ID")
     const discordOAuthClientSecret = getRequiredEnv("DISCORD_CLIENT_SECRET")
+    const isProduction = process.env.NODE_ENV === "production"
 
     return {
         secret: betterAuthSecret,
         baseURL: betterAuthUrl,
         trustedOrigins: [betterAuthUrl],
+        advanced: {
+            useSecureCookies: isProduction,
+            defaultCookieAttributes: {
+                secure: isProduction,
+                httpOnly: true,
+                sameSite: "lax" as const,
+            },
+        },
         /** Encrypt OAuth tokens at rest; uses the same `secret` as signing (see Better Auth `account` plugin). */
         account: {
             encryptOAuthTokens: true,

--- a/src/web/app/page.tsx
+++ b/src/web/app/page.tsx
@@ -1,10 +1,35 @@
 import Link from "next/link"
+import { headers } from "next/headers"
 import { redirect } from "next/navigation"
 import { LoginButton } from "@/components/LoginButton"
 import { readSessionSafe, type SessionReadFailureKind } from "@/server/auth-session"
 
 /** Session read uses `headers()`; avoid any static/CDN caching of personalized HTML. */
 export const dynamic = "force-dynamic"
+
+function readPublicOrigin(): string | null {
+    const configured = process.env.BETTER_AUTH_URL?.trim()
+    if (configured) {
+        try {
+            return new URL(configured).origin
+        } catch {
+            // fall through to request headers
+        }
+    }
+    return null
+}
+
+function readRequestOrigin(h: Headers): string {
+    const configured = readPublicOrigin()
+    if (configured) return configured
+
+    const forwardedHost = h.get("x-forwarded-host")?.split(",")[0]?.trim()
+    const host = forwardedHost || h.get("host")?.trim()
+    if (!host) return "this site"
+
+    const proto = h.get("x-forwarded-proto")?.split(",")[0]?.trim() || "https"
+    return `${proto}://${host}`
+}
 
 function sessionFailureHint(kind: SessionReadFailureKind): string {
     switch (kind) {
@@ -25,6 +50,8 @@ export default async function HomePage() {
         redirect("/dashboard")
     }
     const sessionReadError = sessionResult.ok === false ? sessionResult : null
+    const h = await headers()
+    const publicOrigin = readRequestOrigin(h)
 
     return (
         <main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col items-center justify-center px-6 text-center">
@@ -32,6 +59,12 @@ export default async function HomePage() {
             <p className="mt-2 text-muted-foreground">
                 Sign in with Discord to control music playback.
             </p>
+            <p className="mt-2 max-w-md text-sm text-muted-foreground">
+                You&apos;ll be redirected to{" "}
+                <strong className="text-foreground">discord.com</strong> to authorize DimbyBot. This
+                app never sees your Discord password.
+            </p>
+            <p className="mt-1 font-mono text-xs text-muted-foreground">{publicOrigin}</p>
             {sessionReadError ? (
                 <div className="mt-6 w-full max-w-md rounded-lg border border-amber-500/40 bg-amber-500/10 p-4 text-left text-sm">
                     <p className="font-medium text-foreground">

--- a/src/web/components/LoginButton.tsx
+++ b/src/web/components/LoginButton.tsx
@@ -4,6 +4,20 @@ import { useState } from "react"
 import { authClient } from "@/auth-client"
 import { toast } from "sonner"
 
+function DiscordLogo({ className }: { className?: string }) {
+    return (
+        <svg
+            className={className}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            fill="currentColor"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.2252 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189z" />
+        </svg>
+    )
+}
+
 export function LoginButton() {
     const [isSigning, setIsSigning] = useState(false)
     const onSignIn = async () => {
@@ -25,13 +39,20 @@ export function LoginButton() {
     }
 
     return (
-        <button
-            type="button"
-            disabled={isSigning}
-            onClick={() => void onSignIn()}
-            className="rounded bg-primary px-4 py-2 font-medium text-primary-foreground hover:opacity-90"
-        >
-            Sign in with Discord
-        </button>
+        <div className="flex flex-col items-center gap-3">
+            <button
+                type="button"
+                disabled={isSigning}
+                onClick={() => void onSignIn()}
+                className="inline-flex items-center gap-2 rounded-md bg-[#5865F2] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#4752C4] disabled:opacity-60"
+            >
+                <DiscordLogo className="h-5 w-5 shrink-0" />
+                {isSigning ? "Redirecting to Discord…" : "Sign in with Discord"}
+            </button>
+            <p className="max-w-sm text-xs text-muted-foreground">
+                Opens <span className="font-medium text-foreground">discord.com</span> in this
+                window. DimbyBot never asks for your Discord password.
+            </p>
+        </div>
     )
 }

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+
+/**
+ * Logs when the incoming Host does not match `BETTER_AUTH_URL` (www/scheme drift breaks OAuth cookies).
+ * Does not block requests — only surfaces misconfiguration in server logs.
+ */
+export function middleware(request: NextRequest): NextResponse {
+    const configuredUrl = process.env.BETTER_AUTH_URL?.trim()
+    if (!configuredUrl) {
+        return NextResponse.next()
+    }
+
+    try {
+        const expected = new URL(configuredUrl)
+        const forwardedHost = request.headers.get("x-forwarded-host")
+        const host =
+            forwardedHost?.split(",")[0]?.trim() ||
+            request.headers.get("host")?.trim() ||
+            request.nextUrl.host
+
+        if (host && host !== expected.host) {
+            console.warn(
+                `[middleware] Host mismatch: requestHost=${host} BETTER_AUTH_URL host=${expected.host} path=${request.nextUrl.pathname}`
+            )
+        }
+    } catch {
+        console.warn(
+            "[middleware] BETTER_AUTH_URL is not a valid URL; host alignment check skipped"
+        )
+    }
+
+    return NextResponse.next()
+}
+
+export const config = {
+    matcher: [
+        "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+    ],
+}

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -1,6 +1,17 @@
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 
+/** Lowercase and strip default HTTP(S) ports so `Host` and `BETTER_AUTH_URL` compare consistently. */
+function normalizeHost(host: string): string {
+    let normalized = host.trim().toLowerCase()
+    if (normalized.endsWith(":443")) {
+        normalized = normalized.slice(0, -4)
+    } else if (normalized.endsWith(":80")) {
+        normalized = normalized.slice(0, -3)
+    }
+    return normalized
+}
+
 /**
  * Logs when the incoming Host does not match `BETTER_AUTH_URL` (www/scheme drift breaks OAuth cookies).
  * Does not block requests — only surfaces misconfiguration in server logs.
@@ -19,9 +30,12 @@ export function middleware(request: NextRequest): NextResponse {
             request.headers.get("host")?.trim() ||
             request.nextUrl.host
 
-        if (host && host !== expected.host) {
+        const normalizedHost = host ? normalizeHost(host) : null
+        const normalizedExpectedHost = normalizeHost(expected.host)
+
+        if (normalizedHost && normalizedHost !== normalizedExpectedHost) {
             console.warn(
-                `[middleware] Host mismatch: requestHost=${host} BETTER_AUTH_URL host=${expected.host} path=${request.nextUrl.pathname}`
+                `[middleware] Host mismatch: normalizedHost=${normalizedHost} normalizedExpectedHost=${normalizedExpectedHost} path=${request.nextUrl.pathname}`
             )
         }
     } catch {

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -1,12 +1,22 @@
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 
-/** Lowercase and strip default HTTP(S) ports so `Host` and `BETTER_AUTH_URL` compare consistently. */
-function normalizeHost(host: string): string {
-    let normalized = host.trim().toLowerCase()
-    if (normalized.endsWith(":443")) {
+/** Lowercase and strip default ports only when they match the URL scheme (https→443, http→80). */
+function normalizeHost(host: string, protocol: string): string {
+    let hostPart = host.trim()
+    let scheme = protocol
+    const lowerInput = hostPart.toLowerCase()
+
+    if (lowerInput.startsWith("https://") || lowerInput.startsWith("http://")) {
+        const parsed = new URL(hostPart)
+        hostPart = parsed.host
+        scheme = parsed.protocol
+    }
+
+    let normalized = hostPart.toLowerCase()
+    if (scheme === "https:" && normalized.endsWith(":443")) {
         normalized = normalized.slice(0, -4)
-    } else if (normalized.endsWith(":80")) {
+    } else if (scheme === "http:" && normalized.endsWith(":80")) {
         normalized = normalized.slice(0, -3)
     }
     return normalized
@@ -30,8 +40,20 @@ export function middleware(request: NextRequest): NextResponse {
             request.headers.get("host")?.trim() ||
             request.nextUrl.host
 
-        const normalizedHost = host ? normalizeHost(host) : null
-        const normalizedExpectedHost = normalizeHost(expected.host)
+        const forwardedProto = request.headers
+            .get("x-forwarded-proto")
+            ?.split(",")[0]
+            ?.trim()
+            .toLowerCase()
+        const requestProtocol =
+            forwardedProto === "http"
+                ? "http:"
+                : forwardedProto === "https"
+                  ? "https:"
+                  : request.nextUrl.protocol
+
+        const normalizedHost = host ? normalizeHost(host, requestProtocol) : null
+        const normalizedExpectedHost = normalizeHost(expected.host, expected.protocol)
 
         if (normalizedHost && normalizedHost !== normalizedExpectedHost) {
             console.warn(

--- a/src/web/next.config.mjs
+++ b/src/web/next.config.mjs
@@ -1,9 +1,29 @@
 import path from "path"
 
+/** Security headers applied to all dashboard routes (anti-clickjacking + baseline hardening). */
+const securityHeaders = [
+    { key: "X-Frame-Options", value: "DENY" },
+    { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+    { key: "X-Content-Type-Options", value: "nosniff" },
+    { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+    {
+        key: "Permissions-Policy",
+        value: "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
+    },
+]
+
 /** @type {import("next").NextConfig} */
 const nextConfig = {
     reactStrictMode: true,
     output: "standalone",
+    async headers() {
+        return [
+            {
+                source: "/:path*",
+                headers: securityHeaders,
+            },
+        ]
+    },
     images: {
         remotePatterns: [
             {


### PR DESCRIPTION
## Summary
- Add anti-clickjacking and baseline security headers on all dashboard routes
- Set explicit production Better Auth cookie attributes (Secure, HttpOnly, SameSite=Lax)
- Clarify Discord OAuth flow on the login page with branded button and public origin display
- Log Host vs BETTER_AUTH_URL mismatches in middleware for OAuth misconfiguration detection

## Test plan
- [ ] Deploy and confirm response headers include X-Frame-Options: DENY and Content-Security-Policy: frame-ancestors 'none'
- [ ] Smoke-test Discord OAuth: / → discord.com → callback → /dashboard
- [ ] Verify session cookies are Secure/HttpOnly in production
- [ ] Re-check Google Safe Browsing status after deploy; request review if still flagged

Made with [Cursor](https://cursor.com)