### PR TITLE
fix: prevent countdown loss on transient fetches and metadata save races

### DIFF
--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -533,14 +533,17 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
 
                 const metadata: DownloadsMetadataStore = getDownloadMetadataStore()
 
-                metadata[downloadMetadataStoreKey(guildId, downloadedFile)] = {
+                const metadataKey = downloadMetadataStoreKey(guildId, downloadedFile)
+                metadata[metadataKey] = {
                     downloadDate: new Date().toISOString(),
                     originalUrl: url,
                     filePath: filePath,
                     guildId: guildId,
                 }
 
-                const metadataSaved = await saveDownloadMetadataStore(metadata, client)
+                const metadataSaved = await saveDownloadMetadataStore(metadata, client, {
+                    touchedStoreKeys: [metadataKey],
+                })
                 if (metadataSaved) {
                     client.debug(`[Download] Updated metadata for ${downloadedFile}`)
                 } else {

--- a/src/repositories/downloadMetadataRepository.ts
+++ b/src/repositories/downloadMetadataRepository.ts
@@ -175,10 +175,6 @@ export async function replaceDownloadMetadataStoreInDatabase(
     )
 
     if (rows.length === 0 && deleteStoreKeys.length === 0) {
-        if (skippedEntries.length > 0) {
-            return { rowsWritten: 0, rowsDeleted: 0, skippedEntries }
-        }
-        await prisma.downloadMetadata.deleteMany({})
         return { rowsWritten: 0, rowsDeleted: 0, skippedEntries }
     }
 

--- a/src/util/countdownUpdater.ts
+++ b/src/util/countdownUpdater.ts
@@ -1,4 +1,4 @@
-import type { SendableChannels } from "discord.js"
+import type { Message, SendableChannels, TextBasedChannel } from "discord.js"
 import type BotClient from "../lib/BotClient.js"
 import type { CountdownEntry } from "../types/index.js"
 import { buildCountdownEmbed, buildCountdownFinishEmbed } from "./countdownEmbed.js"
@@ -59,15 +59,38 @@ export async function updateAllCountdowns(client: BotClient): Promise<void> {
 
     for (const entry of countdowns) {
         try {
-            const channel = await client.channels.fetch(entry.channelId).catch((): null => null)
-            if (!channel || !("messages" in channel)) {
-                await removeCountdown(entry.id)
+            let channel: TextBasedChannel
+            try {
+                const fetched = await client.channels.fetch(entry.channelId)
+                if (!("messages" in fetched)) {
+                    await removeCountdown(entry.id)
+                    continue
+                }
+                channel = fetched
+            } catch (error: unknown) {
+                if (isUnrecoverableError(error)) {
+                    await removeCountdown(entry.id)
+                } else {
+                    client.warn(
+                        `[countdown] Transient channel fetch failure for countdown #${entry.id}; will retry:`,
+                        error
+                    )
+                }
                 continue
             }
 
-            const message = await channel.messages.fetch(entry.messageId).catch((): null => null)
-            if (!message) {
-                await removeCountdown(entry.id)
+            let message: Message
+            try {
+                message = await channel.messages.fetch(entry.messageId)
+            } catch (error: unknown) {
+                if (isUnrecoverableError(error)) {
+                    await removeCountdown(entry.id)
+                } else {
+                    client.warn(
+                        `[countdown] Transient message fetch failure for countdown #${entry.id}; will retry:`,
+                        error
+                    )
+                }
                 continue
             }
 

--- a/src/util/countdownUpdater.ts
+++ b/src/util/countdownUpdater.ts
@@ -62,6 +62,10 @@ export async function updateAllCountdowns(client: BotClient): Promise<void> {
             let channel: TextBasedChannel
             try {
                 const fetched = await client.channels.fetch(entry.channelId)
+                if (fetched == null) {
+                    await removeCountdown(entry.id)
+                    continue
+                }
                 if (!("messages" in fetched)) {
                     await removeCountdown(entry.id)
                     continue

--- a/src/util/downloadMetadataStore.ts
+++ b/src/util/downloadMetadataStore.ts
@@ -1,4 +1,8 @@
-import type { DownloadsMetadataStore, LoggerInterface } from "../types/index.js"
+import type {
+    DownloadFileMetadata,
+    DownloadsMetadataStore,
+    LoggerInterface,
+} from "../types/index.js"
 import {
     getDownloadMetadataStoreFromDatabase,
     replaceDownloadMetadataStoreInDatabase,
@@ -13,6 +17,12 @@ function cloneStore(store: DownloadsMetadataStore): DownloadsMetadataStore {
     return typeof structuredClone === "function"
         ? structuredClone(store)
         : (JSON.parse(JSON.stringify(store)) as DownloadsMetadataStore)
+}
+
+function cloneMetadataEntry(entry: DownloadFileMetadata): DownloadFileMetadata {
+    return typeof structuredClone === "function"
+        ? structuredClone(entry)
+        : (JSON.parse(JSON.stringify(entry)) as DownloadFileMetadata)
 }
 
 /** Loads download metadata from the database into the in-memory cache. */
@@ -51,6 +61,11 @@ async function withDownloadMetadataSaveLock<T>(work: () => Promise<T>): Promise<
 export type SaveDownloadMetadataStoreOptions = {
     /** Store keys removed from the in-memory map (cleanup); must be listed explicitly. */
     deleteStoreKeys?: string[]
+    /**
+     * Store keys to take from `metadata` when persisting. When set, other keys in `metadata` are
+     * ignored and the latest database values are kept (prevents lost updates across concurrent saves).
+     */
+    touchedStoreKeys?: string[]
 }
 
 /** Returns a clone of the metadata cache so callers cannot mutate shared state. */
@@ -71,11 +86,30 @@ export async function saveDownloadMetadataStore(
     const deleteStoreKeys = (options?.deleteStoreKeys ?? []).filter(
         (key) => typeof key === "string" && key.length > 0
     )
+    const touchedStoreKeys = (options?.touchedStoreKeys ?? []).filter(
+        (key) => typeof key === "string" && key.length > 0
+    )
     return withDownloadMetadataSaveLock(async () => {
         const logger = loggerFromPartial(loggerInstance)
         const previousCache = cloneStore(downloadMetadataCache)
         try {
-            const result = await replaceDownloadMetadataStoreInDatabase(nextCache, {
+            const dbStore = await getDownloadMetadataStoreFromDatabase()
+            const merged = cloneStore(dbStore)
+            if (touchedStoreKeys.length > 0) {
+                for (const key of touchedStoreKeys) {
+                    const row = nextCache[key]
+                    if (row !== undefined) {
+                        merged[key] = cloneMetadataEntry(row)
+                    }
+                }
+            } else if (deleteStoreKeys.length === 0) {
+                for (const [key, row] of Object.entries(nextCache)) {
+                    if (row !== undefined) {
+                        merged[key] = cloneMetadataEntry(row)
+                    }
+                }
+            }
+            const result = await replaceDownloadMetadataStoreInDatabase(merged, {
                 deleteStoreKeys,
             })
             try {

--- a/src/util/downloadMetadataStore.ts
+++ b/src/util/downloadMetadataStore.ts
@@ -86,16 +86,16 @@ export async function saveDownloadMetadataStore(
     const deleteStoreKeys = (options?.deleteStoreKeys ?? []).filter(
         (key) => typeof key === "string" && key.length > 0
     )
+    const hasTouchedOption = options?.touchedStoreKeys !== undefined
     const touchedStoreKeys = (options?.touchedStoreKeys ?? []).filter(
         (key) => typeof key === "string" && key.length > 0
     )
     return withDownloadMetadataSaveLock(async () => {
         const logger = loggerFromPartial(loggerInstance)
-        const previousCache = cloneStore(downloadMetadataCache)
         try {
             const dbStore = await getDownloadMetadataStoreFromDatabase()
             const merged = cloneStore(dbStore)
-            if (touchedStoreKeys.length > 0) {
+            if (hasTouchedOption) {
                 for (const key of touchedStoreKeys) {
                     const row = nextCache[key]
                     if (row !== undefined) {
@@ -118,10 +118,14 @@ export async function saveDownloadMetadataStore(
                 initialized = true
             } catch (reloadErr: unknown) {
                 logger.warn(
-                    "[downloadMetadata] replaceDownloadMetadataStoreInDatabase succeeded but cache reload failed; keeping previous in-memory cache",
+                    "[downloadMetadata] replaceDownloadMetadataStoreInDatabase succeeded but cache reload failed; using persisted snapshot",
                     reloadErr
                 )
-                downloadMetadataCache = previousCache
+                const fallback = cloneStore(merged)
+                for (const key of deleteStoreKeys) {
+                    delete fallback[key]
+                }
+                downloadMetadataCache = fallback
                 initialized = true
                 return false
             }


### PR DESCRIPTION
## Summary

Integrates the two open draft bug PRs into one fix:

- **Countdown (#89):** The minute updater no longer deletes countdown rows when `channels.fetch` or `messages.fetch` fails transiently (rate limits, network). Only unrecoverable Discord codes (unknown channel/message, missing access/permissions) trigger removal; transient failures log and retry on the next interval.
- **Downloads (#86):** `saveDownloadMetadataStore` now re-reads the DB under the save lock and merges only `touchedStoreKeys` (mirroring `saveGuildSettings`), preventing concurrent `/download` and cleanup from overwriting each other. Delete-only saves use the fresh DB snapshot plus explicit `deleteStoreKeys` without stale upserts. Removes the latent `deleteMany({})` footgun on empty store writes.

## Test plan

- [x] `yarn tsc --noEmit`, `yarn lint`, Prettier on touched files
- [ ] Create a countdown; confirm a transient fetch failure does not remove it from `/countdown list`
- [ ] Run `/download` while `/downloads cleanup` is in progress; confirm metadata is not lost or resurrected
- [ ] No slash command redeploy needed

Supersedes #89 and #86.
