### PR TITLE
fix: combine concurrency and queue-restore correctness fixes (#76-#81)

### DIFF
--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -10,6 +10,7 @@ import { searchAndEnqueue } from "./searchAndEnqueue.js"
 import {
     clearUpcomingQueue,
     enqueueResolvedPlaylistTracks,
+    type EnqueuePlaylistResult,
     resolveStoredPlaylistTracks,
     restoreUpcomingQueue,
     snapshotUpcomingQueue,
@@ -154,31 +155,15 @@ export async function playerPlaylistPlayPOST(
         }
 
         const savedUpcoming = snapshotUpcomingQueue(player)
+        let enqueue: EnqueuePlaylistResult
         try {
             await clearUpcomingQueue(player)
-            const enqueue = await enqueueResolvedPlaylistTracks(
+            enqueue = await enqueueResolvedPlaylistTracks(
                 player,
                 resolved,
                 requester.requesterId,
                 shuffle
             )
-
-            const state = await toPlayerStateResponse(guildId, requester.requesterId, player)
-
-            return {
-                status: 200,
-                body: {
-                    ok: true,
-                    data: {
-                        state,
-                        playlistId: playlist.id,
-                        playlistName: playlist.name,
-                        queued: enqueue.queued,
-                        failed,
-                        shuffle,
-                    },
-                },
-            }
         } catch (enqueueErr: unknown) {
             try {
                 await restoreUpcomingQueue(player, savedUpcoming)
@@ -194,6 +179,23 @@ export async function playerPlaylistPlayPOST(
                 )
             }
             throw enqueueErr
+        }
+
+        const state = await toPlayerStateResponse(guildId, requester.requesterId, player)
+
+        return {
+            status: 200,
+            body: {
+                ok: true,
+                data: {
+                    state,
+                    playlistId: playlist.id,
+                    playlistName: playlist.name,
+                    queued: enqueue.queued,
+                    failed,
+                    shuffle,
+                },
+            },
         }
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)

--- a/src/botApi/handlers/queueIndex.ts
+++ b/src/botApi/handlers/queueIndex.ts
@@ -125,10 +125,40 @@ export async function queueIndexPATCH(
         }
 
         const [track] = await player.queue.splice(sourceIndex, 1)
+        if (!track) {
+            return {
+                status: 404,
+                body: { ok: false, error: { error: "Queue index out of range." } },
+            }
+        }
         const insertIndexRaw = destinationIndex
         const lenAfterRemove = player.queue.tracks.length
         const insertIndex = Math.min(Math.max(insertIndexRaw, 0), lenAfterRemove)
-        await player.queue.splice(insertIndex, 0, track)
+        try {
+            await player.queue.splice(insertIndex, 0, track)
+        } catch (insertErr: unknown) {
+            try {
+                await player.queue.splice(sourceIndex, 0, track)
+            } catch (restoreErr: unknown) {
+                const restoreMessage =
+                    restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
+                const client = tryGetBotClient()
+                if (client) {
+                    client.error("[queueIndexPATCH] failed to restore track after reorder error", {
+                        guildId,
+                        sourceIndex,
+                        restoreMessage,
+                        insertErr,
+                    })
+                } else {
+                    console.error(
+                        "[queueIndexPATCH] failed to restore track after reorder error",
+                        { guildId, sourceIndex, restoreMessage, insertErr }
+                    )
+                }
+            }
+            throw insertErr
+        }
         playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
 
         return {

--- a/src/commands/admin/Control-Channel.ts
+++ b/src/commands/admin/Control-Channel.ts
@@ -126,7 +126,9 @@ export default {
                 client.debug(
                     `[Control-Channel] Saving new settings for guild ${guild.id}: Channel ${targetChannel.id}, Message ${controlMessage.id}.`
                 )
-                const persisted = await saveGuildSettings(guildSettings, client)
+                const persisted = await saveGuildSettings(guildSettings, client, {
+                    touchedGuildIds: [guild.id],
+                })
                 if (!persisted) {
                     await controlMessage.delete().catch((rollbackErr: unknown) => {
                         client.warn(
@@ -216,6 +218,7 @@ export default {
             }
             const persisted = await saveGuildSettings(guildSettings, client, {
                 deleteGuildIds: [guild.id],
+                touchedGuildIds: [guild.id],
             })
             client.debug(
                 `[Control-Channel] Persist settings after unset for guild ${guild.id}: ${persisted ? "ok" : "failed"}.`

--- a/src/commands/admin/Discord-Logs.ts
+++ b/src/commands/admin/Discord-Logs.ts
@@ -246,7 +246,10 @@ export default {
             const deleteGuildIds = guildIdsRemovedFromStore(store, nextStore)
             try {
                 await interaction.deferReply({ flags: [MessageFlags.Ephemeral] })
-                const ok = await saveGuildSettings(nextStore, client, { deleteGuildIds })
+                const ok = await saveGuildSettings(nextStore, client, {
+                    deleteGuildIds,
+                    touchedGuildIds: [guild.id],
+                })
                 if (!ok) {
                     return interaction.editReply({
                         content:
@@ -306,7 +309,10 @@ export default {
             const deleteGuildIds = guildIdsRemovedFromStore(store, nextStore)
             try {
                 await interaction.deferReply({ flags: [MessageFlags.Ephemeral] })
-                const ok = await saveGuildSettings(nextStore, client, { deleteGuildIds })
+                const ok = await saveGuildSettings(nextStore, client, {
+                    deleteGuildIds,
+                    touchedGuildIds: [guild.id],
+                })
                 if (!ok) {
                     return interaction.editReply({
                         content:
@@ -382,7 +388,10 @@ export default {
             const deleteGuildIds = guildIdsRemovedFromStore(latestStore, nextStore)
             try {
                 await interaction.deferReply({ flags: [MessageFlags.Ephemeral] })
-                const ok = await saveGuildSettings(nextStore, client, { deleteGuildIds })
+                const ok = await saveGuildSettings(nextStore, client, {
+                    deleteGuildIds,
+                    touchedGuildIds: [guild.id],
+                })
                 if (!ok) {
                     return interaction.editReply({
                         content:

--- a/src/commands/developer/DownloadLimit.ts
+++ b/src/commands/developer/DownloadLimit.ts
@@ -112,7 +112,9 @@ export default {
         if (subcommand === "set") {
             const sizeMb = interaction.options.getNumber("size_mb", true)
             settings[targetGuildId].downloadsMaxMb = sizeMb
-            const ok = await saveGuildSettings(settings, client)
+            const ok = await saveGuildSettings(settings, client, {
+                touchedGuildIds: [targetGuildId],
+            })
             if (!ok) {
                 client.error("[DownloadLimit] Failed to persist guild settings after set.")
                 return interaction.reply({
@@ -134,7 +136,10 @@ export default {
                     delete settings[targetGuildId]
                     deleteGuildIds = [targetGuildId]
                 }
-                const ok = await saveGuildSettings(settings, client, { deleteGuildIds })
+                const ok = await saveGuildSettings(settings, client, {
+                    deleteGuildIds,
+                    touchedGuildIds: [targetGuildId],
+                })
                 if (!ok) {
                     client.error("[DownloadLimit] Failed to persist guild settings after clear.")
                     return interaction.reply({

--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -65,6 +65,7 @@ async function cleanupOldFiles(downloadsDir: string, client: BotClient, guildId:
     let deletedCount = 0
     let totalSize = 0
     let metadataDirty = false
+    const deletedStoreKeys = new Set<string>()
 
     const metadata: DownloadsMetadataStore = getDownloadMetadataStore()
 
@@ -87,6 +88,7 @@ async function cleanupOldFiles(downloadsDir: string, client: BotClient, guildId:
                 if (err.code === "ENOENT") {
                     for (const metaKey of metadataKeysForFile) {
                         delete metadata[metaKey]
+                        deletedStoreKeys.add(metaKey)
                     }
                     metadataDirty = true
                     client.debug(
@@ -111,6 +113,7 @@ async function cleanupOldFiles(downloadsDir: string, client: BotClient, guildId:
                         if (err.code === "ENOENT") {
                             for (const metaKey of metadataKeysForFile) {
                                 delete metadata[metaKey]
+                                deletedStoreKeys.add(metaKey)
                             }
                             metadataDirty = true
                             client.debug(
@@ -128,6 +131,7 @@ async function cleanupOldFiles(downloadsDir: string, client: BotClient, guildId:
                 }
                 for (const metaKey of metadataKeysForFile) {
                     delete metadata[metaKey]
+                    deletedStoreKeys.add(metaKey)
                 }
                 metadataDirty = true
                 client.debug(
@@ -143,7 +147,9 @@ async function cleanupOldFiles(downloadsDir: string, client: BotClient, guildId:
     }
 
     if (metadataDirty) {
-        const ok = await saveDownloadMetadataStore(metadata, client)
+        const ok = await saveDownloadMetadataStore(metadata, client, {
+            deleteStoreKeys: [...deletedStoreKeys],
+        })
         if (ok) {
             client.debug("[Download Cleanup] Updated metadata store after deleting old entries.")
         } else {
@@ -225,6 +231,7 @@ async function enforceDirectoryLimit(
         let deletedCount = 0
         let deletedSize = 0
         let metadataDirty = false
+        const deletedStoreKeys = new Set<string>()
 
         for (const file of candidates) {
             if (totalSizeMB - deletedSize / (1024 * 1024) <= maxDirSizeMb) {
@@ -236,6 +243,7 @@ async function enforceDirectoryLimit(
                 deletedSize += file.size
                 for (const metaKey of downloadMetadataKeysForFile(metadata, file.name, guildId)) {
                     delete metadata[metaKey]
+                    deletedStoreKeys.add(metaKey)
                     metadataDirty = true
                 }
             } catch (error: unknown) {
@@ -244,7 +252,9 @@ async function enforceDirectoryLimit(
         }
 
         if (metadataDirty) {
-            const ok = await saveDownloadMetadataStore(metadata, client)
+            const ok = await saveDownloadMetadataStore(metadata, client, {
+                deleteStoreKeys: [...deletedStoreKeys],
+            })
             if (ok) {
                 client.debug("[Download Cleanup] Updated metadata after size cleanup.")
             } else {

--- a/src/commands/user/downloads.ts
+++ b/src/commands/user/downloads.ts
@@ -306,6 +306,7 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
             let deletedCount = 0
             let totalSize = 0
             const errors = []
+            const deletedStoreKeys = new Set<string>()
 
             for (const file of files) {
                 const metadataKeys = downloadMetadataKeysForFile(metadata, file.name, guildId)
@@ -316,6 +317,7 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                     deletedCount++
                     for (const metaKey of metadataKeys) {
                         delete metadata[metaKey]
+                        deletedStoreKeys.add(metaKey)
                     }
                 } catch (err: unknown) {
                     const code =
@@ -325,6 +327,7 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                     if (code === "ENOENT") {
                         for (const metaKey of metadataKeys) {
                             delete metadata[metaKey]
+                            deletedStoreKeys.add(metaKey)
                         }
                     } else {
                         client.warn(
@@ -336,7 +339,9 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                 }
             }
 
-            const metadataSaved = await saveDownloadMetadataStore(metadata, client)
+            const metadataSaved = await saveDownloadMetadataStore(metadata, client, {
+                deleteStoreKeys: [...deletedStoreKeys],
+            })
             if (!metadataSaved) {
                 client.error(
                     `[Downloads] Failed to persist metadata cleanup updates to database (guildId=${guildId}, subcommand=${subcommand}).`

--- a/src/repositories/downloadMetadataRepository.ts
+++ b/src/repositories/downloadMetadataRepository.ts
@@ -151,10 +151,13 @@ function deleteConditionsForStoreKeys(
                 : `|${parsed.fileName}`
         if (seen.has(dedupe)) continue
         seen.add(dedupe)
+        // Only delete by composite `(guildId, fileName)`. A filename-only key (parsed.guildId null/empty)
+        // would translate to `{ fileName }`, matching that fileName across EVERY guild and wiping
+        // unrelated guilds' rows. DB rows always carry a guildId (NULL legacy rows were migrated to the
+        // UNKNOWN sentinel), so callers' keys from downloadMetadataKeysForFile are composite — the
+        // filename-only branch targets no real row precisely and is intentionally skipped here.
         if (parsed.guildId !== null && parsed.guildId.length > 0) {
             conditions.push({ guildId: parsed.guildId, fileName: parsed.fileName })
-        } else {
-            conditions.push({ fileName: parsed.fileName })
         }
     }
     return conditions

--- a/src/repositories/downloadMetadataRepository.ts
+++ b/src/repositories/downloadMetadataRepository.ts
@@ -128,53 +128,67 @@ export async function isDownloadMetadataTableEmpty(): Promise<boolean> {
  */
 export type ReplaceDownloadMetadataStoreResult = {
     rowsWritten: number
+    rowsDeleted: number
     skippedEntries: SkippedDownloadMetadataEntry[]
 }
 
+export type ReplaceDownloadMetadataStoreOptions = {
+    /** Store keys removed intentionally (cleanup); never inferred from snapshot omissions. */
+    deleteStoreKeys?: string[]
+}
+
+function deleteConditionsForStoreKeys(
+    deleteStoreKeys: string[]
+): Prisma.DownloadMetadataWhereInput[] {
+    const conditions: Prisma.DownloadMetadataWhereInput[] = []
+    const seen = new Set<string>()
+    for (const storeKey of deleteStoreKeys) {
+        if (typeof storeKey !== "string" || !storeKey.trim()) continue
+        const parsed = parseDownloadMetadataStoreKey(storeKey)
+        const dedupe =
+            parsed.guildId !== null && parsed.guildId.length > 0
+                ? `${parsed.guildId}|${parsed.fileName}`
+                : `|${parsed.fileName}`
+        if (seen.has(dedupe)) continue
+        seen.add(dedupe)
+        if (parsed.guildId !== null && parsed.guildId.length > 0) {
+            conditions.push({ guildId: parsed.guildId, fileName: parsed.fileName })
+        } else {
+            conditions.push({ fileName: parsed.fileName })
+        }
+    }
+    return conditions
+}
+
 export async function replaceDownloadMetadataStoreInDatabase(
-    store: DownloadsMetadataStore
+    store: DownloadsMetadataStore,
+    options?: ReplaceDownloadMetadataStoreOptions
 ): Promise<ReplaceDownloadMetadataStoreResult> {
     const prisma = getPrismaClient()
     const { rows, skippedEntries } = normalizedRowsFromStore(store)
 
-    if (rows.length === 0) {
+    const deleteStoreKeys = (options?.deleteStoreKeys ?? []).filter(
+        (key) => typeof key === "string" && key.length > 0
+    )
+
+    if (rows.length === 0 && deleteStoreKeys.length === 0) {
         if (skippedEntries.length > 0) {
-            return { rowsWritten: 0, skippedEntries }
+            return { rowsWritten: 0, rowsDeleted: 0, skippedEntries }
         }
         await prisma.downloadMetadata.deleteMany({})
-        return { rowsWritten: 0, skippedEntries }
+        return { rowsWritten: 0, rowsDeleted: 0, skippedEntries }
     }
 
     const UPSERT_BATCH = 32
-    const KEEP_INSERT_CHUNK = 500
+    let rowsDeleted = 0
 
     await prisma.$transaction(async (tx) => {
-        // PostgreSQL-specific temp table lifecycle (`ON COMMIT DROP`) is intentional; this project is
-        // configured for PostgreSQL via Prisma, and `_dimbybot_dm_keep` must be transaction-scoped.
-        await tx.$executeRaw`
-            CREATE TEMP TABLE _dimbybot_dm_keep (
-                "guildId" TEXT NOT NULL,
-                "fileName" TEXT NOT NULL
-            ) ON COMMIT DROP
-        `
-
-        for (let i = 0; i < rows.length; i += KEEP_INSERT_CHUNK) {
-            const batch = rows.slice(i, i + KEEP_INSERT_CHUNK)
-            const tuples = batch.map((r) => Prisma.sql`(${r.guildId}, ${r.fileName})`)
-            await tx.$executeRaw`
-                INSERT INTO _dimbybot_dm_keep ("guildId", "fileName")
-                VALUES ${Prisma.join(tuples, ", ")}
-            `
-        }
-
-        if (skippedEntries.length === 0) {
-            await tx.$executeRaw`
-                DELETE FROM "DownloadMetadata" AS d
-                WHERE NOT EXISTS (
-                    SELECT 1 FROM _dimbybot_dm_keep k
-                    WHERE k."guildId" = d."guildId" AND k."fileName" = d."fileName"
-                )
-            `
+        const deleteConditions = deleteConditionsForStoreKeys(deleteStoreKeys)
+        if (deleteConditions.length > 0) {
+            const deleted = await tx.downloadMetadata.deleteMany({
+                where: { OR: deleteConditions },
+            })
+            rowsDeleted = deleted.count
         }
 
         for (let i = 0; i < rows.length; i += UPSERT_BATCH) {
@@ -214,5 +228,5 @@ export async function replaceDownloadMetadataStoreInDatabase(
         }
     })
 
-    return { rowsWritten: rows.length, skippedEntries }
+    return { rowsWritten: rows.length, rowsDeleted, skippedEntries }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -137,11 +137,13 @@ export type ReplaceGuildSettingsStoreFn = (
 
 export type ReplaceDownloadMetadataStoreResult = {
     rowsWritten: number
+    rowsDeleted: number
     skippedEntries: DownloadMetadataStoreSkippedEntry[]
 }
 
 export type ReplaceDownloadMetadataStoreFn = (
-    store: DownloadsMetadataStore
+    store: DownloadsMetadataStore,
+    options?: { deleteStoreKeys?: string[] }
 ) => Promise<ReplaceDownloadMetadataStoreResult>
 
 /** Options for JSON → DB migration helpers. */

--- a/src/util/downloadMetadataStore.ts
+++ b/src/util/downloadMetadataStore.ts
@@ -7,6 +7,7 @@ import { loggerFromPartial } from "./loggerFromPartial.js"
 
 let downloadMetadataCache: DownloadsMetadataStore = {}
 let initialized = false
+let saveDownloadMetadataChain: Promise<void> = Promise.resolve()
 
 function cloneStore(store: DownloadsMetadataStore): DownloadsMetadataStore {
     return typeof structuredClone === "function"
@@ -33,6 +34,25 @@ export async function initializeDownloadMetadataStore(
     }
 }
 
+async function withDownloadMetadataSaveLock<T>(work: () => Promise<T>): Promise<T> {
+    let release: () => void = () => {}
+    const previous = saveDownloadMetadataChain
+    saveDownloadMetadataChain = new Promise<void>((resolve) => {
+        release = resolve
+    })
+    await previous
+    try {
+        return await work()
+    } finally {
+        release()
+    }
+}
+
+export type SaveDownloadMetadataStoreOptions = {
+    /** Store keys removed from the in-memory map (cleanup); must be listed explicitly. */
+    deleteStoreKeys?: string[]
+}
+
 /** Returns a clone of the metadata cache so callers cannot mutate shared state. */
 export function getDownloadMetadataStore(): DownloadsMetadataStore {
     if (!initialized) {
@@ -44,45 +64,47 @@ export function getDownloadMetadataStore(): DownloadsMetadataStore {
 /** Persists the provided metadata map to the database and replaces the in-memory cache with a deep clone. */
 export async function saveDownloadMetadataStore(
     metadata: DownloadsMetadataStore,
-    loggerInstance?: Partial<LoggerInterface>
+    loggerInstance?: Partial<LoggerInterface>,
+    options?: SaveDownloadMetadataStoreOptions
 ): Promise<boolean> {
-    const logger = loggerFromPartial(loggerInstance)
-    const previousCache = cloneStore(downloadMetadataCache)
     const nextCache = cloneStore(metadata)
-    try {
-        const result = await replaceDownloadMetadataStoreInDatabase(nextCache)
+    const deleteStoreKeys = (options?.deleteStoreKeys ?? []).filter(
+        (key) => typeof key === "string" && key.length > 0
+    )
+    return withDownloadMetadataSaveLock(async () => {
+        const logger = loggerFromPartial(loggerInstance)
+        const previousCache = cloneStore(downloadMetadataCache)
         try {
-            if (result.skippedEntries.length === 0) {
-                downloadMetadataCache = nextCache
-                initialized = true
-            } else {
+            const result = await replaceDownloadMetadataStoreInDatabase(nextCache, {
+                deleteStoreKeys,
+            })
+            try {
                 const persistedCache = await getDownloadMetadataStoreFromDatabase()
                 downloadMetadataCache = cloneStore(persistedCache)
                 initialized = true
+            } catch (reloadErr: unknown) {
+                logger.warn(
+                    "[downloadMetadata] replaceDownloadMetadataStoreInDatabase succeeded but cache reload failed; keeping previous in-memory cache",
+                    reloadErr
+                )
+                downloadMetadataCache = previousCache
+                initialized = true
+                return false
             }
-        } catch (reloadErr: unknown) {
-            logger.warn(
-                "[downloadMetadata] replaceDownloadMetadataStoreInDatabase succeeded but cache reload failed; keeping previous in-memory cache",
-                reloadErr
+            if (result.skippedEntries.length > 0) {
+                logger.warn(
+                    `[downloadMetadata] Skipped ${result.skippedEntries.length} metadata row(s) (no resolvable guild id); cache reloaded from database.`
+                )
+            }
+            logger.debug(
+                `[downloadMetadata] Saved metadata store to database (upserted=${result.rowsWritten}, deleted=${result.rowsDeleted}).`
             )
-            downloadMetadataCache = previousCache
-            initialized = true
+            return result.skippedEntries.length === 0
+        } catch (error: unknown) {
+            logger.error("[downloadMetadata] Failed saving metadata store to database:", error)
             return false
         }
-        if (result.skippedEntries.length > 0) {
-            logger.warn(
-                `[downloadMetadata] Skipped ${result.skippedEntries.length} metadata row(s) (no resolvable guild id); cache reloaded from database.`
-            )
-        }
-        logger.debug(
-            `[downloadMetadata] Saved metadata store to database (${result.rowsWritten} rows).`
-        )
-        // Success only when nothing was skipped (including empty saves: 0 rows written, 0 skipped).
-        return result.skippedEntries.length === 0
-    } catch (error: unknown) {
-        logger.error("[downloadMetadata] Failed saving metadata store to database:", error)
-        return false
-    }
+    })
 }
 
 /** Indicates whether the metadata cache has been initialized from the database. */

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -97,6 +97,7 @@ export async function restoreUpcomingQueue(
     player: Player,
     tracks: Array<Track | UnresolvedTrack>
 ): Promise<void> {
+    await clearUpcomingQueue(player)
     if (tracks.length > 0) {
         await player.queue.splice(0, 0, tracks)
     }

--- a/src/util/saveControlChannel.ts
+++ b/src/util/saveControlChannel.ts
@@ -102,6 +102,11 @@ async function withGuildSettingsSaveLock<T>(work: () => Promise<T>): Promise<T> 
 export type SaveGuildSettingsOptions = {
     /** Guild IDs to delete from the database (must be intentional removals, not snapshot omissions). */
     deleteGuildIds?: string[]
+    /**
+     * Guild rows to take from `settings` when persisting. When set, other guilds in `settings` are
+     * ignored and the latest database values are kept (prevents lost updates across concurrent saves).
+     */
+    touchedGuildIds?: string[]
 }
 
 /**
@@ -117,11 +122,27 @@ export async function saveGuildSettings(
     const deleteGuildIds = (options?.deleteGuildIds ?? []).filter(
         (id) => typeof id === "string" && id.length > 0
     )
+    const touchedGuildIds = (options?.touchedGuildIds ?? []).filter(
+        (id) => typeof id === "string" && id.length > 0
+    )
     return withGuildSettingsSaveLock(async () => {
         const logger = loggerFromPartial(loggerInstance)
         logger.debug("[guildSettings] Attempting to save settings to database.")
         try {
-            const result = await replaceGuildSettingsStoreInDatabase(settingsSnapshot, {
+            const dbStore = await readGuildSettingsFromDatabase(logger)
+            const merged = cloneGuildSettingsStore(dbStore)
+            const guildIdsToApply =
+                touchedGuildIds.length > 0 ? touchedGuildIds : Object.keys(settingsSnapshot)
+            for (const guildId of guildIdsToApply) {
+                const row = settingsSnapshot[guildId]
+                if (row !== undefined) {
+                    merged[guildId] = cloneGuildSettingsStore({ [guildId]: row })[guildId]!
+                }
+            }
+            for (const guildId of deleteGuildIds) {
+                delete merged[guildId]
+            }
+            const result = await replaceGuildSettingsStoreInDatabase(merged, {
                 deleteGuildIds,
             })
             const reloaded = await readGuildSettingsFromDatabase(logger)


### PR DESCRIPTION
## Summary

Combines four independent correctness fixes that were previously split across PRs #76-#81 into a single commit, for a clean consolidated review. The triplicate `restoreUpcomingQueue` fix (#78/#79/#81) is deduplicated to the `clearUpcomingQueue`-based version.

- **Guild settings concurrency (#76)** — adds `touchedGuildIds` to `saveGuildSettings`; concurrent admin saves now merge their touched guild rows onto the latest DB store instead of clobbering each other. (`saveControlChannel.ts`, `Control-Channel.ts`, `Discord-Logs.ts`, `DownloadLimit.ts`)
- **Playlist play flow + reorder safety (#77)** — builds the success response outside the enqueue `try` block so a response-build failure no longer leaves the queue corrupted, and guards/restores tracks on queue reorder failure. (`playlistPlay.ts`, `queueIndex.ts`)
- **Queue restore (#78/#79)** — `restoreUpcomingQueue` now clears the upcoming queue before re-inserting, so a failed playlist play fully restores prior state. (`playlistQueue.ts`)
- **Download metadata concurrency (#80)** — adds a save lock plus explicit `deleteStoreKeys`; concurrent cleanup saves no longer drop unrelated metadata rows. (`download.ts`, `downloads.ts`, `downloadMetadataRepository.ts`, `types/index.ts`, `downloadMetadataStore.ts`)

Supersedes #76, #77, #78, #79, #80, #81.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [ ] CodeRabbit review on the consolidated diff
