### PR TITLE
feat: add /countdown command with auto-updating embeds

### DIFF
--- a/prisma/migrations/20260604120000_add_countdown/migration.sql
+++ b/prisma/migrations/20260604120000_add_countdown/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "Countdown" (
+    "id" SERIAL NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "channelId" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "eventName" TEXT NOT NULL,
+    "description" TEXT,
+    "imageUrl" TEXT,
+    "targetTime" TIMESTAMP(3) NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Countdown_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Countdown_guildId_idx" ON "Countdown"("guildId");

--- a/prisma/migrations/20260604130000_countdown_color_footer/migration.sql
+++ b/prisma/migrations/20260604130000_countdown_color_footer/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Countdown" ADD COLUMN "color" INTEGER;
+ALTER TABLE "Countdown" ADD COLUMN "footer" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,23 @@ model PlaylistTrack {
   @@index([playlistId], name: "PlaylistTrack_playlistId_idx")
 }
 
+model Countdown {
+  id          Int      @id @default(autoincrement())
+  guildId     String
+  channelId   String
+  messageId   String
+  eventName   String
+  description String?
+  imageUrl    String?
+  color       Int?
+  footer      String?
+  targetTime  DateTime
+  createdBy   String
+  createdAt   DateTime @default(now())
+
+  @@index([guildId], name: "Countdown_guildId_idx")
+}
+
 model User {
   id            String    @id
   name          String

--- a/src/commands/admin/Countdown.ts
+++ b/src/commands/admin/Countdown.ts
@@ -1,0 +1,362 @@
+import {
+    SlashCommandBuilder,
+    PermissionFlagsBits,
+    ChannelType,
+    EmbedBuilder,
+    type ChatInputCommandInteraction,
+    type GuildTextBasedChannel,
+} from "discord.js"
+import type BotClient from "../../lib/BotClient.js"
+import { buildCountdownEmbed } from "../../util/countdownEmbed.js"
+import { formatCountdownDuration } from "../../util/formatCountdownDuration.js"
+import { parseEventDateTime } from "../../util/parseEventDateTime.js"
+import {
+    addCountdown,
+    getCountdown,
+    getCountdownsForGuild,
+    removeCountdown,
+} from "../../util/countdownStore.js"
+
+/** Validates that a string is an http(s) URL usable as an embed image. */
+function isValidHttpUrl(value: string): boolean {
+    let parsed: URL
+    try {
+        parsed = new URL(value)
+    } catch {
+        return false
+    }
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+}
+
+const REQUIRED_CHANNEL_PERMS = [
+    PermissionFlagsBits.ViewChannel,
+    PermissionFlagsBits.SendMessages,
+    PermissionFlagsBits.EmbedLinks,
+]
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName("countdown")
+        .setDescription("Manage auto-updating countdown messages.")
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+        .setDMPermission(false)
+        .addSubcommand((sub) =>
+            sub
+                .setName("create")
+                .setDescription("Create a countdown that updates every minute.")
+                .addStringOption((opt) =>
+                    opt
+                        .setName("event_name")
+                        .setDescription("Name of the event to count down to")
+                        .setRequired(true)
+                )
+                .addStringOption((opt) =>
+                    opt
+                        .setName("date")
+                        .setDescription("Target date as YYYY-MM-DD (use with time)")
+                        .setRequired(false)
+                )
+                .addStringOption((opt) =>
+                    opt
+                        .setName("time")
+                        .setDescription("Target time as 24-hour HH:MM (use with date)")
+                        .setRequired(false)
+                )
+                .addStringOption((opt) =>
+                    opt
+                        .setName("timezone")
+                        .setDescription("Time zone for date/time (defaults to UTC)")
+                        .setRequired(false)
+                        .addChoices(
+                            { name: "UTC", value: "UTC" },
+                            { name: "US Eastern", value: "America/New_York" },
+                            { name: "US Central", value: "America/Chicago" },
+                            { name: "US Mountain", value: "America/Denver" },
+                            { name: "US Pacific", value: "America/Los_Angeles" },
+                            { name: "US Alaska", value: "America/Anchorage" },
+                            { name: "US Hawaii", value: "Pacific/Honolulu" },
+                            { name: "UK (London)", value: "Europe/London" },
+                            { name: "Central Europe (Paris)", value: "Europe/Paris" },
+                            { name: "Eastern Europe (Athens)", value: "Europe/Athens" },
+                            { name: "India (Kolkata)", value: "Asia/Kolkata" },
+                            { name: "China (Shanghai)", value: "Asia/Shanghai" },
+                            { name: "Japan (Tokyo)", value: "Asia/Tokyo" },
+                            { name: "Australia (Sydney)", value: "Australia/Sydney" }
+                        )
+                )
+                .addIntegerOption((opt) =>
+                    opt
+                        .setName("timestamp")
+                        .setDescription("Advanced: target time as a Unix timestamp in seconds")
+                        .setRequired(false)
+                        .setMinValue(1)
+                )
+                .addChannelOption((opt) =>
+                    opt
+                        .setName("channel")
+                        .setDescription("Channel to post in (defaults to the current channel)")
+                        .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
+                        .setRequired(false)
+                )
+                .addStringOption((opt) =>
+                    opt
+                        .setName("description")
+                        .setDescription("Optional description shown in the embed")
+                        .setRequired(false)
+                )
+                .addStringOption((opt) =>
+                    opt
+                        .setName("image_url")
+                        .setDescription("Optional image URL (http/https) shown in the embed")
+                        .setRequired(false)
+                )
+                .addIntegerOption((opt) =>
+                    opt
+                        .setName("color")
+                        .setDescription("Optional embed accent color")
+                        .setRequired(false)
+                        .addChoices(
+                            { name: "Blurple", value: 0x5865f2 },
+                            { name: "Red", value: 0xed4245 },
+                            { name: "Green", value: 0x57f287 },
+                            { name: "Blue", value: 0x3498db },
+                            { name: "Yellow", value: 0xfee75c },
+                            { name: "Orange", value: 0xe67e22 },
+                            { name: "Purple", value: 0x9b59b6 },
+                            { name: "Pink", value: 0xeb459e },
+                            { name: "White", value: 0xffffff },
+                            { name: "Black", value: 0x2b2d31 }
+                        )
+                )
+                .addStringOption((opt) =>
+                    opt
+                        .setName("footer")
+                        .setDescription(
+                            "Optional custom footer text (defaults to the countdown id)"
+                        )
+                        .setRequired(false)
+                        .setMaxLength(256)
+                )
+        )
+        .addSubcommand((sub) =>
+            sub.setName("list").setDescription("List active countdowns in this server.")
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName("delete")
+                .setDescription("Delete a countdown by id.")
+                .addIntegerOption((opt) =>
+                    opt
+                        .setName("countdown_id")
+                        .setDescription("Countdown id (see /countdown list)")
+                        .setRequired(true)
+                        .setMinValue(1)
+                )
+        ),
+    category: "admin",
+
+    async execute(interaction: ChatInputCommandInteraction, client: BotClient): Promise<unknown> {
+        if (!interaction.inGuild() || !interaction.guild) {
+            return interaction.reply({ content: "Use this command in a server.", ephemeral: true })
+        }
+        const guild = interaction.guild
+        const subcommand = interaction.options.getSubcommand()
+
+        try {
+            if (subcommand === "create") {
+                return await handleCreate(interaction, client, guild.id)
+            }
+            if (subcommand === "list") {
+                return await handleList(interaction, guild.id)
+            }
+            if (subcommand === "delete") {
+                return await handleDelete(interaction, client, guild.id)
+            }
+            return interaction.reply({ content: "Unknown subcommand.", ephemeral: true })
+        } catch (err: unknown) {
+            client.error("[Countdown command] execute failed:", err)
+            const content = "An error occurred while processing your request."
+            if (interaction.deferred || interaction.replied) {
+                return interaction.editReply({ content })
+            }
+            return interaction.reply({ content, ephemeral: true })
+        }
+    },
+}
+
+async function handleCreate(
+    interaction: ChatInputCommandInteraction,
+    client: BotClient,
+    guildId: string
+): Promise<unknown> {
+    await interaction.deferReply({ ephemeral: true })
+
+    const eventName = interaction.options.getString("event_name", true)
+    const date = interaction.options.getString("date")
+    const time = interaction.options.getString("time")
+    const timezone = interaction.options.getString("timezone") ?? "UTC"
+    const timestamp = interaction.options.getInteger("timestamp")
+    const description = interaction.options.getString("description")
+    const imageUrl = interaction.options.getString("image_url")
+    const color = interaction.options.getInteger("color")
+    const footer = interaction.options.getString("footer")
+
+    let targetMs: number
+    if (date || time) {
+        if (!date || !time) {
+            return interaction.editReply({
+                content: "Provide both `date` and `time` together (or use `timestamp` instead).",
+            })
+        }
+        const parsed = parseEventDateTime(date, time, timezone)
+        if (parsed.ok === false) {
+            return interaction.editReply({ content: parsed.error })
+        }
+        targetMs = parsed.epochSeconds * 1000
+    } else if (timestamp !== null) {
+        targetMs = timestamp * 1000
+    } else {
+        return interaction.editReply({
+            content: "Provide a target time: either `date` + `time`, or a Unix `timestamp`.",
+        })
+    }
+
+    if (targetMs <= Date.now()) {
+        return interaction.editReply({
+            content: "The target time must be in the future.",
+        })
+    }
+
+    if (imageUrl && !isValidHttpUrl(imageUrl)) {
+        return interaction.editReply({
+            content: "The image URL must be a valid http or https URL.",
+        })
+    }
+
+    const channelId = interaction.options.getChannel("channel")?.id ?? interaction.channelId
+    const resolved = await client.channels.fetch(channelId).catch((): null => null)
+    if (!resolved || !resolved.isTextBased() || resolved.isDMBased() || !("send" in resolved)) {
+        return interaction.editReply({
+            content: "The target channel must be a text channel in this server.",
+        })
+    }
+    const targetChannel = resolved as GuildTextBasedChannel
+
+    const botUser = client.user
+    if (!botUser) {
+        return interaction.editReply({ content: "Bot user is not available yet. Try again." })
+    }
+    const botPermissions = targetChannel.permissionsFor(botUser)
+    if (!botPermissions?.has(REQUIRED_CHANNEL_PERMS)) {
+        return interaction.editReply({
+            content:
+                "I need View Channel, Send Messages, and Embed Links permissions in the target channel.",
+        })
+    }
+
+    const placeholder = await targetChannel
+        .send({ content: "Setting up countdown..." })
+        .catch((): null => null)
+    if (!placeholder) {
+        return interaction.editReply({
+            content: "Failed to post the countdown message. Check my permissions in that channel.",
+        })
+    }
+
+    let entry
+    try {
+        entry = await addCountdown({
+            guildId,
+            channelId: targetChannel.id,
+            messageId: placeholder.id,
+            eventName,
+            description: description ?? null,
+            imageUrl: imageUrl ?? null,
+            color: color ?? null,
+            footer: footer ?? null,
+            targetTime: new Date(targetMs),
+            createdBy: interaction.user.id,
+        })
+    } catch (err: unknown) {
+        await placeholder.delete().catch((rollbackErr: unknown) => {
+            client.warn(
+                `[Countdown] Failed to roll back placeholder message ${placeholder.id} after save failure:`,
+                rollbackErr
+            )
+        })
+        throw err
+    }
+
+    await placeholder.edit({ content: null, embeds: [buildCountdownEmbed(entry)] })
+
+    return interaction.editReply({
+        content: `Created countdown **#${entry.id}** for **${eventName}** in ${targetChannel}.`,
+    })
+}
+
+async function handleList(
+    interaction: ChatInputCommandInteraction,
+    guildId: string
+): Promise<unknown> {
+    await interaction.deferReply({ ephemeral: true })
+
+    const countdowns = getCountdownsForGuild(guildId).sort(
+        (a, b) => a.targetTime.getTime() - b.targetTime.getTime()
+    )
+    if (countdowns.length === 0) {
+        return interaction.editReply({
+            content: "No active countdowns in this server. Use `/countdown create` to add one.",
+        })
+    }
+
+    const now = Date.now()
+    const embed = new EmbedBuilder()
+        .setColor(0x5865f2)
+        .setTitle("Active Countdowns")
+        .setDescription(
+            countdowns
+                .map((c) => {
+                    const remaining = c.targetTime.getTime() - now
+                    const remainingText =
+                        remaining <= 0 ? "Event started!" : formatCountdownDuration(remaining)
+                    return `**#${c.id}** — ${c.eventName}\n<#${c.channelId}> • ${remainingText}`
+                })
+                .join("\n\n")
+        )
+        .setTimestamp()
+
+    return interaction.editReply({ embeds: [embed] })
+}
+
+async function handleDelete(
+    interaction: ChatInputCommandInteraction,
+    client: BotClient,
+    guildId: string
+): Promise<unknown> {
+    await interaction.deferReply({ ephemeral: true })
+
+    const id = interaction.options.getInteger("countdown_id", true)
+    const entry = getCountdown(id)
+    if (!entry || entry.guildId !== guildId) {
+        return interaction.editReply({
+            content: `No countdown **#${id}** found in this server.`,
+        })
+    }
+
+    const channel = await client.channels.fetch(entry.channelId).catch((): null => null)
+    if (channel && "messages" in channel) {
+        const message = await channel.messages.fetch(entry.messageId).catch((): null => null)
+        if (message) {
+            await message.delete().catch((err: unknown) => {
+                client.warn(
+                    `[Countdown] Failed to delete message ${entry.messageId} for countdown #${id}:`,
+                    err
+                )
+            })
+        }
+    }
+
+    await removeCountdown(id)
+
+    return interaction.editReply({ content: `Deleted countdown **#${id}** (${entry.eventName}).` })
+}

--- a/src/commands/admin/Countdown.ts
+++ b/src/commands/admin/Countdown.ts
@@ -34,6 +34,9 @@ const REQUIRED_CHANNEL_PERMS = [
     PermissionFlagsBits.EmbedLinks,
 ]
 
+/** Discord's maximum embed description length. */
+const EMBED_DESCRIPTION_LIMIT = 4096
+
 export default {
     data: new SlashCommandBuilder()
         .setName("countdown")
@@ -287,7 +290,14 @@ async function handleCreate(
         throw err
     }
 
-    await placeholder.edit({ content: null, embeds: [buildCountdownEmbed(entry)] })
+    try {
+        await placeholder.edit({ content: null, embeds: [buildCountdownEmbed(entry)] })
+    } catch (editErr: unknown) {
+        client.warn(
+            `[Countdown] Failed to render initial embed for countdown #${entry.id} (message ${placeholder.id}); the periodic updater will correct the stale message:`,
+            editErr
+        )
+    }
 
     return interaction.editReply({
         content: `Created countdown **#${entry.id}** for **${eventName}** in ${targetChannel}.`,
@@ -310,19 +320,35 @@ async function handleList(
     }
 
     const now = Date.now()
+    const entries = countdowns.map((c) => {
+        const remaining = c.targetTime.getTime() - now
+        const remainingText = remaining <= 0 ? "Event started!" : formatCountdownDuration(remaining)
+        return `**#${c.id}** — ${c.eventName}\n<#${c.channelId}> • ${remainingText}`
+    })
+
+    const separator = "\n\n"
+    const safeLimit = EMBED_DESCRIPTION_LIMIT - 100
+    const included: string[] = []
+    let length = 0
+    for (const entry of entries) {
+        const added = included.length === 0 ? entry.length : separator.length + entry.length
+        if (length + added > safeLimit) {
+            break
+        }
+        included.push(entry)
+        length += added
+    }
+
+    let description = included.join(separator)
+    const omitted = entries.length - included.length
+    if (omitted > 0) {
+        description += `${separator}…and ${omitted} more countdown${omitted === 1 ? "" : "s"}`
+    }
+
     const embed = new EmbedBuilder()
         .setColor(0x5865f2)
         .setTitle("Active Countdowns")
-        .setDescription(
-            countdowns
-                .map((c) => {
-                    const remaining = c.targetTime.getTime() - now
-                    const remainingText =
-                        remaining <= 0 ? "Event started!" : formatCountdownDuration(remaining)
-                    return `**#${c.id}** — ${c.eventName}\n<#${c.channelId}> • ${remainingText}`
-                })
-                .join("\n\n")
-        )
+        .setDescription(description)
         .setTimestamp()
 
     return interaction.editReply({ embeds: [embed] })

--- a/src/events/onReady.ts
+++ b/src/events/onReady.ts
@@ -2,6 +2,7 @@ import { ActivityType } from "discord.js"
 import type BotClient from "../lib/BotClient.js"
 import { attachDiscordLogForwarding } from "../util/discordLogForward.js"
 import { refreshAllControlMessages } from "./handlers/handleControlChannel.js"
+import { updateAllCountdowns } from "../util/countdownUpdater.js"
 
 export default async (client: BotClient) => {
     client.on("clientReady", () => {
@@ -26,6 +27,16 @@ export default async (client: BotClient) => {
         )
 
         user.setActivity("I hate that Pancake guy!", { type: ActivityType.Custom })
+
+        // Refresh countdown messages immediately, then every minute.
+        updateAllCountdowns(client).catch((err: unknown) =>
+            client.error("[onReady] initial updateAllCountdowns failed:", err)
+        )
+        setInterval(() => {
+            updateAllCountdowns(client).catch((err: unknown) =>
+                client.error("[onReady] updateAllCountdowns interval failed:", err)
+            )
+        }, 60 * 1000)
 
         // Create a toggle for status rotation
         let showGuildCount = true

--- a/src/lib/BotClient.ts
+++ b/src/lib/BotClient.ts
@@ -9,6 +9,7 @@ import { initializeDatabaseConnection, runPrismaMigrateDeploy } from "./database
 import { migrateDownloadMetadata, migrateGuildSettings } from "../util/migrateJsonToDatabase.js"
 import { initializeGuildSettingsStore } from "../util/saveControlChannel.js"
 import { initializeDownloadMetadataStore } from "../util/downloadMetadataStore.js"
+import { initializeCountdownStore } from "../util/countdownStore.js"
 
 export default class BotClient extends Client {
     logger: Logger
@@ -102,6 +103,7 @@ export default class BotClient extends Client {
         try {
             await initializeGuildSettingsStore(this)
             await initializeDownloadMetadataStore(this)
+            await initializeCountdownStore(this)
             this.info(
                 "BotClient start: Runtime settings/metadata caches initialized from database."
             )

--- a/src/repositories/countdownRepository.ts
+++ b/src/repositories/countdownRepository.ts
@@ -1,0 +1,102 @@
+import { getPrismaClient } from "../lib/database.js"
+import type { CountdownEntry, CountdownInput, CountdownStore } from "../types/index.js"
+
+const DISCORD_SNOWFLAKE_ID_RE = /^\d{1,20}$/
+const MAX_SNOWFLAKE = (1n << 64n) - 1n
+
+/** Trims and validates a Discord snowflake: must be a positive uint64 digit string. */
+function normalizeSnowflake(value: unknown): string | null {
+    if (typeof value !== "string") return null
+    const t = value.trim()
+    if (!DISCORD_SNOWFLAKE_ID_RE.test(t)) return null
+    try {
+        const n = BigInt(t)
+        if (n < 1n || n > MAX_SNOWFLAKE) return null
+    } catch {
+        return null
+    }
+    return t
+}
+
+/** Maps a Prisma row to the domain {@link CountdownEntry} shape. */
+function toCountdownEntry(row: {
+    id: number
+    guildId: string
+    channelId: string
+    messageId: string
+    eventName: string
+    description: string | null
+    imageUrl: string | null
+    color: number | null
+    footer: string | null
+    targetTime: Date
+    createdBy: string
+    createdAt: Date
+}): CountdownEntry {
+    return {
+        id: row.id,
+        guildId: row.guildId,
+        channelId: row.channelId,
+        messageId: row.messageId,
+        eventName: row.eventName,
+        description: row.description,
+        imageUrl: row.imageUrl,
+        color: row.color,
+        footer: row.footer,
+        targetTime: row.targetTime,
+        createdBy: row.createdBy,
+        createdAt: row.createdAt,
+    }
+}
+
+/** Reads all countdown rows and returns a map keyed by countdown id. */
+export async function getAllCountdownsFromDatabase(): Promise<CountdownStore> {
+    const prisma = getPrismaClient()
+    const rows = await prisma.countdown.findMany()
+    return rows.reduce<CountdownStore>((acc, row) => {
+        acc[row.id] = toCountdownEntry(row)
+        return acc
+    }, {})
+}
+
+/** Persists a new countdown and returns the created entry (with its assigned id). */
+export async function createCountdown(input: CountdownInput): Promise<CountdownEntry> {
+    const guildId = normalizeSnowflake(input.guildId)
+    const channelId = normalizeSnowflake(input.channelId)
+    const messageId = normalizeSnowflake(input.messageId)
+    const createdBy = normalizeSnowflake(input.createdBy)
+    if (!guildId || !channelId || !messageId || !createdBy) {
+        throw new Error("createCountdown: invalid Discord snowflake in input.")
+    }
+    const prisma = getPrismaClient()
+    const row = await prisma.countdown.create({
+        data: {
+            guildId,
+            channelId,
+            messageId,
+            eventName: input.eventName,
+            description: input.description,
+            imageUrl: input.imageUrl,
+            color: input.color,
+            footer: input.footer,
+            targetTime: input.targetTime,
+            createdBy,
+        },
+    })
+    return toCountdownEntry(row)
+}
+
+/** Removes a single countdown by id. No-op if the row no longer exists. */
+export async function deleteCountdown(id: number): Promise<void> {
+    const prisma = getPrismaClient()
+    await prisma.countdown.deleteMany({ where: { id } })
+}
+
+/** Bulk-removes countdowns whose target time is at or before `beforeTime`; returns rows deleted. */
+export async function deleteExpiredCountdowns(beforeTime: Date): Promise<number> {
+    const prisma = getPrismaClient()
+    const result = await prisma.countdown.deleteMany({
+        where: { targetTime: { lte: beforeTime } },
+    })
+    return result.count
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -223,6 +223,41 @@ export interface PlaylistTrackInput {
     addedAt: Date
 }
 
+/** A persisted countdown that renders an auto-updating embed in a guild channel. */
+export interface CountdownEntry {
+    id: number
+    guildId: string
+    channelId: string
+    messageId: string
+    eventName: string
+    description: string | null
+    imageUrl: string | null
+    /** Embed accent color as a 0xRRGGBB integer, or null for the default. */
+    color: number | null
+    /** Custom embed footer text, or null to show the countdown id reference. */
+    footer: string | null
+    targetTime: Date
+    createdBy: string
+    createdAt: Date
+}
+
+/** Input for creating a countdown (id/createdAt assigned by the database). */
+export interface CountdownInput {
+    guildId: string
+    channelId: string
+    messageId: string
+    eventName: string
+    description: string | null
+    imageUrl: string | null
+    color: number | null
+    footer: string | null
+    targetTime: Date
+    createdBy: string
+}
+
+/** Map of countdown id → countdown entry. */
+export type CountdownStore = Record<number, CountdownEntry>
+
 /** Tracks a user who left voice while RRQ is active and has queued tracks. */
 export interface DisconnectedRRQUser {
     userId: string

--- a/src/util/countdownEmbed.ts
+++ b/src/util/countdownEmbed.ts
@@ -1,0 +1,40 @@
+import { EmbedBuilder } from "discord.js"
+import type { CountdownEntry } from "../types/index.js"
+import { formatCountdownDuration } from "./formatCountdownDuration.js"
+
+/** Default embed accent color (Discord blurple) when no per-countdown color is set. */
+export const DEFAULT_COUNTDOWN_COLOR = 0x5865f2
+
+/**
+ * Builds the countdown embed shared by the create command and the recurring updater.
+ * `now` is injectable for deterministic remaining-time calculation (defaults to current time).
+ */
+export function buildCountdownEmbed(entry: CountdownEntry, now: number = Date.now()): EmbedBuilder {
+    const targetMs = entry.targetTime.getTime()
+    const unixSeconds = Math.floor(targetMs / 1000)
+    const remaining = targetMs - now
+    const started = remaining <= 0
+
+    const lines: string[] = []
+    if (entry.description) {
+        lines.push(entry.description, "")
+    }
+    lines.push(`**Starts:** <t:${unixSeconds}:F> (<t:${unixSeconds}:R>)`)
+    lines.push(
+        started
+            ? "**Time remaining:** Event started!"
+            : `**Time remaining:** ${formatCountdownDuration(remaining)}`
+    )
+
+    const embed = new EmbedBuilder()
+        .setColor(entry.color ?? DEFAULT_COUNTDOWN_COLOR)
+        .setTitle(entry.eventName)
+        .setDescription(lines.join("\n"))
+        .setFooter({ text: entry.footer ?? `Countdown #${entry.id}` })
+
+    if (entry.imageUrl) {
+        embed.setImage(entry.imageUrl)
+    }
+
+    return embed
+}

--- a/src/util/countdownStore.ts
+++ b/src/util/countdownStore.ts
@@ -1,0 +1,116 @@
+import type {
+    CountdownEntry,
+    CountdownInput,
+    CountdownStore,
+    LoggerInterface,
+} from "../types/index.js"
+import {
+    createCountdown as createCountdownInDatabase,
+    deleteCountdown as deleteCountdownInDatabase,
+    getAllCountdownsFromDatabase,
+} from "../repositories/countdownRepository.js"
+import { loggerFromPartial } from "./loggerFromPartial.js"
+
+/** In-memory countdown cache loaded from the database at startup. */
+let countdownCache: CountdownStore = {}
+let initialized = false
+let saveCountdownChain: Promise<void> = Promise.resolve()
+
+/**
+ * Deep-clones the countdown store. `structuredClone` is required here (not the JSON fallback)
+ * because entries carry `Date` fields that JSON round-tripping would corrupt; Node 24+ always
+ * provides `structuredClone` (see repo `engines`).
+ */
+function cloneStore(store: CountdownStore): CountdownStore {
+    return structuredClone(store)
+}
+
+function cloneEntry(entry: CountdownEntry): CountdownEntry {
+    return structuredClone(entry)
+}
+
+/** Returns whether {@link initializeCountdownStore} has finished loading from the database. */
+export function isCountdownStoreInitialized(): boolean {
+    return initialized
+}
+
+/** Loads all countdowns from the database into the in-memory cache. */
+export async function initializeCountdownStore(
+    loggerInstance?: Partial<LoggerInterface>
+): Promise<void> {
+    const logger = loggerFromPartial(loggerInstance)
+    try {
+        const loaded = await getAllCountdownsFromDatabase()
+        countdownCache = cloneStore(loaded)
+        initialized = true
+        logger.info(
+            `[countdown] Loaded ${Object.keys(countdownCache).length} countdown(s) from database.`
+        )
+    } catch (error: unknown) {
+        logger.error("[countdown] Failed to load countdowns from database:", error)
+        initialized = false
+        throw error
+    }
+}
+
+async function withCountdownSaveLock<T>(work: () => Promise<T>): Promise<T> {
+    let release: () => void = () => {}
+    const previous = saveCountdownChain
+    saveCountdownChain = new Promise<void>((resolve) => {
+        release = resolve
+    })
+    await previous
+    try {
+        return await work()
+    } finally {
+        release()
+    }
+}
+
+function assertInitialized(): void {
+    if (!initialized) {
+        throw new Error(
+            "Countdown store accessed before initialization. Call initializeCountdownStore() first."
+        )
+    }
+}
+
+/** Returns a clone of a single countdown, or undefined if not found. */
+export function getCountdown(id: number): CountdownEntry | undefined {
+    assertInitialized()
+    const entry = countdownCache[id]
+    return entry ? cloneEntry(entry) : undefined
+}
+
+/** Returns a clone of all countdowns keyed by id. */
+export function getAllCountdowns(): CountdownStore {
+    assertInitialized()
+    return cloneStore(countdownCache)
+}
+
+/** Returns clones of all countdowns belonging to a guild. */
+export function getCountdownsForGuild(guildId: string): CountdownEntry[] {
+    assertInitialized()
+    return Object.values(countdownCache)
+        .filter((entry) => entry.guildId === guildId)
+        .map(cloneEntry)
+}
+
+/** Persists a new countdown to the database and adds it to the cache. Returns the created entry. */
+export async function addCountdown(input: CountdownInput): Promise<CountdownEntry> {
+    assertInitialized()
+    return withCountdownSaveLock(async () => {
+        const created = await createCountdownInDatabase(input)
+        countdownCache[created.id] = cloneEntry(created)
+        return cloneEntry(created)
+    })
+}
+
+/** Removes a countdown from the database and the cache. */
+export async function removeCountdown(id: number): Promise<void> {
+    assertInitialized()
+    await withCountdownSaveLock(async () => {
+        await deleteCountdownInDatabase(id)
+        delete countdownCache[id]
+    })
+}

--- a/src/util/countdownUpdater.ts
+++ b/src/util/countdownUpdater.ts
@@ -1,0 +1,64 @@
+import type BotClient from "../lib/BotClient.js"
+import { buildCountdownEmbed } from "./countdownEmbed.js"
+import { getAllCountdowns, removeCountdown } from "./countdownStore.js"
+
+/** Discord API error codes treated as permanently unrecoverable for a countdown message. */
+const UNRECOVERABLE_CODES = new Set([
+    10003, // Unknown Channel
+    10008, // Unknown Message
+    50001, // Missing Access
+    50013, // Missing Permissions
+])
+
+function isUnrecoverableError(error: unknown): boolean {
+    if (typeof error === "object" && error !== null && "code" in error) {
+        const code = (error as { code: unknown }).code
+        return typeof code === "number" && UNRECOVERABLE_CODES.has(code)
+    }
+    return false
+}
+
+/**
+ * Refreshes every countdown message once. Edits each embed with the latest remaining time,
+ * removes countdowns whose channel/message is gone or whose permissions were lost, and removes
+ * expired countdowns after writing their final "Event started!" state.
+ */
+export async function updateAllCountdowns(client: BotClient): Promise<void> {
+    const countdowns = Object.values(getAllCountdowns())
+    if (countdowns.length === 0) return
+
+    const now = Date.now()
+
+    for (const entry of countdowns) {
+        try {
+            const channel = await client.channels.fetch(entry.channelId).catch((): null => null)
+            if (!channel || !("messages" in channel)) {
+                await removeCountdown(entry.id)
+                continue
+            }
+
+            const message = await channel.messages.fetch(entry.messageId).catch((): null => null)
+            if (!message) {
+                await removeCountdown(entry.id)
+                continue
+            }
+
+            await message.edit({ content: null, embeds: [buildCountdownEmbed(entry, now)] })
+
+            if (entry.targetTime.getTime() <= now) {
+                await removeCountdown(entry.id)
+            }
+        } catch (error: unknown) {
+            if (isUnrecoverableError(error)) {
+                await removeCountdown(entry.id).catch((removeErr: unknown) =>
+                    client.warn(
+                        `[countdown] Failed to remove unrecoverable countdown #${entry.id}:`,
+                        removeErr
+                    )
+                )
+            } else {
+                client.warn(`[countdown] Failed to update countdown #${entry.id}:`, error)
+            }
+        }
+    }
+}

--- a/src/util/formatCountdownDuration.ts
+++ b/src/util/formatCountdownDuration.ts
@@ -1,0 +1,28 @@
+/**
+ * Formats remaining milliseconds as a human-readable countdown string, e.g.
+ * `"3 days, 4 hours, 20 minutes"` or `"45 minutes"`. Seconds are intentionally omitted because
+ * countdown messages only refresh once per minute, so a seconds value would always be stale.
+ * Zero-value units are omitted. Returns `"Event started!"` for non-positive or non-finite input.
+ */
+export function formatCountdownDuration(ms: number): string {
+    if (!Number.isFinite(ms) || ms <= 0) {
+        return "Event started!"
+    }
+
+    const totalMinutes = Math.floor(ms / 60000)
+    const days = Math.floor(totalMinutes / 1440)
+    const hours = Math.floor((totalMinutes % 1440) / 60)
+    const minutes = totalMinutes % 60
+
+    const parts: string[] = []
+    if (days > 0) parts.push(`${days} ${days === 1 ? "day" : "days"}`)
+    if (hours > 0) parts.push(`${hours} ${hours === 1 ? "hour" : "hours"}`)
+    if (minutes > 0) parts.push(`${minutes} ${minutes === 1 ? "minute" : "minutes"}`)
+
+    // Possible only when 0 < ms < 60000 (under a minute rounds all buckets to zero).
+    if (parts.length === 0) {
+        return "Less than a minute"
+    }
+
+    return parts.join(", ")
+}

--- a/src/util/parseEventDateTime.ts
+++ b/src/util/parseEventDateTime.ts
@@ -1,0 +1,70 @@
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+
+export type ParseEventDateTimeResult =
+    | { ok: true; epochSeconds: number }
+    | { ok: false; error: string }
+
+/** Validates that a string is a usable IANA time zone (e.g. `America/Chicago`). */
+function isValidTimeZone(timeZone: string): boolean {
+    try {
+        new Intl.DateTimeFormat("en-US", { timeZone })
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Returns the offset (ms) of `timeZone` from UTC at the given instant.
+ * Positive means the zone is ahead of UTC. Uses the locale-string round-trip technique
+ * so no external date library is required.
+ */
+function timeZoneOffsetMs(timeZone: string, instant: Date): number {
+    const tzDate = new Date(instant.toLocaleString("en-US", { timeZone }))
+    const utcDate = new Date(instant.toLocaleString("en-US", { timeZone: "UTC" }))
+    return tzDate.getTime() - utcDate.getTime()
+}
+
+/**
+ * Converts a wall-clock `date` (`YYYY-MM-DD`) and `time` (`HH:MM`, 24h) interpreted in
+ * `timeZone` (IANA name) to a Unix timestamp in seconds. Validates formats, calendar validity,
+ * and the time zone. The offset is resolved at the target instant so DST is accounted for.
+ */
+export function parseEventDateTime(
+    date: string,
+    time: string,
+    timeZone: string
+): ParseEventDateTimeResult {
+    const d = date.trim()
+    const t = time.trim()
+    if (!DATE_RE.test(d)) {
+        return { ok: false, error: "Date must be in `YYYY-MM-DD` format (e.g. `2026-12-25`)." }
+    }
+    if (!TIME_RE.test(t)) {
+        return { ok: false, error: "Time must be in 24-hour `HH:MM` format (e.g. `18:30`)." }
+    }
+    if (!isValidTimeZone(timeZone)) {
+        return { ok: false, error: `Unknown time zone: \`${timeZone}\`.` }
+    }
+
+    const [year, month, day] = d.split("-").map(Number) as [number, number, number]
+    const [hour, minute] = t.split(":").map(Number) as [number, number]
+
+    // Treat the wall-clock components as if they were UTC, then shift by the zone's offset.
+    const asUtc = Date.UTC(year, month - 1, day, hour, minute)
+
+    // Reject calendar overflow (e.g. 2026-02-30 rolling into March).
+    const check = new Date(asUtc)
+    if (
+        check.getUTCFullYear() !== year ||
+        check.getUTCMonth() !== month - 1 ||
+        check.getUTCDate() !== day
+    ) {
+        return { ok: false, error: "That date does not exist on the calendar." }
+    }
+
+    const offset = timeZoneOffsetMs(timeZone, new Date(asUtc))
+    const epochMs = asUtc - offset
+    return { ok: true, epochSeconds: Math.floor(epochMs / 1000) }
+}


### PR DESCRIPTION
## Summary

Implements #85: a per-guild `/countdown` command that posts an embed counting down to an event, auto-updating every minute and surviving bot restarts.

- `/countdown create | list | delete` (ManageGuild-gated, guild-only)
- Target time via `date` + `time` + `timezone` picker (converted to a Unix timestamp in the background), or a raw `timestamp` as an advanced fallback
- Optional `description`, `image_url` (http/https validated), `color` (named picker) and custom `footer`
- Persisted in Postgres (new `Countdown` model + repository + in-memory store with serial save lock)
- Recurring updater refreshes messages every 60s; removes countdowns whose channel/message is gone or whose permissions were lost; writes a final "Event started!" state on expiry

## Implementation notes

- Divergences from the original CodeRabbit plan: `Int` autoincrement id (typeable in `delete`), no `@@map` (matches existing bot models), store init in `BotClient.start()` (alongside other cache init), shared `buildCountdownEmbed` in its own util so the updater stays decoupled from the command module.
- Seconds are intentionally omitted from the remaining-time text since the message only refreshes once per minute.
- `color`/`footer` are added as a separate migration (`20260604130000_countdown_color_footer`) so existing databases that already applied `add_countdown` get the new columns cleanly.

## Test plan

- [ ] `yarn build:bot` and restart the bot; confirm it logs in (no `initializeCountdownStore` error)
- [ ] Deploy commands (`/deploycommands deploylocal` or `yarn deployGuild`)
- [ ] `/countdown create` with `date`+`time`+`timezone`; verify the embed and that "Starts" renders in viewer-local time
- [ ] `/countdown create` with a raw `timestamp`, plus `description`, `image_url`, `color`, `footer`
- [ ] Confirm the embed updates after a minute and on restart
- [ ] `/countdown list` and `/countdown delete <id>`; verify the message is removed
- [ ] Expiry: countdown flips to "Event started!" and is cleaned up
