### PR TITLE
Route web dashboard queue updates to requester voice channel

### DIFF
--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -92,7 +92,7 @@ export async function searchAndEnqueue(
         }
     }
 
-    const textChannelId = await resolveWebDashboardTextChannelId(guild)
+    const textChannelId = await resolveWebDashboardTextChannelId(guild, voiceChannel)
 
     const botUser = client.user
     if (!botUser) {
@@ -139,6 +139,10 @@ export async function searchAndEnqueue(
                 error: { error: "Could not create the player.", details: message },
             }
         }
+    }
+
+    if (textChannelId) {
+        player.textChannelId = textChannelId
     }
 
     const cleanupCreatedPlayer = async (): Promise<void> => {

--- a/src/botApi/webDashboardTextChannel.ts
+++ b/src/botApi/webDashboardTextChannel.ts
@@ -1,4 +1,9 @@
-import { PermissionFlagsBits, type Guild, type GuildBasedChannel } from "discord.js"
+import {
+    PermissionFlagsBits,
+    type Guild,
+    type GuildBasedChannel,
+    type VoiceBasedChannel,
+} from "discord.js"
 import { getGuildSettings } from "../util/saveControlChannel.js"
 
 function botCanUseWebDashboardTextChannel(guild: Guild, ch: GuildBasedChannel): boolean {
@@ -32,10 +37,20 @@ async function resolveValidTextChannelId(
 }
 
 /**
- * Lavalink `textChannelId` when the web dashboard creates a player: guild control channel if set and
- * usable, otherwise the guild system channel (same idea as `guild.systemChannelId` fallback).
+ * Lavalink `textChannelId` when the web dashboard creates or drives a player: prefer the requester's
+ * voice channel text chat, then guild control channel if set, otherwise the guild system channel.
  */
-export async function resolveWebDashboardTextChannelId(guild: Guild): Promise<string | undefined> {
+export async function resolveWebDashboardTextChannelId(
+    guild: Guild,
+    voiceChannel?: VoiceBasedChannel | null
+): Promise<string | undefined> {
+    if (voiceChannel?.isTextBased() && !voiceChannel.isDMBased()) {
+        const voiceTextId = await resolveValidTextChannelId(guild, voiceChannel.id)
+        if (voiceTextId) {
+            return voiceTextId
+        }
+    }
+
     let controlId: string | undefined
     try {
         const settings = getGuildSettings()


### PR DESCRIPTION
## Summary
- Prefer the requester's active voice channel text chat for Lavalink queue/player messages when starting playback from the web dashboard
- Fall back to guild control channel, then system channel when the bot cannot post in the voice channel chat
- Update existing players' textChannelId on web-driven enqueue so updates follow the requester

## Test plan
- [ ] Join a voice channel and start playback from the web dashboard; confirm track/queue messages appear in that voice channel's text chat
- [ ] Verify fallback to control/system channel when the bot lacks Send Messages in the voice channel
- [ ] Confirm slash-command /play behavior in a text channel is unchanged