### PR TITLE
feat(web): dashboard admin nav and player control layout

### DIFF
--- a/src/web/app/dashboard/layout.tsx
+++ b/src/web/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react"
 import Link from "next/link"
 import { redirect } from "next/navigation"
 import { readSessionSafe } from "@/server/auth-session"
+import { canAccessAdmin } from "@/lib/admin-access"
 import { DashboardInviteLink } from "@/components/DashboardInviteLink"
 import { ServiceDegraded } from "@/components/ServiceDegraded"
 import { GoToNowPlayingButton } from "@/components/GoToNowPlayingButton"
@@ -46,12 +47,14 @@ export default async function DashboardLayout({ children }: { children: ReactNod
         redirect("/")
     }
 
+    const showAdminLink = await canAccessAdmin()
+
     return (
         <div className="min-h-screen bg-background text-foreground">
             <header className="border-b p-4">
                 <div className="mx-auto flex max-w-6xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <div className="min-w-0 flex-1">
-                        <UserHeader />
+                        <UserHeader showAdminLink={showAdminLink} />
                     </div>
                     <DashboardInviteLink />
                 </div>

--- a/src/web/app/playlists/layout.tsx
+++ b/src/web/app/playlists/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react"
 import Link from "next/link"
 import { redirect } from "next/navigation"
 import { readSessionSafe } from "@/server/auth-session"
+import { canAccessAdmin } from "@/lib/admin-access"
 import { DashboardInviteLink } from "@/components/DashboardInviteLink"
 import { ServiceDegraded } from "@/components/ServiceDegraded"
 import { GoToNowPlayingButton } from "@/components/GoToNowPlayingButton"
@@ -44,12 +45,14 @@ export default async function PlaylistsLayout({ children }: { children: ReactNod
         redirect("/")
     }
 
+    const showAdminLink = await canAccessAdmin()
+
     return (
         <div className="min-h-screen bg-background text-foreground">
             <header className="border-b p-4">
                 <div className="mx-auto flex max-w-6xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <div className="min-w-0 flex-1">
-                        <UserHeader />
+                        <UserHeader showAdminLink={showAdminLink} />
                     </div>
                     <DashboardInviteLink />
                 </div>

--- a/src/web/components/PlayerPanel.tsx
+++ b/src/web/components/PlayerPanel.tsx
@@ -751,9 +751,6 @@ export function PlayerPanel({ guildId, discordUserId, permissionSnapshot }: Play
                         >
                             Loop ({loopLabel})
                         </button>
-                    </div>
-
-                    <div className="mt-3">
                         <button
                             type="button"
                             className="rounded border bg-secondary px-3 py-2 text-secondary-foreground hover:opacity-90 disabled:opacity-50"

--- a/src/web/components/UserHeader.tsx
+++ b/src/web/components/UserHeader.tsx
@@ -15,7 +15,7 @@ async function signOutAndGoHome(): Promise<void> {
     window.location.assign("/")
 }
 
-export function UserHeader() {
+export function UserHeader({ showAdminLink = false }: { showAdminLink?: boolean }) {
     const { data: session } = authClient.useSession()
     const [signOutError, setSignOutError] = useState<string | null>(null)
     const [signOutLoading, setSignOutLoading] = useState(false)
@@ -34,6 +34,15 @@ export function UserHeader() {
                 >
                     Playlists
                 </Link>
+                {showAdminLink ? (
+                    <Link
+                        href="/admin"
+                        prefetch={false}
+                        className="text-sm text-muted-foreground hover:text-foreground"
+                    >
+                        Admin
+                    </Link>
+                ) : null}
             </div>
 
             <div className="flex items-center gap-3">

--- a/src/web/lib/admin-access.ts
+++ b/src/web/lib/admin-access.ts
@@ -71,9 +71,15 @@ export async function resolveAdminAccess(reqHeaders: Headers): Promise<AdminAcce
 
 /** True when the current session is the bot owner (`OWNER_ID`). */
 export async function canAccessAdmin(): Promise<boolean> {
-    const h = await headers()
-    const result = await resolveAdminAccess(new Headers(h))
-    return result.ok
+    try {
+        const h = await headers()
+        const result = await resolveAdminAccess(new Headers(h))
+        return result.ok
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        console.error("[admin-access] canAccessAdmin failed:", message)
+        return false
+    }
 }
 
 /** Returns a JSON error response when access is denied; `null` when the caller may proceed. */

--- a/src/web/lib/admin-access.ts
+++ b/src/web/lib/admin-access.ts
@@ -69,6 +69,13 @@ export async function resolveAdminAccess(reqHeaders: Headers): Promise<AdminAcce
     return { ok: true, session, discordUserId }
 }
 
+/** True when the current session is the bot owner (`OWNER_ID`). */
+export async function canAccessAdmin(): Promise<boolean> {
+    const h = await headers()
+    const result = await resolveAdminAccess(new Headers(h))
+    return result.ok
+}
+
 /** Returns a JSON error response when access is denied; `null` when the caller may proceed. */
 export async function guardAdminAccess(): Promise<NextResponse | null> {
     try {


### PR DESCRIPTION
## Summary

- Show an **Admin** link in the dashboard and playlists headers when the signed-in user is the bot owner (`OWNER_ID`), using a new `canAccessAdmin()` helper.
- Keep the player panel **Loop** and **Leave voice** buttons on the same row instead of splitting them across two rows.

## Test plan

- [ ] Sign in as the bot owner and confirm **Admin** appears in the dashboard/playlists header nav alongside Dashboard and Playlists.
- [ ] Sign in as a non-owner user and confirm **Admin** is hidden.
- [ ] Open a guild player panel and verify Loop and Leave voice sit on one row on desktop and mobile widths.
- [ ] Confirm `/admin` is still blocked for non-owners via existing guard.