### PR TITLE
fix(auth): align secure cookies between web and bot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
             postgres-db:
                 condition: service_healthy
         environment:
+            - NODE_ENV=production
             # These will be picked up by entrypoint.sh for lavaNodesConfig.js
             - LAVALINK_HOST=lavalink # Service name in this compose file
             - LAVALINK_PORT=${LAVALINK_PORT}

--- a/src/shared/auth-base-config.ts
+++ b/src/shared/auth-base-config.ts
@@ -70,16 +70,17 @@ export function getBetterAuthBaseConfig() {
     const betterAuthUrl = getRequiredEnv("BETTER_AUTH_URL")
     const discordOAuthClientId = getRequiredEnv("CLIENT_ID")
     const discordOAuthClientSecret = getRequiredEnv("DISCORD_CLIENT_SECRET")
-    const isProduction = process.env.NODE_ENV === "production"
+    /** Match web and bot: derive from public dashboard URL, not NODE_ENV (bot container often omits it). */
+    const useSecureCookies = betterAuthUrl.startsWith("https://")
 
     return {
         secret: betterAuthSecret,
         baseURL: betterAuthUrl,
         trustedOrigins: [betterAuthUrl],
         advanced: {
-            useSecureCookies: isProduction,
+            useSecureCookies,
             defaultCookieAttributes: {
-                secure: isProduction,
+                secure: useSecureCookies,
                 httpOnly: true,
                 sameSite: "lax" as const,
             },

--- a/src/web/server/bot-api-proxy.ts
+++ b/src/web/server/bot-api-proxy.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { randomUUID } from "node:crypto"
 import { getBotApiOrigin } from "@/server/bot-api-origin"
 import { isBotApiVerbose, logBotApiVerbose } from "@/server/bot-api-verbose"
+import { getOriginFallback } from "@/server/origin-fallback"
 
 function readBotApiProxyTimeoutMs(): number {
     const raw = process.env.BOT_API_PROXY_TIMEOUT_MS?.trim()
@@ -57,14 +58,8 @@ export async function proxyBotApi(request: Request): Promise<NextResponse> {
         if (value) headers.set(name, value)
     }
     if (!headers.has("origin")) {
-        const authUrl = process.env.BETTER_AUTH_URL?.trim()
-        if (authUrl) {
-            try {
-                headers.set("origin", new URL(authUrl).origin)
-            } catch {
-                /* ignore invalid BETTER_AUTH_URL */
-            }
-        }
+        const fallbackOrigin = getOriginFallback()
+        if (fallbackOrigin) headers.set("origin", fallbackOrigin)
     }
     const incomingCorrelationId = request.headers.get("x-correlation-id")
     const incomingRequestId = request.headers.get("x-request-id")

--- a/src/web/server/bot-api-proxy.ts
+++ b/src/web/server/bot-api-proxy.ts
@@ -52,9 +52,19 @@ export async function proxyBotApi(request: Request): Promise<NextResponse> {
     const targetUrl = `${origin}${incoming.pathname}${incoming.search}`
 
     const headers = new Headers()
-    for (const name of ["cookie", "authorization", "content-type"] as const) {
+    for (const name of ["cookie", "authorization", "content-type", "origin"] as const) {
         const value = request.headers.get(name)
         if (value) headers.set(name, value)
+    }
+    if (!headers.has("origin")) {
+        const authUrl = process.env.BETTER_AUTH_URL?.trim()
+        if (authUrl) {
+            try {
+                headers.set("origin", new URL(authUrl).origin)
+            } catch {
+                /* ignore invalid BETTER_AUTH_URL */
+            }
+        }
     }
     const incomingCorrelationId = request.headers.get("x-correlation-id")
     const incomingRequestId = request.headers.get("x-request-id")

--- a/src/web/server/fetch-bot-api.ts
+++ b/src/web/server/fetch-bot-api.ts
@@ -1,6 +1,7 @@
 import { headers } from "next/headers"
 import { getBotApiOrigin } from "@/server/bot-api-origin"
 import { isBotApiVerbose, logBotApiVerbose } from "@/server/bot-api-verbose"
+import { getOriginFallback } from "@/server/origin-fallback"
 
 const DEFAULT_UPSTREAM_FETCH_TIMEOUT_MS = 10_000
 const MAX_UPSTREAM_FETCH_TIMEOUT_MS = 300_000
@@ -74,14 +75,8 @@ export async function serverFetchBot(
     if (requestOrigin) {
         outHeaders.set("origin", requestOrigin)
     } else {
-        const authUrl = process.env.BETTER_AUTH_URL?.trim()
-        if (authUrl) {
-            try {
-                outHeaders.set("origin", new URL(authUrl).origin)
-            } catch {
-                /* ignore invalid BETTER_AUTH_URL */
-            }
-        }
+        const fallbackOrigin = getOriginFallback()
+        if (fallbackOrigin) outHeaders.set("origin", fallbackOrigin)
     }
 
     const method = (options?.method ?? "GET").toUpperCase()

--- a/src/web/server/fetch-bot-api.ts
+++ b/src/web/server/fetch-bot-api.ts
@@ -70,6 +70,19 @@ export async function serverFetchBot(
     if (cookie) outHeaders.set("cookie", cookie)
     const authorization = incoming.get("authorization")
     if (authorization) outHeaders.set("authorization", authorization)
+    const requestOrigin = incoming.get("origin")
+    if (requestOrigin) {
+        outHeaders.set("origin", requestOrigin)
+    } else {
+        const authUrl = process.env.BETTER_AUTH_URL?.trim()
+        if (authUrl) {
+            try {
+                outHeaders.set("origin", new URL(authUrl).origin)
+            } catch {
+                /* ignore invalid BETTER_AUTH_URL */
+            }
+        }
+    }
 
     const method = (options?.method ?? "GET").toUpperCase()
     if (options?.body != null && method !== "GET" && method !== "HEAD") {
@@ -94,10 +107,7 @@ export async function serverFetchBot(
     const controller = new AbortController()
     let timeoutId: ReturnType<typeof setTimeout> | undefined
     try {
-        timeoutId = setTimeout(
-            () => controller.abort(),
-            resolveFetchTimeoutMs(options?.timeoutMs)
-        )
+        timeoutId = setTimeout(() => controller.abort(), resolveFetchTimeoutMs(options?.timeoutMs))
         const res = await fetch(url, {
             method,
             headers: outHeaders,

--- a/src/web/server/origin-fallback.ts
+++ b/src/web/server/origin-fallback.ts
@@ -1,0 +1,10 @@
+/** Trusted Origin for dashboard→bot requests when the inbound request has no `Origin` header. */
+export function getOriginFallback(): string | null {
+    const authUrl = process.env.BETTER_AUTH_URL?.trim()
+    if (!authUrl) return null
+    try {
+        return new URL(authUrl).origin
+    } catch {
+        return null
+    }
+}


### PR DESCRIPTION
## Summary
- Derive Better Auth secure cookie settings from BETTER_AUTH_URL so web and bot use the same cookie names
- Forward Origin on dashboard-to-bot API calls for CSRF validation
- Set NODE_ENV=production on dimbybot for config parity

Fixes production Unauthorized errors after the auth hardening deploy when the dashboard shell looked logged in but guild/player API calls failed.

## Test plan
- [ ] Deploy both dimbybot-web and dimbybot
- [ ] Clear site cookies and sign in again
- [ ] Confirm guild list and player load without Unauthorized

Made with [Cursor](https://cursor.com)