### PR TITLE
fix(deploy): extend Lavalink healthcheck grace and add bot compose probe

### DIFF
--- a/Lavalink/Dockerfile
+++ b/Lavalink/Dockerfile
@@ -34,7 +34,7 @@ EXPOSE 2333
 
 # Health check to see if Lavalink is ready
 # Requires LAVALINK_PORT and LAVALINK_PASSWORD env vars to be set
-HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=5 \
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=10 \
   CMD /bin/sh /app/healthcheck.sh || exit 1
 
 # Run the entrypoint script which generates application.yml and starts Lavalink

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,12 +21,13 @@ services:
             - LAVALINK_SPOTIFY_ALBUM_LOAD_LIMIT=${LAVALINK_SPOTIFY_ALBUM_LOAD_LIMIT}
         ports:
             - "${LAVALINK_PORT}:${LAVALINK_PORT}" # Map host port to container port
+        # JVM + Maven plugin load can exceed 15s on container recreate; allow ~160s before unhealthy.
         healthcheck:
             test: ["CMD", "/bin/sh", "/app/healthcheck.sh"]
             interval: 10s
             timeout: 5s
-            retries: 5
-            start_period: 15s
+            retries: 10
+            start_period: 60s
         volumes:
             - lavalink-plugins:/app/plugins
             - dimbybot-downloads:/app/downloads
@@ -119,6 +120,13 @@ services:
         # Pair with BOT_API_REQUIRE_PRIVATE_CLIENT_IP=1 (default) and host firewall rules so only RFC1918 sources reach the port.
         ports:
             - "${BOT_API_HOST:-127.0.0.1}:${BOT_API_PORT:-3001}:${BOT_API_PORT:-3001}"
+        # Explicit healthcheck so dimbybot-web `depends_on: service_healthy` waits for the bot API (matches Dockerfile).
+        healthcheck:
+            test: ["CMD", "/bin/sh", "/app/healthcheck.sh"]
+            interval: 30s
+            timeout: 5s
+            retries: 3
+            start_period: 120s
         networks:
             - internal
 


### PR DESCRIPTION
## Summary
- Increase Lavalink `start_period` (60s) and `retries` (10) so JVM + plugin startup on container recreate has up to ~160s before Compose marks the service unhealthy.
- Add an explicit `dimbybot` healthcheck in `docker-compose.yml` so `dimbybot-web` `depends_on: service_healthy` waits for the bot API (aligned with the bot Dockerfile probe).
- Mirror Lavalink timing in `Lavalink/Dockerfile` for consistency outside compose.

Fixes the failed deploy after PR #103 merge ([run 27629425598](https://github.com/bpeters132/DimbyBot2/actions/runs/27629425598)) where Lavalink was marked unhealthy after ~60s while still starting.

## Test plan
- [ ] Merge and let CI deploy to production
- [ ] Confirm `docker compose up` completes without `lavalink is unhealthy`
- [ ] If deploy still fails, check `docker logs lavalink` on the host for a startup crash vs slow start