### PR TITLE
chore(ci): prune unused images and build cache after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -328,7 +328,13 @@ jobs:
                   # Pull new images first, then reconcile containers (avoids full downtime if pull fails).
                   /usr/bin/docker compose -f docker-compose.yml -f docker-compose.dashboard.yml pull
                   /usr/bin/docker compose -f docker-compose.yml -f docker-compose.dashboard.yml up -d --remove-orphans
-                  /usr/bin/docker image prune -f
+                  # Reclaim disk after a successful rollout. `image prune -f` only drops dangling layers, so the
+                  # previous deploy's immutable :sha images linger; `-a` removes any image not used by a running
+                  # container (old bot/web/lavalink :sha tags), while keeping the just-deployed stack. Cleanup must
+                  # never fail an otherwise-successful deploy, hence the `|| true`.
+                  /usr/bin/docker container prune -f || true
+                  /usr/bin/docker image prune -af || true
+                  /usr/bin/docker builder prune -f || true
                   EOS
 
                   # Create SSH key file with proper permissions


### PR DESCRIPTION
## Summary

- Make the on-server deploy cleanup actually reclaim disk after each rollout. The previous `docker image prune -f` only removed dangling layers, so every deploy's immutable `:sha` images (`BOT_IMAGE`/`WEB_IMAGE`/`LAVALINK_IMAGE`) accumulated on the server indefinitely.
- After `compose up -d`, now run `docker container prune -f`, `docker image prune -af`, and `docker builder prune -f`. `-a` removes images not used by a running container (old per-commit `:sha` tags) while keeping the just-deployed stack and in-use upstream images (postgres, spotify-tokener).
- Each cleanup is guarded with `|| true` so a prune hiccup can never fail an otherwise-successful deploy (the script runs under `set -e`).

Scope is intentionally limited to the deploy server; the `build-and-push` job runs on ephemeral GitHub runners whose disk resets each run and uses the GitHub-managed `type=gha` cache, so there is nothing persistent to clean there.

## Test plan

- [ ] Trigger a deploy and confirm prior `:sha` images are removed from the server while the running stack stays healthy.
- [ ] Verify deploy still succeeds if a prune command returns non-zero (cleanup is non-fatal).
