### PR TITLE
feat: persist Lavalink player sessions across bot restarts

### DIFF
--- a/prisma/migrations/20260614120000_add_player_session/migration.sql
+++ b/prisma/migrations/20260614120000_add_player_session/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "PlayerSession" (
+    "guildId" TEXT NOT NULL,
+    "voiceChannelId" TEXT NOT NULL,
+    "textChannelId" TEXT,
+    "snapshot" JSONB NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PlayerSession_pkey" PRIMARY KEY ("guildId")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,15 @@ model GuildSettings {
   discordLog       Json?
 }
 
+/// Persisted Lavalink player snapshot for crash/restart recovery (one row per active guild).
+model PlayerSession {
+  guildId        String   @id
+  voiceChannelId String
+  textChannelId  String?
+  snapshot       Json
+  updatedAt      DateTime @updatedAt
+}
+
 model DownloadMetadata {
   fileName     String
   /// Discord guild id, or `UNKNOWN` for legacy rows migrated from NULL (see migration `20260410140000_downloadmetadata_composite_pk`).

--- a/src/botApi/handlers/player.ts
+++ b/src/botApi/handlers/player.ts
@@ -6,6 +6,7 @@ import { getBotClient } from "../../lib/botClientRegistry.js"
 import { toPlayerStateResponse } from "../../shared/player-state.js"
 import { webPlayerDebug } from "../../shared/web-player-debug-log.js"
 import { playerBroadcaster } from "../../shared/websocket/PlayerBroadcaster.js"
+import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
 
 type PlayerAction = "pause" | "skip" | "stop" | "seek" | "loop" | "shuffle" | "autoplay"
 
@@ -134,13 +135,14 @@ export async function playerPOST(
                 await player.queue.shuffle()
                 break
             case "autoplay":
-                // Autoplay is Lavalink player session state (same as `/autoplay`); it is not persisted
-                // to guild DB — toggling only affects this player until it is destroyed.
                 player.set("autoplay", !player.get("autoplay"))
                 break
         }
 
         const refreshedPlayer = action === "stop" ? null : client.lavalink.getPlayer(guildId)
+        if (refreshedPlayer) {
+            schedulePlayerSessionSave(refreshedPlayer)
+        }
         if (action === "stop") {
             playerBroadcaster.broadcastPlayerEvent(guildId, null, "playerDestroy")
         } else {

--- a/src/botApi/handlers/queue.ts
+++ b/src/botApi/handlers/queue.ts
@@ -7,6 +7,7 @@ import { getBotClient } from "../../lib/botClientRegistry.js"
 import { toQueueResponse } from "../../shared/player-state.js"
 import { playerBroadcaster } from "../../shared/websocket/PlayerBroadcaster.js"
 import { searchAndEnqueue } from "./searchAndEnqueue.js"
+import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
 
 const MAX_QUEUE_PAGE_LIMIT = 100
 
@@ -124,6 +125,7 @@ export async function queueDELETE(
     try {
         if (player) {
             await player.queue.splice(0, player.queue.tracks.length)
+            schedulePlayerSessionSave(player)
             playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
         }
         return {

--- a/src/botApi/handlers/queueIndex.ts
+++ b/src/botApi/handlers/queueIndex.ts
@@ -5,6 +5,7 @@ import { requirePermissions } from "../../shared/api-auth.js"
 import { getBotClient, tryGetBotClient } from "../../lib/botClientRegistry.js"
 import { toQueueResponse } from "../../shared/player-state.js"
 import { playerBroadcaster } from "../../shared/websocket/PlayerBroadcaster.js"
+import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
 
 function parseIndex(value: string): number | null {
     const index = Number(value)
@@ -48,6 +49,7 @@ export async function queueIndexDELETE(
         }
 
         await player.queue.splice(queueIndex, 1)
+        schedulePlayerSessionSave(player)
         playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
         return {
             status: 200,
@@ -151,15 +153,18 @@ export async function queueIndexPATCH(
                         insertErr,
                     })
                 } else {
-                    console.error(
-                        "[queueIndexPATCH] failed to restore track after reorder error",
-                        { guildId, sourceIndex, restoreMessage, insertErr }
-                    )
+                    console.error("[queueIndexPATCH] failed to restore track after reorder error", {
+                        guildId,
+                        sourceIndex,
+                        restoreMessage,
+                        insertErr,
+                    })
                 }
             }
             throw insertErr
         }
         playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
+        schedulePlayerSessionSave(player)
 
         return {
             status: 200,

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -6,6 +6,7 @@ import { ensurePlayerConnected, startPlaybackIfNeeded } from "../../util/musicMa
 import { stampRequesterUserIdOnTracks } from "../../util/rrqDisconnect.js"
 import type { PermissionGuardSuccess } from "../../shared/api-auth.js"
 import { resolveWebDashboardTextChannelId } from "../webDashboardTextChannel.js"
+import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
 
 export type SearchAndEnqueueGuard = Pick<PermissionGuardSuccess, "session">
 
@@ -268,9 +269,11 @@ export async function searchAndEnqueue(
 
     try {
         await startPlaybackIfNeeded(player)
+        schedulePlayerSessionSave(player)
         return { ok: true, player, playbackStarted: true }
     } catch (error: unknown) {
         const playbackError = error instanceof Error ? error.message : String(error)
+        schedulePlayerSessionSave(player)
         return {
             ok: true,
             player,

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -35,6 +35,8 @@ import {
     userHasQueuedTracks,
 } from "../util/rrqDisconnect.js"
 import { playerBroadcaster } from "../shared/websocket/PlayerBroadcaster.js"
+import { clearPlayerSession, schedulePlayerSessionSave } from "../util/playerSessionPersistence.js"
+import { countHumanMembers } from "../util/voiceChannelMembers.js"
 
 /** Rate-limit `queueUpdate` websocket fan-out on Lavalink position ticks (pause/resume still immediate). */
 const lastQueueUpdateBroadcastAtMs = new Map<string, number>()
@@ -114,6 +116,12 @@ export default async (client: BotClient) => {
             )
             lastQueueUpdateBroadcastAtMs.delete(player.guildId)
             player.set(DASHBOARD_REQUESTER_KEY, undefined)
+            void clearPlayerSession(player.guildId).catch((err: unknown) => {
+                const msg = err instanceof Error ? err.message : String(err)
+                client.error(
+                    `[LavaMgrEvents] clearPlayerSession failed (guildId=${player.guildId}): ${msg}`
+                )
+            })
             scheduleControlMessageUpdate(client, player.guildId, "playerDestroy")
             playerBroadcaster.broadcastPlayerEvent(player.guildId, null, "playerDestroy")
         })
@@ -129,7 +137,7 @@ export default async (client: BotClient) => {
                 client.debug(
                     `[LavaMgrEvents] Player moved in Guild: ${player.guildId}, Old: ${oldChannelId}, New: ${newChannelId}`
                 )
-                // updateControlMessage(client, player.guildId) // Optional update
+                schedulePlayerSessionSave(player)
             }
         )
 
@@ -175,6 +183,7 @@ export default async (client: BotClient) => {
             if (track?.info) {
                 rememberAutoplayPlayed(player, track.info)
             }
+            schedulePlayerSessionSave(player)
 
             const textId = player.textChannelId
             const channel = textId ? client.channels.cache.get(textId) : undefined
@@ -224,6 +233,7 @@ export default async (client: BotClient) => {
             )
             scheduleControlMessageUpdate(client, player.guildId, "trackEnd")
             playerBroadcaster.broadcastPlayerEvent(player.guildId, player, "trackEnd")
+            schedulePlayerSessionSave(player)
         })
         .on("trackStuck", async (player: Player, track: Track | null, payload: TrackStuckEvent) => {
             client.warn(
@@ -356,6 +366,7 @@ export default async (client: BotClient) => {
             client.debug(`[LavaMgrEvents] Queue ended for Guild: ${player.guildId}`)
             scheduleControlMessageUpdate(client, player.guildId, "queueEnd")
             playerBroadcaster.broadcastPlayerEvent(player.guildId, player, "queueUpdate")
+            schedulePlayerSessionSave(player)
 
             // Send message to non-control channel
             const textIdQ = player.textChannelId
@@ -431,13 +442,11 @@ export default async (client: BotClient) => {
                             .fetch(vcId)
                             .catch(() => null)
                         if (updatedVoiceChannel && updatedVoiceChannel.isVoiceBased()) {
-                            const humanMembers = updatedVoiceChannel.members.filter(
-                                (m) => !m.user.bot
-                            )
+                            const humanCount = countHumanMembers(updatedVoiceChannel)
                             client.debug(
-                                `[LavaMgrEvents] Current human member count in VC ${player.voiceChannelId}: ${humanMembers.size}`
+                                `[LavaMgrEvents] Current human member count in VC ${player.voiceChannelId}: ${humanCount}`
                             ) // Log count
-                            if (humanMembers.size === 0) {
+                            if (humanCount === 0) {
                                 client.info(
                                     `[LavaMgrEvents] Destroying player in Guild ${player.guildId} as bot is alone.`
                                 )
@@ -560,6 +569,7 @@ export default async (client: BotClient) => {
         .on("playerUpdate", (oldPlayerJson: PlayerJson, newPlayer: Player) => {
             const oldPaused = Boolean(oldPlayerJson.paused)
             if (oldPaused !== newPlayer.paused) {
+                schedulePlayerSessionSave(newPlayer)
                 playerBroadcaster.broadcastPlayerEvent(
                     newPlayer.guildId,
                     newPlayer,

--- a/src/events/lavaNodeEvents.ts
+++ b/src/events/lavaNodeEvents.ts
@@ -7,6 +7,7 @@
 
 import type { LavalinkNode } from "lavalink-client"
 import type BotClient from "../lib/BotClient.js"
+import { tryRestorePlayerSessionsOnLavalinkConnect } from "../util/restorePlayerSessions.js"
 
 export default async (client: BotClient) => {
     client.lavalink.nodeManager
@@ -31,6 +32,10 @@ export default async (client: BotClient) => {
         // Emitted when a Lavalink node successfully connects to the Lavalink server.
         .on("connect", (node: LavalinkNode) => {
             client.info(`Lavalink Node ${node.id} CONNECTED`)
+            void tryRestorePlayerSessionsOnLavalinkConnect(client).catch((err: unknown) => {
+                const msg = err instanceof Error ? err.message : String(err)
+                client.error(`[lavaNodeEvents] player session restore failed: ${msg}`)
+            })
         })
         // Emitted when a Lavalink node disconnects from the Lavalink server.
         // Includes the disconnection code and reason.

--- a/src/events/onReady.ts
+++ b/src/events/onReady.ts
@@ -3,6 +3,7 @@ import type BotClient from "../lib/BotClient.js"
 import { attachDiscordLogForwarding } from "../util/discordLogForward.js"
 import { refreshAllControlMessages } from "./handlers/handleControlChannel.js"
 import { updateAllCountdowns } from "../util/countdownUpdater.js"
+import { markDiscordReadyForPlayerRestore } from "../util/restorePlayerSessions.js"
 
 export default async (client: BotClient) => {
     client.on("clientReady", () => {
@@ -12,6 +13,7 @@ export default async (client: BotClient) => {
             return
         }
         client.debug("Ready event triggered.") // Debug log
+        markDiscordReadyForPlayerRestore()
         client.lavalink.init({ id: user.id, username: user.username })
 
         client.info(`Logged in as ${user.tag}! (${user.id})`)

--- a/src/repositories/playerSessionRepository.ts
+++ b/src/repositories/playerSessionRepository.ts
@@ -1,0 +1,86 @@
+import { Prisma } from "@prisma/client"
+import { getPrismaClient } from "../lib/database.js"
+import type { PlayerSessionData, PlayerSessionSnapshotV1 } from "../types/index.js"
+
+function parseSnapshot(value: Prisma.JsonValue): PlayerSessionSnapshotV1 | null {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    const raw = value as Record<string, unknown>
+    if (raw.version !== 1) return null
+    if (typeof raw.volume !== "number") return null
+    if (raw.repeatMode !== "off" && raw.repeatMode !== "track" && raw.repeatMode !== "queue") {
+        return null
+    }
+    if (typeof raw.paused !== "boolean" || typeof raw.playing !== "boolean") return null
+    if (typeof raw.autoplay !== "boolean" || typeof raw.rrqEnabled !== "boolean") return null
+    if (!Array.isArray(raw.queue)) return null
+    if (raw.current !== null && typeof raw.current !== "object") return null
+    return raw as unknown as PlayerSessionSnapshotV1
+}
+
+function toPlayerSessionData(row: {
+    guildId: string
+    voiceChannelId: string
+    textChannelId: string | null
+    snapshot: Prisma.JsonValue
+    updatedAt: Date
+}): PlayerSessionData | null {
+    const snapshot = parseSnapshot(row.snapshot)
+    if (!snapshot) return null
+    return {
+        guildId: row.guildId,
+        voiceChannelId: row.voiceChannelId,
+        textChannelId: row.textChannelId,
+        snapshot,
+        updatedAt: row.updatedAt,
+    }
+}
+
+/** Upserts a player session snapshot for crash/restart recovery. */
+export async function upsertPlayerSession(
+    guildId: string,
+    voiceChannelId: string,
+    textChannelId: string | null,
+    snapshot: PlayerSessionSnapshotV1
+): Promise<void> {
+    const prisma = getPrismaClient()
+    await prisma.playerSession.upsert({
+        where: { guildId },
+        create: {
+            guildId,
+            voiceChannelId,
+            textChannelId,
+            snapshot: snapshot as unknown as Prisma.InputJsonValue,
+        },
+        update: {
+            voiceChannelId,
+            textChannelId,
+            snapshot: snapshot as unknown as Prisma.InputJsonValue,
+        },
+    })
+}
+
+/** Removes a persisted player session (intentional destroy or stale cleanup). */
+export async function deletePlayerSession(guildId: string): Promise<void> {
+    const prisma = getPrismaClient()
+    await prisma.playerSession.deleteMany({ where: { guildId } })
+}
+
+/** Returns all persisted player sessions with valid v1 snapshots. */
+export async function listPlayerSessions(): Promise<PlayerSessionData[]> {
+    const prisma = getPrismaClient()
+    const rows = await prisma.playerSession.findMany()
+    const out: PlayerSessionData[] = []
+    for (const row of rows) {
+        const parsed = toPlayerSessionData(row)
+        if (parsed) out.push(parsed)
+    }
+    return out
+}
+
+/** Loads a single player session by guild id. */
+export async function getPlayerSession(guildId: string): Promise<PlayerSessionData | null> {
+    const prisma = getPrismaClient()
+    const row = await prisma.playerSession.findUnique({ where: { guildId } })
+    if (!row) return null
+    return toPlayerSessionData(row)
+}

--- a/src/repositories/playerSessionRepository.ts
+++ b/src/repositories/playerSessionRepository.ts
@@ -10,7 +10,7 @@ function parsePersistedQueueTrack(value: unknown): PersistedQueueTrack | null {
     if (!value || typeof value !== "object" || Array.isArray(value)) return null
     const raw = value as Record<string, unknown>
     if (typeof raw.title !== "string" || !raw.title.trim()) return null
-    if (typeof raw.author !== "string") return null
+    if (typeof raw.author !== "string" || !raw.author.trim()) return null
     if (typeof raw.uri !== "string" || !raw.uri.trim()) return null
     if (typeof raw.duration !== "number" || !Number.isFinite(raw.duration)) return null
     if (typeof raw.isStream !== "boolean") return null

--- a/src/repositories/playerSessionRepository.ts
+++ b/src/repositories/playerSessionRepository.ts
@@ -47,7 +47,7 @@ function parseSnapshot(value: Prisma.JsonValue): PlayerSessionSnapshotV1 | null 
     if (!value || typeof value !== "object" || Array.isArray(value)) return null
     const raw = value as Record<string, unknown>
     if (raw.version !== 1) return null
-    if (typeof raw.volume !== "number") return null
+    if (typeof raw.volume !== "number" || !Number.isFinite(raw.volume)) return null
     if (raw.repeatMode !== "off" && raw.repeatMode !== "track" && raw.repeatMode !== "queue") {
         return null
     }

--- a/src/repositories/playerSessionRepository.ts
+++ b/src/repositories/playerSessionRepository.ts
@@ -1,6 +1,47 @@
 import { Prisma } from "@prisma/client"
 import { getPrismaClient } from "../lib/database.js"
-import type { PlayerSessionData, PlayerSessionSnapshotV1 } from "../types/index.js"
+import type {
+    PlayerSessionData,
+    PlayerSessionSnapshotV1,
+    PersistedQueueTrack,
+} from "../types/index.js"
+
+function parsePersistedQueueTrack(value: unknown): PersistedQueueTrack | null {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    const raw = value as Record<string, unknown>
+    if (typeof raw.title !== "string" || !raw.title.trim()) return null
+    if (typeof raw.author !== "string") return null
+    if (typeof raw.uri !== "string" || !raw.uri.trim()) return null
+    if (typeof raw.duration !== "number" || !Number.isFinite(raw.duration)) return null
+    if (typeof raw.isStream !== "boolean") return null
+
+    let encoded: string | null = null
+    if (raw.encoded !== null && raw.encoded !== undefined) {
+        if (typeof raw.encoded !== "string") return null
+        encoded = raw.encoded
+    }
+    let requesterId: string | null = null
+    if (raw.requesterId !== null && raw.requesterId !== undefined) {
+        if (typeof raw.requesterId !== "string") return null
+        requesterId = raw.requesterId
+    }
+    let thumbnailUrl: string | null = null
+    if (raw.thumbnailUrl !== null && raw.thumbnailUrl !== undefined) {
+        if (typeof raw.thumbnailUrl !== "string") return null
+        thumbnailUrl = raw.thumbnailUrl
+    }
+
+    return {
+        title: raw.title.trim(),
+        author: raw.author.trim(),
+        uri: raw.uri.trim(),
+        duration: raw.duration,
+        encoded,
+        requesterId,
+        thumbnailUrl,
+        isStream: raw.isStream,
+    }
+}
 
 function parseSnapshot(value: Prisma.JsonValue): PlayerSessionSnapshotV1 | null {
     if (!value || typeof value !== "object" || Array.isArray(value)) return null
@@ -13,8 +54,31 @@ function parseSnapshot(value: Prisma.JsonValue): PlayerSessionSnapshotV1 | null 
     if (typeof raw.paused !== "boolean" || typeof raw.playing !== "boolean") return null
     if (typeof raw.autoplay !== "boolean" || typeof raw.rrqEnabled !== "boolean") return null
     if (!Array.isArray(raw.queue)) return null
-    if (raw.current !== null && typeof raw.current !== "object") return null
-    return raw as unknown as PlayerSessionSnapshotV1
+
+    let current: PersistedQueueTrack | null = null
+    if (raw.current !== null) {
+        current = parsePersistedQueueTrack(raw.current)
+        if (!current) return null
+    }
+
+    const queue: PersistedQueueTrack[] = []
+    for (const item of raw.queue) {
+        const track = parsePersistedQueueTrack(item)
+        if (!track) return null
+        queue.push(track)
+    }
+
+    return {
+        version: 1,
+        volume: raw.volume,
+        repeatMode: raw.repeatMode,
+        paused: raw.paused,
+        playing: raw.playing,
+        autoplay: raw.autoplay,
+        rrqEnabled: raw.rrqEnabled,
+        current,
+        queue,
+    }
 }
 
 function toPlayerSessionData(row: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -80,9 +80,13 @@ async function run(): Promise<void> {
         logger.info(`Received ${signal}, shutting down...`)
         let shouldExitWithFailure = false
         try {
-            const { flushAllPlayerSessionSaves } =
-                await import("./util/playerSessionPersistence.js")
-            await flushAllPlayerSessionSaves()
+            try {
+                const { flushAllPlayerSessionSaves } =
+                    await import("./util/playerSessionPersistence.js")
+                await flushAllPlayerSessionSaves()
+            } catch (flushErr: unknown) {
+                logger.error("Error flushing player session saves:", flushErr)
+            }
             stopHeartbeat?.()
             if (wss) {
                 for (const ws of wss.clients) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -80,6 +80,9 @@ async function run(): Promise<void> {
         logger.info(`Received ${signal}, shutting down...`)
         let shouldExitWithFailure = false
         try {
+            const { flushAllPlayerSessionSaves } =
+                await import("./util/playerSessionPersistence.js")
+            await flushAllPlayerSessionSaves()
             stopHeartbeat?.()
             if (wss) {
                 for (const ws of wss.clients) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -85,6 +85,7 @@ async function run(): Promise<void> {
                     await import("./util/playerSessionPersistence.js")
                 await flushAllPlayerSessionSaves()
             } catch (flushErr: unknown) {
+                shouldExitWithFailure = true
                 logger.error("Error flushing player session saves:", flushErr)
             }
             stopHeartbeat?.()

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -264,6 +264,40 @@ export interface CountdownInput {
 /** Map of countdown id → countdown entry. */
 export type CountdownStore = Record<number, CountdownEntry>
 
+/** Serialized queue track for player session persistence across bot restarts. */
+export interface PersistedQueueTrack {
+    title: string
+    author: string
+    uri: string
+    duration: number
+    encoded: string | null
+    requesterId: string | null
+    thumbnailUrl: string | null
+    isStream: boolean
+}
+
+/** Versioned Lavalink player snapshot stored in `PlayerSession.snapshot`. */
+export interface PlayerSessionSnapshotV1 {
+    version: 1
+    volume: number
+    repeatMode: "off" | "track" | "queue"
+    paused: boolean
+    playing: boolean
+    autoplay: boolean
+    rrqEnabled: boolean
+    current: PersistedQueueTrack | null
+    queue: PersistedQueueTrack[]
+}
+
+/** Row shape for a persisted player session. */
+export interface PlayerSessionData {
+    guildId: string
+    voiceChannelId: string
+    textChannelId: string | null
+    snapshot: PlayerSessionSnapshotV1
+    updatedAt: Date
+}
+
 /** Tracks a user who left voice while RRQ is active and has queued tracks. */
 export interface DisconnectedRRQUser {
     userId: string

--- a/src/util/musicManager.ts
+++ b/src/util/musicManager.ts
@@ -21,6 +21,7 @@ import {
 } from "./rrqDisconnect.js"
 import { downloadMetadataFileBelongsToGuild } from "./downloadMetadataKeys.js"
 import { getDownloadMetadataStore } from "./downloadMetadataStore.js"
+import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
 
 type SearchAttempt =
     | { source: string; success: true; loadType?: string }
@@ -647,6 +648,7 @@ export async function handleQueryAndPlay(
                     `[MusicManager] Before play check: player.playing=${player.playing}, player.queue.tracks.length=${player.queue.tracks.length}`
                 )
                 await startPlaybackIfNeeded(player)
+                schedulePlayerSessionSave(player)
                 client.debug(
                     `[MusicManager] Lavalink player started playing [${player.queue.current?.info?.title || "track from queue"}].`
                 )

--- a/src/util/musicManager.ts
+++ b/src/util/musicManager.ts
@@ -675,6 +675,7 @@ export async function handleQueryAndPlay(
                 if (originalFeedback.startsWith("Added")) {
                     feedbackText = `${originalFeedback}\nHowever, ${feedbackText.substring(feedbackText.indexOf(",") + 1).trim()}`
                 }
+                schedulePlayerSessionSave(player)
                 success = false
                 errorResult = playError instanceof Error ? playError : new Error(String(playError))
             }

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -1,0 +1,152 @@
+import type { Player, Track, UnresolvedTrack } from "lavalink-client"
+import type { PlayerSessionSnapshotV1 } from "../types/index.js"
+import {
+    deletePlayerSession,
+    upsertPlayerSession,
+} from "../repositories/playerSessionRepository.js"
+import { isRRQActive } from "./rrqDisconnect.js"
+import { persistedTrackFromLavalink } from "./playerSessionTracks.js"
+import { tryGetBotClient } from "../lib/botClientRegistry.js"
+
+const SAVE_DEBOUNCE_MS = 2000
+
+const pendingSaveTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const pendingPlayers = new Map<string, Player>()
+const restoreInProgressGuilds = new Set<string>()
+
+function repeatModeToLabel(mode: unknown): "off" | "track" | "queue" {
+    if (mode === "track" || mode === "queue") return mode
+    return "off"
+}
+
+/** Builds a v1 snapshot from the live Lavalink player; null when there is nothing to restore. */
+export function snapshotFromPlayer(player: Player): PlayerSessionSnapshotV1 | null {
+    const currentTrack = player.queue.current
+    const current = currentTrack ? persistedTrackFromLavalink(currentTrack) : null
+    const queue: PlayerSessionSnapshotV1["queue"] = []
+    for (const track of player.queue.tracks) {
+        const persisted = persistedTrackFromLavalink(track as Track | UnresolvedTrack)
+        if (persisted) queue.push(persisted)
+    }
+    if (!current && queue.length === 0) return null
+
+    return {
+        version: 1,
+        volume: typeof player.volume === "number" ? player.volume : 100,
+        repeatMode: repeatModeToLabel(player.repeatMode),
+        paused: Boolean(player.paused),
+        playing: Boolean(player.playing),
+        autoplay: player.get("autoplay") === true,
+        rrqEnabled: isRRQActive(player),
+        current,
+        queue,
+    }
+}
+
+/** Marks a guild as mid-restore so debounced saves do not race with hydration. */
+export function markPlayerSessionRestoreInProgress(guildId: string): void {
+    restoreInProgressGuilds.add(guildId)
+}
+
+/** Clears the restore-in-progress guard after hydration completes. */
+export function clearPlayerSessionRestoreInProgress(guildId: string): void {
+    restoreInProgressGuilds.delete(guildId)
+}
+
+function isRestoreInProgress(guildId: string): boolean {
+    return restoreInProgressGuilds.has(guildId)
+}
+
+async function writePlayerSession(player: Player): Promise<void> {
+    const snapshot = snapshotFromPlayer(player)
+    const voiceChannelId = player.voiceChannelId
+    if (!voiceChannelId) return
+
+    if (!snapshot) {
+        await deletePlayerSession(player.guildId)
+        return
+    }
+
+    await upsertPlayerSession(
+        player.guildId,
+        voiceChannelId,
+        player.textChannelId ?? null,
+        snapshot
+    )
+}
+
+/** Debounced upsert of the player session snapshot (~2s per guild). */
+export function schedulePlayerSessionSave(player: Player): void {
+    if (isRestoreInProgress(player.guildId)) return
+
+    const guildId = player.guildId
+    pendingPlayers.set(guildId, player)
+    const existing = pendingSaveTimers.get(guildId)
+    if (existing) clearTimeout(existing)
+
+    const timer = setTimeout(() => {
+        pendingSaveTimers.delete(guildId)
+        const latest = pendingPlayers.get(guildId)
+        pendingPlayers.delete(guildId)
+        if (!latest) return
+        void writePlayerSession(latest).catch((err: unknown) => {
+            const client = tryGetBotClient()
+            const msg = err instanceof Error ? err.message : String(err)
+            if (client) {
+                client.error(`[playerSession] save failed for guild ${guildId}: ${msg}`)
+            } else {
+                console.error(`[playerSession] save failed for guild ${guildId}: ${msg}`)
+            }
+        })
+    }, SAVE_DEBOUNCE_MS)
+
+    pendingSaveTimers.set(guildId, timer)
+    if (typeof timer.unref === "function") timer.unref()
+}
+
+/** Immediately persists the latest snapshot for one guild. */
+export async function flushPlayerSessionSave(guildId: string): Promise<void> {
+    const timer = pendingSaveTimers.get(guildId)
+    if (timer) {
+        clearTimeout(timer)
+        pendingSaveTimers.delete(guildId)
+    }
+    const player = pendingPlayers.get(guildId)
+    pendingPlayers.delete(guildId)
+    if (player) {
+        await writePlayerSession(player)
+    }
+}
+
+/** Flushes all pending debounced saves and snapshots for active Lavalink players. */
+export async function flushAllPlayerSessionSaves(): Promise<void> {
+    const guildIds = new Set([...pendingSaveTimers.keys(), ...pendingPlayers.keys()])
+    for (const guildId of guildIds) {
+        await flushPlayerSessionSave(guildId)
+    }
+
+    const client = tryGetBotClient()
+    if (!client) return
+    for (const player of client.lavalink.players.values()) {
+        if (isRestoreInProgress(player.guildId)) continue
+        try {
+            await writePlayerSession(player)
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err)
+            client.error(
+                `[playerSession] flushAll write failed for guild ${player.guildId}: ${msg}`
+            )
+        }
+    }
+}
+
+/** Removes a persisted session row (intentional destroy or stale cleanup). */
+export async function clearPlayerSession(guildId: string): Promise<void> {
+    const timer = pendingSaveTimers.get(guildId)
+    if (timer) {
+        clearTimeout(timer)
+        pendingSaveTimers.delete(guildId)
+    }
+    pendingPlayers.delete(guildId)
+    await deletePlayerSession(guildId)
+}

--- a/src/util/playerSessionTracks.ts
+++ b/src/util/playerSessionTracks.ts
@@ -1,0 +1,122 @@
+import type { Player, Track, UnresolvedTrack } from "lavalink-client"
+import type { PersistedQueueTrack } from "../types/index.js"
+import { getRequesterUserId, stampRequesterUserIdOnTracks } from "./rrqDisconnect.js"
+import { thumbnailFromLavalinkTrack } from "./trackThumbnail.js"
+
+const RESOLVE_CONCURRENCY = 6
+
+function isResolvedTrack(track: unknown): track is Track {
+    return (
+        Boolean(track) &&
+        typeof track === "object" &&
+        "info" in track &&
+        typeof (track as Track).info?.uri === "string"
+    )
+}
+
+/** Serializes a Lavalink track into a DB-safe persisted shape. */
+export function persistedTrackFromLavalink(
+    track: Track | UnresolvedTrack
+): PersistedQueueTrack | null {
+    const uri = track.info.uri?.trim()
+    if (!uri) return null
+    const encoded =
+        typeof (track as { encoded?: unknown }).encoded === "string"
+            ? (track as { encoded: string }).encoded
+            : null
+    return {
+        title: track.info.title?.trim() || "Unknown",
+        author: track.info.author?.trim() || "Unknown",
+        uri,
+        duration: track.info.duration ?? 0,
+        encoded,
+        requesterId: getRequesterUserId(track.requester),
+        thumbnailUrl: isResolvedTrack(track) ? thumbnailFromLavalinkTrack(track) : null,
+        isStream: Boolean(track.info.isStream),
+    }
+}
+
+function normalizeUriForCompare(uri: string): string {
+    return uri.trim().toLowerCase().replace(/\/+$/, "")
+}
+
+/** True when a resolved Lavalink track matches what we persisted (guards bad search hits). */
+function trackMatchesStored(track: Track, stored: PersistedQueueTrack): boolean {
+    const resolvedUri = track.info.uri?.trim()
+    const storedUri = stored.uri.trim()
+    if (resolvedUri && storedUri) {
+        if (normalizeUriForCompare(resolvedUri) === normalizeUriForCompare(storedUri)) {
+            return true
+        }
+    }
+    const resolvedTitle = track.info.title?.trim().toLowerCase()
+    const storedTitle = stored.title.trim().toLowerCase()
+    return Boolean(resolvedTitle && storedTitle && resolvedTitle === storedTitle)
+}
+
+async function resolvePersistedTrackAtIndex(
+    player: Player,
+    stored: PersistedQueueTrack
+): Promise<Track | null> {
+    const requester = stored.requesterId ?? "session-restore"
+
+    if (stored.encoded) {
+        try {
+            const decoded = await player.node.decode.singleTrack(stored.encoded, requester)
+            if (isResolvedTrack(decoded)) {
+                if (stored.requesterId) {
+                    stampRequesterUserIdOnTracks([decoded], stored.requesterId)
+                }
+                return decoded
+            }
+        } catch {
+            /* fall through to URI search */
+        }
+    }
+
+    if (stored.uri) {
+        try {
+            const res = await player.search(stored.uri, requester)
+            const first = res?.tracks?.[0]
+            if (isResolvedTrack(first) && trackMatchesStored(first, stored)) {
+                if (stored.requesterId) {
+                    stampRequesterUserIdOnTracks([first], stored.requesterId)
+                }
+                return first
+            }
+        } catch {
+            /* unresolved */
+        }
+    }
+    return null
+}
+
+/** Resolves persisted tracks via Lavalink (parallel, preserves order). */
+export async function resolvePersistedTracks(
+    player: Player,
+    storedTracks: PersistedQueueTrack[]
+): Promise<{ resolved: Track[]; failed: number }> {
+    if (storedTracks.length === 0) {
+        return { resolved: [], failed: 0 }
+    }
+
+    const slots: (Track | null)[] = new Array(storedTracks.length).fill(null)
+    let nextIndex = 0
+
+    async function worker(): Promise<void> {
+        while (true) {
+            const i = nextIndex++
+            if (i >= storedTracks.length) return
+            slots[i] = await resolvePersistedTrackAtIndex(player, storedTracks[i]!)
+        }
+    }
+
+    const workerCount = Math.min(RESOLVE_CONCURRENCY, storedTracks.length)
+    await Promise.all(Array.from({ length: workerCount }, () => worker()))
+
+    const resolved: Track[] = []
+    for (const track of slots) {
+        if (track) resolved.push(track)
+    }
+    return { resolved, failed: storedTracks.length - resolved.length }
+}

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -7,6 +7,7 @@ import {
     stampRequesterUserIdOnTracks,
 } from "./rrqDisconnect.js"
 import { startPlaybackIfNeeded } from "./musicManager.js"
+import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
 
 export function shuffleArray<T>(items: T[]): T[] {
     const arr = [...items]
@@ -62,11 +63,7 @@ export async function resolveStoredPlaylistTracks(
         while (true) {
             const i = nextIndex++
             if (i >= storedTracks.length) return
-            slots[i] = await resolveStoredTrackAtIndex(
-                player,
-                storedTracks[i]!.uri,
-                requester
-            )
+            slots[i] = await resolveStoredTrackAtIndex(player, storedTracks[i]!.uri, requester)
         }
     }
 
@@ -137,6 +134,7 @@ export async function enqueueResolvedPlaylistTracks(
             playbackError = error instanceof Error ? error.message : String(error)
         }
     }
+    schedulePlayerSessionSave(player)
     return {
         queued: toQueue.length,
         failed: 0,

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -1,0 +1,172 @@
+import type { VoiceBasedChannel } from "discord.js"
+import type BotClient from "../lib/BotClient.js"
+import type { PlayerSessionData } from "../types/index.js"
+import { deletePlayerSession, listPlayerSessions } from "../repositories/playerSessionRepository.js"
+import { updateControlMessage } from "../events/handlers/handleControlChannel.js"
+import { playerBroadcaster } from "../shared/websocket/PlayerBroadcaster.js"
+import { getGuildSettings } from "./saveControlChannel.js"
+import { ensurePlayerConnected, startPlaybackIfNeeded } from "./musicManager.js"
+import {
+    clearPlayerSessionRestoreInProgress,
+    markPlayerSessionRestoreInProgress,
+    schedulePlayerSessionSave,
+} from "./playerSessionPersistence.js"
+import { resolvePersistedTracks } from "./playerSessionTracks.js"
+import { countHumanMembers } from "./voiceChannelMembers.js"
+
+let discordReady = false
+let restoreAttempted = false
+
+/** Called from `clientReady` so restore waits for Discord before touching guild channels. */
+export function markDiscordReadyForPlayerRestore(): void {
+    discordReady = true
+}
+
+/** Attempts one-shot restore after Lavalink node connect (no-op if Discord is not ready yet). */
+export async function tryRestorePlayerSessionsOnLavalinkConnect(client: BotClient): Promise<void> {
+    if (!discordReady || restoreAttempted) return
+    restoreAttempted = true
+    await restorePlayerSessions(client)
+}
+
+async function fetchVoiceChannel(
+    client: BotClient,
+    guildId: string,
+    voiceChannelId: string
+): Promise<VoiceBasedChannel | null> {
+    const guild =
+        client.guilds.cache.get(guildId) ?? (await client.guilds.fetch(guildId).catch(() => null))
+    if (!guild) return null
+
+    const cached = guild.channels.cache.get(voiceChannelId)
+    if (cached?.isVoiceBased()) return cached
+
+    const fetched = await guild.channels.fetch(voiceChannelId).catch(() => null)
+    if (fetched?.isVoiceBased()) return fetched
+    return null
+}
+
+function resolveTextChannelId(session: PlayerSessionData): string | null {
+    if (session.textChannelId) return session.textChannelId
+    const settings = getGuildSettings()[session.guildId]
+    return settings?.controlChannelId ?? null
+}
+
+async function restoreSingleSession(client: BotClient, session: PlayerSessionData): Promise<void> {
+    const { guildId, voiceChannelId, snapshot } = session
+
+    if (client.lavalink.getPlayer(guildId)) {
+        client.debug(`[playerSession] restore skipped for ${guildId}: player already exists`)
+        return
+    }
+
+    const voiceChannel = await fetchVoiceChannel(client, guildId, voiceChannelId)
+    if (!voiceChannel) {
+        client.info(
+            `[playerSession] stale session removed for ${guildId}: voice channel ${voiceChannelId} not found`
+        )
+        await deletePlayerSession(guildId)
+        return
+    }
+
+    const humans = countHumanMembers(voiceChannel)
+    if (humans === 0) {
+        client.info(
+            `[playerSession] stale session removed for ${guildId}: no humans in VC ${voiceChannelId}`
+        )
+        await deletePlayerSession(guildId)
+        return
+    }
+
+    const tracksToRestore = [...(snapshot.current ? [snapshot.current] : []), ...snapshot.queue]
+    if (tracksToRestore.length === 0) {
+        await deletePlayerSession(guildId)
+        return
+    }
+
+    const textChannelId = resolveTextChannelId(session)
+    markPlayerSessionRestoreInProgress(guildId)
+
+    try {
+        const player = await client.lavalink.createPlayer({
+            guildId,
+            voiceChannelId,
+            textChannelId: textChannelId ?? undefined,
+            selfDeaf: true,
+            volume: snapshot.volume,
+        })
+
+        await ensurePlayerConnected(client, player, voiceChannel)
+
+        const { resolved, failed } = await resolvePersistedTracks(player, tracksToRestore)
+        if (failed > 0) {
+            client.warn(
+                `[playerSession] restore for ${guildId}: ${failed}/${tracksToRestore.length} tracks failed to resolve`
+            )
+        }
+        if (resolved.length === 0) {
+            client.warn(
+                `[playerSession] restore for ${guildId}: no tracks resolved; destroying player`
+            )
+            await player.destroy()
+            await deletePlayerSession(guildId)
+            return
+        }
+
+        await player.queue.add(resolved)
+
+        if (snapshot.repeatMode !== "off") {
+            await player.setRepeatMode(snapshot.repeatMode)
+        }
+        player.set("autoplay", snapshot.autoplay)
+        player.set("rrqEnabled", snapshot.rrqEnabled)
+
+        await startPlaybackIfNeeded(player)
+        if (snapshot.paused && player.playing) {
+            await player.pause()
+        }
+
+        client.info(
+            `[playerSession] restored player for guild ${guildId} (${resolved.length} tracks, humans=${humans})`
+        )
+
+        scheduleControlMessageUpdate(client, guildId)
+        playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
+        schedulePlayerSessionSave(player)
+    } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err)
+        client.error(`[playerSession] restore failed for guild ${guildId}: ${msg}`)
+        await deletePlayerSession(guildId).catch(() => undefined)
+    } finally {
+        clearPlayerSessionRestoreInProgress(guildId)
+    }
+}
+
+function scheduleControlMessageUpdate(client: BotClient, guildId: string): void {
+    void updateControlMessage(client, guildId).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err)
+        client.error(`[playerSession] updateControlMessage failed for ${guildId}: ${msg}`)
+    })
+}
+
+/** Loads all persisted sessions and restores players when humans remain in the saved VC. */
+export async function restorePlayerSessions(client: BotClient): Promise<void> {
+    let sessions: PlayerSessionData[]
+    try {
+        sessions = await listPlayerSessions()
+    } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err)
+        client.error(`[playerSession] failed to list sessions: ${msg}`)
+        return
+    }
+
+    if (sessions.length === 0) {
+        client.debug("[playerSession] no persisted sessions to restore")
+        return
+    }
+
+    client.info(`[playerSession] attempting restore for ${sessions.length} persisted session(s)`)
+    for (const session of sessions) {
+        await restoreSingleSession(client, session)
+    }
+}

--- a/src/util/voiceChannelMembers.ts
+++ b/src/util/voiceChannelMembers.ts
@@ -1,0 +1,6 @@
+import type { VoiceBasedChannel } from "discord.js"
+
+/** Counts non-bot members in a voice channel (used for alone-in-VC cleanup and session restore). */
+export function countHumanMembers(voiceChannel: VoiceBasedChannel): number {
+    return voiceChannel.members.filter((m) => !m.user.bot).size
+}


### PR DESCRIPTION
## Summary

Adds **PostgreSQL-backed player session persistence** so active Lavalink players survive bot restarts/rebuilds. While a guild has a live player, the bot snapshots queue state to the database; on boot it restores players only when humans are still in the saved voice channel.

This addresses the previous behavior where every restart wiped in-memory queues, current track, and session flags (autoplay, RRQ, repeat mode, pause state).

## Problem

- Lavalink `Player` objects (queue, current track, volume, flags) lived entirely in memory.
- Bot restart/rebuild = all players lost.
- `lavaNodeEvents.ts` had a stub `resumed` handler with no restore logic.

## Solution overview

```mermaid
sequenceDiagram
    participant Player as LavalinkPlayer
    participant Persist as playerSessionPersistence
    participant DB as PlayerSession
    participant Boot as restorePlayerSessions

    Player->>Persist: queue/track/player changes
    Persist->>DB: debounced upsert (~2s)
    Player->>Persist: playerDestroy
    Persist->>DB: delete row

    Note over Boot: Lavalink node connect after clientReady
    Boot->>DB: load all sessions
    Boot->>Boot: require humans in saved VC
    Boot->>Player: createPlayer + decode tracks + play
```

## Database

New Prisma model `PlayerSession` (one row per guild):

| Column | Purpose |
|--------|---------|
| `guildId` | Primary key |
| `voiceChannelId` | VC to rejoin |
| `textChannelId` | Player text channel (falls back to guild control channel) |
| `snapshot` | Versioned JSON (`PlayerSessionSnapshotV1`) |
| `updatedAt` | Last write time |

Migration: `prisma/migrations/20260614120000_add_player_session/`

### Snapshot contents (v1)

- Current track + upcoming queue (title, author, uri, duration, Lavalink `encoded` string, requester id, thumbnail, stream flag)
- Volume, repeat mode, paused/playing, autoplay, RRQ enabled

**Not persisted:** RRQ disconnect timers, dashboard requester snapshots, autoplay recent-history dedup list, local `@discordjs/voice` player path.

## Persistence (write path)

- `schedulePlayerSessionSave(player)` — debounced upsert (~2s per guild)
- `clearPlayerSession(guildId)` — delete on intentional `playerDestroy`
- `flushAllPlayerSessionSaves()` — called on `SIGINT`/`SIGTERM` before shutdown

**Hooks:** `lavaManagerEvents` (track start/end, queue end, player move/update, destroy), `musicManager`, web API queue/player handlers, `playlistQueue`.

## Restore (read path)

Triggered once on **first Lavalink node `connect`** after Discord `clientReady`.

For each `PlayerSession` row:

1. Skip if an in-memory player already exists for the guild.
2. Fetch voice channel; **require at least one human** (non-bot) member.
3. Delete stale row if channel missing or VC empty.
4. `createPlayer` + `ensurePlayerConnected`.
5. Rehydrate tracks:
   - **Primary:** `player.node.decode.singleTrack(encoded)` — Lavalink decode API
   - **Fallback:** `player.search(uri)` only when decode fails, and only if resolved title/URI matches persisted metadata
6. Enqueue current (if any) then queue; restore repeat/autoplay/RRQ; start playback from **beginning of current track** (V1 — no position seek).
7. Apply paused state if snapshot was paused; refresh control embed + dashboard broadcast.

### Bug fix included

Initial restore used `player.search(encoded)`, which treated base64 Lavalink track strings as **text search queries** and returned unrelated YouTube results (e.g. Java `.equals()` videos). Restore now uses `decode.singleTrack` for encoded tracks.

## Files added

- `src/repositories/playerSessionRepository.ts`
- `src/util/playerSessionPersistence.ts`
- `src/util/playerSessionTracks.ts`
- `src/util/restorePlayerSessions.ts`
- `src/util/voiceChannelMembers.ts`

## Explicit non-goals (V1)

| Item | Reason |
|------|--------|
| Local file player | Separate `@discordjs/voice` lifecycle |
| Exact timestamp / seek resume | Current track restarts at 0:00 |
| Lavalink server-native session resume | DB is source of truth when bot + Lavalink restart together |

## Test plan

- [ ] Start playback in a VC with 2+ humans; queue several tracks; restart bot → player rejoins, queue restores, current song plays from start.
- [ ] `/leave` or alone-in-VC destroy → restart → **no** restore for that guild (`PlayerSession` row deleted).
- [ ] Humans leave during outage → restart → stale row deleted, no ghost player.
- [ ] Web dashboard: enqueue, reorder, clear queue, pause/loop/autoplay → restart → state matches.
- [ ] Confirm migration runs on deploy (`prisma migrate deploy` on bot startup).
- [ ] If a bad restore occurred before this PR: stop player to clear `PlayerSession`, then retest with fresh snapshot.

## Verification

- `yarn typecheck` — pass
- `yarn lint` — pass
- Prettier — pass on touched files