### PR TITLE
fix: discord-logs unset clear and Dockerfile.dev Alpine rebuild (#100)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,24 +1,25 @@
 # Node 24 — keep in sync with production Dockerfiles and package.json engines.
-FROM node:24-alpine
+FROM node:24-alpine3.22
 
 WORKDIR /app
 
-# Install yt-dlp (pinned — bump version after testing; keep in sync with docker/ytdlp-requirements.txt).
+# Install yt-dlp (pinned via docker/ytdlp-requirements.txt; bump after testing).
 # Also install build tools needed for native Node.js modules.
 # Install yt-dlp into a shared venv so non-root users can execute it.
+COPY docker/ytdlp-requirements.txt /tmp/ytdlp-requirements.txt
 RUN apk add --no-cache \
-        python3=3.12.13-r0 \
-        py3-pip=25.1.1-r1 \
-        ffmpeg=8.0.1-r1 \
-        build-base=0.5-r3 \
-        autoconf=2.72-r1 \
-        automake=1.18.1-r0 \
-        libtool=2.5.4-r2 \
-        g++=15.2.0-r2 \
-        su-exec=0.3-r0 \
-        wget=1.25.0-r2 \
+        python3 \
+        py3-pip \
+        ffmpeg \
+        build-base \
+        autoconf \
+        automake \
+        libtool \
+        g++ \
+        su-exec \
+        wget \
     && python3 -m venv /opt/venv \
-    && /opt/venv/bin/pip install --no-cache-dir "yt-dlp==2026.2.21" \
+    && /opt/venv/bin/pip install --no-cache-dir -r /tmp/ytdlp-requirements.txt \
     && YTDLP_BIN="/opt/venv/bin/yt-dlp" \
     && test -n "$YTDLP_BIN" && test -x "$YTDLP_BIN" \
     && ln -sf "$YTDLP_BIN" /usr/local/bin/yt-dlp \

--- a/src/commands/admin/Discord-Logs.ts
+++ b/src/commands/admin/Discord-Logs.ts
@@ -12,6 +12,7 @@ import {
     getGuildSettings,
     isGuildSettingsInitialized,
     saveGuildSettings,
+    type SaveGuildSettingsOptions,
 } from "../../util/saveControlChannel.js"
 
 const LEVEL_CHOICES: DiscordLogLevelName[] = ["debug", "info", "warn", "error"]
@@ -86,6 +87,23 @@ function guildIdsRemovedFromStore(
     after: GuildSettingsStore
 ): string[] {
     return Object.keys(before).filter((id) => !(id in after))
+}
+
+/** Save options for a single-guild edit; clears `discordLog` when it was removed from the working row. */
+function guildSettingsSaveOptions(
+    guildId: string,
+    before: GuildSettingsStore,
+    afterStore: GuildSettingsStore,
+    workingRow: GuildSettings
+): SaveGuildSettingsOptions {
+    const options: SaveGuildSettingsOptions = {
+        deleteGuildIds: guildIdsRemovedFromStore(before, afterStore),
+        touchedGuildIds: [guildId],
+    }
+    if (before[guildId]?.discordLog && !workingRow.discordLog) {
+        options.clearedGuildFields = { [guildId]: ["discordLog"] }
+    }
+    return options
 }
 
 function formatConfig(cfg: GuildDiscordLogSettings): string {
@@ -243,13 +261,13 @@ export default {
             }
             applyNormalizedDiscordLog(next, working)
             const nextStore = storeWithGuildRow(store, guild.id, working)
-            const deleteGuildIds = guildIdsRemovedFromStore(store, nextStore)
             try {
                 await interaction.deferReply({ flags: [MessageFlags.Ephemeral] })
-                const ok = await saveGuildSettings(nextStore, client, {
-                    deleteGuildIds,
-                    touchedGuildIds: [guild.id],
-                })
+                const ok = await saveGuildSettings(
+                    nextStore,
+                    client,
+                    guildSettingsSaveOptions(guild.id, store, nextStore, working)
+                )
                 if (!ok) {
                     return interaction.editReply({
                         content:
@@ -306,13 +324,13 @@ export default {
             }
 
             const nextStore = storeWithGuildRow(store, guild.id, working)
-            const deleteGuildIds = guildIdsRemovedFromStore(store, nextStore)
             try {
                 await interaction.deferReply({ flags: [MessageFlags.Ephemeral] })
-                const ok = await saveGuildSettings(nextStore, client, {
-                    deleteGuildIds,
-                    touchedGuildIds: [guild.id],
-                })
+                const ok = await saveGuildSettings(
+                    nextStore,
+                    client,
+                    guildSettingsSaveOptions(guild.id, store, nextStore, working)
+                )
                 if (!ok) {
                     return interaction.editReply({
                         content:
@@ -385,13 +403,13 @@ export default {
 
             applyNormalizedDiscordLog(next, working)
             const nextStore = storeWithGuildRow(latestStore, guild.id, working)
-            const deleteGuildIds = guildIdsRemovedFromStore(latestStore, nextStore)
             try {
                 await interaction.deferReply({ flags: [MessageFlags.Ephemeral] })
-                const ok = await saveGuildSettings(nextStore, client, {
-                    deleteGuildIds,
-                    touchedGuildIds: [guild.id],
-                })
+                const ok = await saveGuildSettings(
+                    nextStore,
+                    client,
+                    guildSettingsSaveOptions(guild.id, latestStore, nextStore, working)
+                )
                 if (!ok) {
                     return interaction.editReply({
                         content:


### PR DESCRIPTION
## Summary

Combines two follow-up fixes after #99 into a single PR.

### Discord-Logs unset regression (#100)

After #99, `/discord-logs unset` reported success but did not remove `discordLog` from the database because field-level merge keeps DB values for keys omitted from the snapshot. Control-Channel and DownloadLimit already passed `clearedGuildFields`; Discord-Logs did not.

- Add `guildSettingsSaveOptions()` helper to detect removed `discordLog` and pass `clearedGuildFields`
- Use it for all Discord-Logs save paths (`min-level`, `unset`, `set`)

Supersedes #100.

### Docker dev rebuild fix

`Dockerfile.dev` pinned Alpine package versions that no longer exist in the current `node:24-alpine` index, causing `yarn docker:dev:rebuild` to fail with `apk` version conflicts.

- Pin base image to `node:24-alpine3.22` (matches production `Dockerfile`)
- Use unpinned `apk` packages within Alpine 3.22
- Install yt-dlp from `docker/ytdlp-requirements.txt`

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml build dimbybot` succeeds
- [ ] Manual: `/discord-logs unset everything` clears log forwarding from DB
- [ ] Manual: `yarn docker:dev:rebuild` completes and containers start
