### PR TITLE
fix(web): route OAuth failures to dedicated auth error page

### DIFF
--- a/src/shared/auth-base-config.ts
+++ b/src/shared/auth-base-config.ts
@@ -77,6 +77,10 @@ export function getBetterAuthBaseConfig() {
         secret: betterAuthSecret,
         baseURL: betterAuthUrl,
         trustedOrigins: [betterAuthUrl],
+        /** Failed OAuth/API auth redirects here instead of `/` (avoids login UI on callback error paths). */
+        onAPIError: {
+            errorURL: "/auth/error",
+        },
         advanced: {
             useSecureCookies,
             defaultCookieAttributes: {

--- a/src/web/app/auth/error/page.tsx
+++ b/src/web/app/auth/error/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { authErrorMessage } from "@/lib/auth-error-message"
+
+export const dynamic = "force-dynamic"
+
+export const metadata: Metadata = {
+    title: "Sign-in error — DimbyBot Dashboard",
+    description: "Discord OAuth sign-in could not be completed.",
+}
+
+type AuthErrorPageProps = {
+    searchParams: Promise<{ error?: string; error_description?: string }>
+}
+
+/** Shown when Discord OAuth or Better Auth fails — intentionally not a login form. */
+export default async function AuthErrorPage({ searchParams }: AuthErrorPageProps) {
+    const { error, error_description } = await searchParams
+    const message = authErrorMessage(error)
+    const detail =
+        error_description?.trim() &&
+        error_description.trim().toLowerCase() !== error?.trim().toLowerCase()
+            ? error_description.trim()
+            : null
+
+    return (
+        <main className="mx-auto flex min-h-screen w-full max-w-lg flex-col items-center justify-center px-6 text-center">
+            <h1 className="text-2xl font-bold">Sign-in could not be completed</h1>
+            <p className="mt-3 text-muted-foreground">{message}</p>
+            {detail ? <p className="mt-2 text-sm text-muted-foreground">{detail}</p> : null}
+            {error ? (
+                <p className="mt-4 font-mono text-xs text-muted-foreground">Code: {error}</p>
+            ) : null}
+            <p className="mt-8 text-sm text-muted-foreground">
+                Return to the{" "}
+                <Link href="/" className="text-primary underline-offset-4 hover:underline">
+                    DimbyBot Dashboard home page
+                </Link>{" "}
+                to start sign-in again. You will be sent to{" "}
+                <strong className="text-foreground">discord.com</strong> — this site never asks for
+                your Discord password.
+            </p>
+            <Link
+                href="/status"
+                className="mt-6 text-xs text-muted-foreground underline-offset-4 hover:underline"
+            >
+                System status
+            </Link>
+        </main>
+    )
+}

--- a/src/web/app/auth/error/page.tsx
+++ b/src/web/app/auth/error/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import Link from "next/link"
 import { authErrorMessage } from "@/lib/auth-error-message"
+import { normalizeSearchParam } from "@/lib/normalize-search-param"
 
 export const dynamic = "force-dynamic"
 
@@ -10,17 +11,18 @@ export const metadata: Metadata = {
 }
 
 type AuthErrorPageProps = {
-    searchParams: Promise<{ error?: string; error_description?: string }>
+    searchParams: Promise<{ error?: string | string[]; error_description?: string | string[] }>
 }
 
 /** Shown when Discord OAuth or Better Auth fails — intentionally not a login form. */
 export default async function AuthErrorPage({ searchParams }: AuthErrorPageProps) {
-    const { error, error_description } = await searchParams
+    const raw = await searchParams
+    const error = normalizeSearchParam(raw.error)?.trim()
+    const errorDescription = normalizeSearchParam(raw.error_description)?.trim()
     const message = authErrorMessage(error)
     const detail =
-        error_description?.trim() &&
-        error_description.trim().toLowerCase() !== error?.trim().toLowerCase()
-            ? error_description.trim()
+        errorDescription && errorDescription.toLowerCase() !== error?.toLowerCase()
+            ? errorDescription
             : null
 
     return (

--- a/src/web/app/page.tsx
+++ b/src/web/app/page.tsx
@@ -44,7 +44,19 @@ function sessionFailureHint(kind: SessionReadFailureKind): string {
     }
 }
 
-export default async function HomePage() {
+export default async function HomePage({
+    searchParams,
+}: {
+    searchParams: Promise<{ error?: string; error_description?: string }>
+}) {
+    const params = await searchParams
+    if (params.error?.trim()) {
+        const qs = new URLSearchParams({ error: params.error.trim() })
+        const description = params.error_description?.trim()
+        if (description) qs.set("error_description", description)
+        redirect(`/auth/error?${qs.toString()}`)
+    }
+
     const sessionResult = await readSessionSafe()
     if (sessionResult.ok && sessionResult.session?.user?.id) {
         redirect("/dashboard")

--- a/src/web/app/page.tsx
+++ b/src/web/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import { headers } from "next/headers"
 import { redirect } from "next/navigation"
 import { LoginButton } from "@/components/LoginButton"
+import { normalizeSearchParam } from "@/lib/normalize-search-param"
 import { readSessionSafe, type SessionReadFailureKind } from "@/server/auth-session"
 
 /** Session read uses `headers()`; avoid any static/CDN caching of personalized HTML. */
@@ -47,12 +48,13 @@ function sessionFailureHint(kind: SessionReadFailureKind): string {
 export default async function HomePage({
     searchParams,
 }: {
-    searchParams: Promise<{ error?: string; error_description?: string }>
+    searchParams: Promise<{ error?: string | string[]; error_description?: string | string[] }>
 }) {
     const params = await searchParams
-    if (params.error?.trim()) {
-        const qs = new URLSearchParams({ error: params.error.trim() })
-        const description = params.error_description?.trim()
+    const error = normalizeSearchParam(params.error)?.trim()
+    if (error) {
+        const qs = new URLSearchParams({ error })
+        const description = normalizeSearchParam(params.error_description)?.trim()
         if (description) qs.set("error_description", description)
         redirect(`/auth/error?${qs.toString()}`)
     }

--- a/src/web/components/LoginButton.tsx
+++ b/src/web/components/LoginButton.tsx
@@ -27,6 +27,7 @@ export function LoginButton() {
             await authClient.signIn.social({
                 provider: "discord",
                 callbackURL: "/dashboard",
+                errorCallbackURL: "/auth/error",
             })
         } catch (err: unknown) {
             const name = err instanceof Error ? err.name : "Error"

--- a/src/web/lib/auth-error-message.ts
+++ b/src/web/lib/auth-error-message.ts
@@ -1,0 +1,18 @@
+/** Maps Better Auth / OAuth error codes to user-facing copy (no credential prompts). */
+export function authErrorMessage(code: string | undefined): string {
+    const normalized = code?.trim().toLowerCase()
+    switch (normalized) {
+        case "please_restart_the_process":
+            return "The sign-in session expired or was interrupted before Discord returned. Close other dashboard tabs, then try again from the home page."
+        case "access_denied":
+            return "Discord sign-in was cancelled."
+        case "invalid_code":
+        case "invalid_grant":
+            return "Discord rejected the authorization code (it may have already been used). Try signing in again."
+        case undefined:
+        case "":
+            return "Sign-in could not be completed."
+        default:
+            return "Sign-in could not be completed. Try again from the home page."
+    }
+}

--- a/src/web/lib/normalize-search-param.ts
+++ b/src/web/lib/normalize-search-param.ts
@@ -1,0 +1,6 @@
+/** First value when App Router searchParams supply string | string[] for repeated keys. */
+export function normalizeSearchParam(value: string | string[] | undefined): string | undefined {
+    if (value === undefined) return undefined
+    if (Array.isArray(value)) return value[0]
+    return value
+}

--- a/src/web/lib/normalize-search-param.ts
+++ b/src/web/lib/normalize-search-param.ts
@@ -1,6 +1,14 @@
 /** First value when App Router searchParams supply string | string[] for repeated keys. */
 export function normalizeSearchParam(value: string | string[] | undefined): string | undefined {
     if (value === undefined) return undefined
-    if (Array.isArray(value)) return value[0]
+    if (Array.isArray(value)) {
+        for (const entry of value) {
+            if (typeof entry !== "string") continue
+            const trimmed = entry.trim()
+            if (trimmed.length > 0) return trimmed
+        }
+        const first = value[0]
+        return typeof first === "string" ? first : undefined
+    }
     return value
 }


### PR DESCRIPTION
## Summary
- Add /auth/error page for failed Discord OAuth (no login form on error paths)
- Configure Better Auth onAPIError.errorURL and sign-in errorCallbackURL
- Redirect legacy /?error= queries to /auth/error

## Test plan
- [ ] Trigger a failed OAuth flow and confirm redirect lands on /auth/error (not / with login button)
- [ ] Confirm successful sign-in still redirects callback to /dashboard
- [ ] Verify /?error=foo redirects to /auth/error?error=foo

Made with [Cursor](https://cursor.com)