### PR TITLE
fix: combine data-loss fixes (#94-#98) and resolve shell-quote alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
         "qs": "^6.15.2",
         "@hono/node-server": "^1.19.13",
         "lodash": "^4.18.0",
+        "shell-quote": "^1.8.4",
         "**/chokidar/**/picomatch": "^2.3.2",
         "**/tinyglobby/**/picomatch": "^4.0.4"
     },

--- a/src/commands/admin/Control-Channel.ts
+++ b/src/commands/admin/Control-Channel.ts
@@ -210,15 +210,19 @@ export default {
                 `[Control-Channel] Removed control channel settings for guild ${guild.id}.`
             )
 
-            if (Object.keys(settings).length === 0) {
+            const rowEmpty = Object.keys(settings).length === 0
+            if (rowEmpty) {
                 client.debug(
                     `[Control-Channel] Removing empty settings entry for guild ${guild.id}.`
                 )
                 delete guildSettings[guild.id]
             }
             const persisted = await saveGuildSettings(guildSettings, client, {
-                deleteGuildIds: [guild.id],
+                ...(rowEmpty ? { deleteGuildIds: [guild.id] } : {}),
                 touchedGuildIds: [guild.id],
+                clearedGuildFields: rowEmpty
+                    ? undefined
+                    : { [guild.id]: ["controlChannelId", "controlMessageId"] },
             })
             client.debug(
                 `[Control-Channel] Persist settings after unset for guild ${guild.id}: ${persisted ? "ok" : "failed"}.`

--- a/src/commands/developer/DownloadLimit.ts
+++ b/src/commands/developer/DownloadLimit.ts
@@ -131,14 +131,16 @@ export default {
         if (subcommand === "clear") {
             if (settings[targetGuildId]?.downloadsMaxMb !== undefined) {
                 delete settings[targetGuildId].downloadsMaxMb
-                let deleteGuildIds: string[] | undefined
-                if (Object.keys(settings[targetGuildId]).length === 0) {
+                const rowEmpty = Object.keys(settings[targetGuildId]).length === 0
+                if (rowEmpty) {
                     delete settings[targetGuildId]
-                    deleteGuildIds = [targetGuildId]
                 }
                 const ok = await saveGuildSettings(settings, client, {
-                    deleteGuildIds,
+                    ...(rowEmpty ? { deleteGuildIds: [targetGuildId] } : {}),
                     touchedGuildIds: [targetGuildId],
+                    clearedGuildFields: rowEmpty
+                        ? undefined
+                        : { [targetGuildId]: ["downloadsMaxMb"] },
                 })
                 if (!ok) {
                     client.error("[DownloadLimit] Failed to persist guild settings after clear.")

--- a/src/util/countdownUpdater.ts
+++ b/src/util/countdownUpdater.ts
@@ -2,14 +2,16 @@ import type { Message, SendableChannels, TextBasedChannel } from "discord.js"
 import type BotClient from "../lib/BotClient.js"
 import type { CountdownEntry } from "../types/index.js"
 import { buildCountdownEmbed, buildCountdownFinishEmbed } from "./countdownEmbed.js"
-import { getAllCountdowns, removeCountdown } from "./countdownStore.js"
+import { getAllCountdowns, getCountdown, removeCountdown } from "./countdownStore.js"
 
-/** Discord API error codes treated as permanently unrecoverable for a countdown message. */
+/**
+ * Discord API error codes that mean the countdown target no longer exists.
+ * Permission errors (50001/50013) are retried — they are often temporary and must not
+ * delete persisted countdown configuration (see handleControlChannel for the same pattern).
+ */
 const UNRECOVERABLE_CODES = new Set([
     10003, // Unknown Channel
     10008, // Unknown Message
-    50001, // Missing Access
-    50013, // Missing Permissions
 ])
 
 function isUnrecoverableError(error: unknown): boolean {
@@ -48,7 +50,7 @@ async function postFinishMessage(
 
 /**
  * Refreshes every countdown message once. Edits each embed with the latest remaining time,
- * removes countdowns whose channel/message is gone or whose permissions were lost, and removes
+ * removes countdowns whose channel/message is gone, and removes
  * expired countdowns after writing their final "Event started!" state.
  */
 export async function updateAllCountdowns(client: BotClient): Promise<void> {
@@ -101,10 +103,15 @@ export async function updateAllCountdowns(client: BotClient): Promise<void> {
             await message.edit({ content: null, embeds: [buildCountdownEmbed(entry, now)] })
 
             if (entry.targetTime.getTime() <= now) {
+                // Another interval pass may have already cleared this countdown (stale snapshot).
+                if (!getCountdown(entry.id)) {
+                    continue
+                }
+                // Remove before posting so a failed DB delete cannot re-ping every interval.
+                await removeCountdown(entry.id)
                 if (channel.isSendable()) {
                     await postFinishMessage(client, channel, entry)
                 }
-                await removeCountdown(entry.id)
             }
         } catch (error: unknown) {
             if (isUnrecoverableError(error)) {

--- a/src/util/saveControlChannel.ts
+++ b/src/util/saveControlChannel.ts
@@ -1,6 +1,6 @@
 import fs from "fs"
 import path from "path"
-import type { GuildSettingsStore } from "../types/index.js"
+import type { GuildSettings, GuildSettingsStore } from "../types/index.js"
 import type { LoggerInterface } from "../types/index.js"
 import {
     getGuildSettingsStoreFromDatabase,
@@ -99,6 +99,56 @@ async function withGuildSettingsSaveLock<T>(work: () => Promise<T>): Promise<T> 
     }
 }
 
+const GUILD_SETTING_FIELD_KEYS: (keyof GuildSettings)[] = [
+    "controlChannelId",
+    "controlMessageId",
+    "downloadsMaxMb",
+    "discordLog",
+]
+
+function cloneGuildSettingsRow(row: GuildSettings): GuildSettings {
+    return typeof structuredClone === "function"
+        ? structuredClone(row)
+        : (JSON.parse(JSON.stringify(row)) as GuildSettings)
+}
+
+/**
+ * Merges only fields present in `snapshotRow` onto `dbRow`, then removes `clearedFields`.
+ * Omitted snapshot fields keep their latest database values (prevents cross-field clobber races).
+ */
+function mergeGuildSettingsRow(
+    dbRow: GuildSettings | undefined,
+    snapshotRow: GuildSettings | undefined,
+    clearedFields: (keyof GuildSettings)[] = []
+): GuildSettings {
+    const merged: GuildSettings = dbRow ? cloneGuildSettingsRow(dbRow) : {}
+    if (snapshotRow) {
+        for (const key of GUILD_SETTING_FIELD_KEYS) {
+            if (key in snapshotRow) {
+                const value = snapshotRow[key]
+                if (value !== undefined) {
+                    switch (key) {
+                        case "controlChannelId":
+                        case "controlMessageId":
+                            merged[key] = value as string
+                            break
+                        case "downloadsMaxMb":
+                            merged.downloadsMaxMb = value as number
+                            break
+                        case "discordLog":
+                            merged.discordLog = value as GuildSettings["discordLog"]
+                            break
+                    }
+                }
+            }
+        }
+    }
+    for (const key of clearedFields) {
+        delete merged[key]
+    }
+    return merged
+}
+
 export type SaveGuildSettingsOptions = {
     /** Guild IDs to delete from the database (must be intentional removals, not snapshot omissions). */
     deleteGuildIds?: string[]
@@ -107,6 +157,8 @@ export type SaveGuildSettingsOptions = {
      * ignored and the latest database values are kept (prevents lost updates across concurrent saves).
      */
     touchedGuildIds?: string[]
+    /** Per-guild setting fields to clear explicitly (e.g. control-channel unset). */
+    clearedGuildFields?: Partial<Record<string, (keyof GuildSettings)[]>>
 }
 
 /**
@@ -122,21 +174,32 @@ export async function saveGuildSettings(
     const deleteGuildIds = (options?.deleteGuildIds ?? []).filter(
         (id) => typeof id === "string" && id.length > 0
     )
+    const hasTouchedOption = options?.touchedGuildIds !== undefined
     const touchedGuildIds = (options?.touchedGuildIds ?? []).filter(
         (id) => typeof id === "string" && id.length > 0
     )
+    const clearedGuildFields = options?.clearedGuildFields ?? {}
     return withGuildSettingsSaveLock(async () => {
         const logger = loggerFromPartial(loggerInstance)
         logger.debug("[guildSettings] Attempting to save settings to database.")
         try {
             const dbStore = await readGuildSettingsFromDatabase(logger)
             const merged = cloneGuildSettingsStore(dbStore)
-            const guildIdsToApply =
-                touchedGuildIds.length > 0 ? touchedGuildIds : Object.keys(settingsSnapshot)
+            const guildIdsToApply = hasTouchedOption
+                ? touchedGuildIds
+                : Object.keys(settingsSnapshot)
             for (const guildId of guildIdsToApply) {
+                const cleared = (clearedGuildFields[guildId] ?? []).filter(
+                    (key): key is keyof GuildSettings =>
+                        typeof key === "string" &&
+                        (GUILD_SETTING_FIELD_KEYS as string[]).includes(key)
+                )
                 const row = settingsSnapshot[guildId]
-                if (row !== undefined) {
-                    merged[guildId] = cloneGuildSettingsStore({ [guildId]: row })[guildId]!
+                const nextRow = mergeGuildSettingsRow(merged[guildId], row, cleared)
+                if (Object.keys(nextRow).length === 0) {
+                    delete merged[guildId]
+                } else {
+                    merged[guildId] = nextRow
                 }
             }
             for (const guildId of deleteGuildIds) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,10 +2592,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+shell-quote@1.8.3, shell-quote@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 side-channel-list@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Summary

Combines five independent correctness fixes that were previously split across PRs #94-#98 into a single branch, for a clean consolidated review. Also resolves open Dependabot alert #81.

### Data-loss fixes (#94-#98)

- **Guild settings field clobber (#94/#95)** — field-level merge under save lock in `saveGuildSettings`; only keys present in the caller snapshot overwrite DB values, preventing concurrent admin saves from clobbering unrelated fields.
- **Control-channel / download-limit unset row wipe (#94/#95)** — `deleteGuildIds` only when the guild row is fully empty; use `clearedGuildFields` for partial clears so unsetting control channel or download limit does not wipe discord-log or other settings.
- **Countdown permission errors (#96)** — treat `50001`/`50013` as retryable; only `10003`/`10008` are fatal. Matches the control-channel handler pattern.
- **Duplicate finish messages (#97)** — call `removeCountdown` before `postFinishMessage`; skip stale snapshot entries via `getCountdown` so failed DB cleanup cannot re-ping every interval.

Supersedes #94, #95, #96, #97, #98.

### Security fix (Dependabot #81)

- **shell-quote (CVE-2026-9277 / GHSA-w7jw-789q-3m8p)** — pin transitive `shell-quote` (via `concurrently`) to `^1.8.4` in root `resolutions` to address critical command-injection advisory.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [ ] Manual: `/control-channel unset` when guild has discord-log or download limit (row preserved)
- [ ] Manual: concurrent admin saves to different guild settings fields (no clobber)
- [ ] Manual: deny bot send permission on countdown channel (countdown not deleted)
- [ ] Manual: countdown expiry with finish message + role mention (single ping)
