### PR TITLE
feat: post finish message with role mention when countdown ends

### DIFF
--- a/prisma/migrations/20260604140000_countdown_finish_message/migration.sql
+++ b/prisma/migrations/20260604140000_countdown_finish_message/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Countdown" ADD COLUMN "finishMessage" TEXT;
+ALTER TABLE "Countdown" ADD COLUMN "mentionRoleId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,5 @@
 generator client {
-  provider        = "prisma-client-js"
+  provider = "prisma-client-js"
 }
 
 datasource db {
@@ -39,34 +39,36 @@ model Playlist {
 }
 
 model PlaylistTrack {
-  id            Int      @id @default(autoincrement())
-  playlistId    Int
-  playlist      Playlist @relation(fields: [playlistId], references: [id], onDelete: Cascade)
-  title         String
-  uri           String
-  author        String
-  duration      Int
-  thumbnailUrl  String?
-  addedAt       DateTime
-  position      Int
+  id           Int      @id @default(autoincrement())
+  playlistId   Int
+  playlist     Playlist @relation(fields: [playlistId], references: [id], onDelete: Cascade)
+  title        String
+  uri          String
+  author       String
+  duration     Int
+  thumbnailUrl String?
+  addedAt      DateTime
+  position     Int
 
   @@unique([playlistId, position])
   @@index([playlistId], name: "PlaylistTrack_playlistId_idx")
 }
 
 model Countdown {
-  id          Int      @id @default(autoincrement())
-  guildId     String
-  channelId   String
-  messageId   String
-  eventName   String
-  description String?
-  imageUrl    String?
-  color       Int?
-  footer      String?
-  targetTime  DateTime
-  createdBy   String
-  createdAt   DateTime @default(now())
+  id            Int      @id @default(autoincrement())
+  guildId       String
+  channelId     String
+  messageId     String
+  eventName     String
+  description   String?
+  imageUrl      String?
+  color         Int?
+  footer        String?
+  finishMessage String?
+  mentionRoleId String?
+  targetTime    DateTime
+  createdBy     String
+  createdAt     DateTime @default(now())
 
   @@index([guildId], name: "Countdown_guildId_idx")
 }
@@ -120,8 +122,8 @@ model Account {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
-  @@index([userId])
   @@unique([providerId, accountId])
+  @@index([userId])
   @@map("account")
 }
 

--- a/src/commands/admin/Countdown.ts
+++ b/src/commands/admin/Countdown.ts
@@ -140,6 +140,19 @@ export default {
                         .setRequired(false)
                         .setMaxLength(256)
                 )
+                .addStringOption((opt) =>
+                    opt
+                        .setName("finish_message")
+                        .setDescription("Message posted in the channel when the countdown finishes")
+                        .setRequired(false)
+                        .setMaxLength(2000)
+                )
+                .addRoleOption((opt) =>
+                    opt
+                        .setName("mention_role")
+                        .setDescription("Role to ping in the finish message")
+                        .setRequired(false)
+                )
         )
         .addSubcommand((sub) =>
             sub.setName("list").setDescription("List active countdowns in this server.")
@@ -203,6 +216,8 @@ async function handleCreate(
     const imageUrl = interaction.options.getString("image_url")
     const color = interaction.options.getInteger("color")
     const footer = interaction.options.getString("footer")
+    const finishMessage = interaction.options.getString("finish_message")
+    const mentionRole = interaction.options.getRole("mention_role")
 
     let targetMs: number
     if (date || time) {
@@ -277,6 +292,8 @@ async function handleCreate(
             imageUrl: imageUrl ?? null,
             color: color ?? null,
             footer: footer ?? null,
+            finishMessage: finishMessage ?? null,
+            mentionRoleId: mentionRole?.id ?? null,
             targetTime: new Date(targetMs),
             createdBy: interaction.user.id,
         })

--- a/src/repositories/countdownRepository.ts
+++ b/src/repositories/countdownRepository.ts
@@ -29,6 +29,8 @@ function toCountdownEntry(row: {
     imageUrl: string | null
     color: number | null
     footer: string | null
+    finishMessage: string | null
+    mentionRoleId: string | null
     targetTime: Date
     createdBy: string
     createdAt: Date
@@ -43,6 +45,8 @@ function toCountdownEntry(row: {
         imageUrl: row.imageUrl,
         color: row.color,
         footer: row.footer,
+        finishMessage: row.finishMessage,
+        mentionRoleId: row.mentionRoleId,
         targetTime: row.targetTime,
         createdBy: row.createdBy,
         createdAt: row.createdAt,
@@ -79,6 +83,8 @@ export async function createCountdown(input: CountdownInput): Promise<CountdownE
             imageUrl: input.imageUrl,
             color: input.color,
             footer: input.footer,
+            finishMessage: input.finishMessage,
+            mentionRoleId: input.mentionRoleId ? normalizeSnowflake(input.mentionRoleId) : null,
             targetTime: input.targetTime,
             createdBy,
         },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -236,6 +236,10 @@ export interface CountdownEntry {
     color: number | null
     /** Custom embed footer text, or null to show the countdown id reference. */
     footer: string | null
+    /** Message posted to the channel when the countdown finishes, or null for none. */
+    finishMessage: string | null
+    /** Role id to mention in the finish message, or null for no mention. */
+    mentionRoleId: string | null
     targetTime: Date
     createdBy: string
     createdAt: Date
@@ -251,6 +255,8 @@ export interface CountdownInput {
     imageUrl: string | null
     color: number | null
     footer: string | null
+    finishMessage: string | null
+    mentionRoleId: string | null
     targetTime: Date
     createdBy: string
 }

--- a/src/util/countdownEmbed.ts
+++ b/src/util/countdownEmbed.ts
@@ -38,3 +38,15 @@ export function buildCountdownEmbed(entry: CountdownEntry, now: number = Date.no
 
     return embed
 }
+
+/**
+ * Builds the embed attached to the finish announcement (event name + image), or null when the
+ * countdown has no image to re-post.
+ */
+export function buildCountdownFinishEmbed(entry: CountdownEntry): EmbedBuilder | null {
+    if (!entry.imageUrl) return null
+    return new EmbedBuilder()
+        .setColor(entry.color ?? DEFAULT_COUNTDOWN_COLOR)
+        .setTitle(entry.eventName)
+        .setImage(entry.imageUrl)
+}

--- a/src/util/countdownUpdater.ts
+++ b/src/util/countdownUpdater.ts
@@ -1,5 +1,7 @@
+import type { SendableChannels } from "discord.js"
 import type BotClient from "../lib/BotClient.js"
-import { buildCountdownEmbed } from "./countdownEmbed.js"
+import type { CountdownEntry } from "../types/index.js"
+import { buildCountdownEmbed, buildCountdownFinishEmbed } from "./countdownEmbed.js"
 import { getAllCountdowns, removeCountdown } from "./countdownStore.js"
 
 /** Discord API error codes treated as permanently unrecoverable for a countdown message. */
@@ -16,6 +18,32 @@ function isUnrecoverableError(error: unknown): boolean {
         return typeof code === "number" && UNRECOVERABLE_CODES.has(code)
     }
     return false
+}
+
+/**
+ * Posts the finish announcement (optional text + role ping + re-posted image) into the
+ * countdown's own channel. No-op when nothing was configured to announce. Errors are swallowed
+ * so they never block cleanup of the expired countdown.
+ */
+async function postFinishMessage(
+    client: BotClient,
+    channel: SendableChannels,
+    entry: CountdownEntry
+): Promise<void> {
+    const mention = entry.mentionRoleId ? `<@&${entry.mentionRoleId}>` : ""
+    const content = [mention, entry.finishMessage ?? ""].filter(Boolean).join(" ").trim()
+    const finishEmbed = buildCountdownFinishEmbed(entry)
+    if (!content && !finishEmbed) return
+
+    try {
+        await channel.send({
+            content: content || undefined,
+            embeds: finishEmbed ? [finishEmbed] : [],
+            allowedMentions: { roles: entry.mentionRoleId ? [entry.mentionRoleId] : [] },
+        })
+    } catch (error: unknown) {
+        client.warn(`[countdown] Failed to post finish message for countdown #${entry.id}:`, error)
+    }
 }
 
 /**
@@ -46,6 +74,9 @@ export async function updateAllCountdowns(client: BotClient): Promise<void> {
             await message.edit({ content: null, embeds: [buildCountdownEmbed(entry, now)] })
 
             if (entry.targetTime.getTime() <= now) {
+                if (channel.isSendable()) {
+                    await postFinishMessage(client, channel, entry)
+                }
                 await removeCountdown(entry.id)
             }
         } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Follow-up to #87. Lets a countdown announce itself when it finishes.

- New `/countdown create` options: `finish_message` (text, max 2000) and `mention_role` (role to ping)
- On expiry, the bot posts a message in the countdown's own channel with the text + role mention and re-attaches the image as an embed
- Role mentions are locked to the selected role via `allowedMentions` (no `@everyone`/`@here` abuse)
- No-op when nothing was configured; send failures are swallowed so cleanup still runs
- Persisted via new `finishMessage` / `mentionRoleId` columns (migration `20260604140000_countdown_finish_message`) so it survives restarts

## Test plan

- [ ] Apply migrations and restart the bot; confirm it logs in
- [ ] Redeploy commands (`/deploycommands deploylocal`); confirm `finish_message` + `mention_role` appear
- [ ] Create a near-future countdown with `finish_message`, `mention_role`, and `image_url`
- [ ] On expiry: message posts in the same channel, pings only that role, and shows the image
- [ ] Create a countdown with no finish options: nothing extra is posted on expiry
