### PR TITLE
chore(deps): patch Dependabot and yarn audit advisories

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,7 @@ POSTGRES_PASSWORD=
 # Other Credentials (if used by bot features)
 EMAIL_USER=
 EMAIL_PASS=
-# Inbox for the disabled /suggest command (nodemailer To: address), if you enable it
+# Inbox for the disabled /suggest command if you re-enable it (add nodemailer to package.json)
 FEEDBACK_EMAIL=
 
 # Lavalink Configuration

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Author is just a dude that can barely code but can figure things out.
 
 Dev splits **backend in Docker** from the **dashboard on the host**:
 
-| Piece | Where it runs | How |
-| ----- | ------------- | --- |
+| Piece                   | Where it runs                                            | How                                                                                             |
+| ----------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | Bot, Lavalink, Postgres | Docker (`docker-compose.yml` + `docker-compose.dev.yml`) | `./dev-env.sh build` then `./dev-env.sh up` (or `yarn docker:dev:build` / `yarn docker:dev:up`) |
-| Next.js dashboard | **Host** (not in the dev compose stack) | `yarn web:install` then `yarn dev:web` |
+| Next.js dashboard       | **Host** (not in the dev compose stack)                  | `yarn web:install` then `yarn dev:web`                                                          |
 
 Production is different: the dashboard is the separate `dimbybot-web` container (`docker-compose.dashboard.yml` + `Dockerfile.web`). Do not expect `dimbybot-web` when using the dev compose files.
 
@@ -112,7 +112,7 @@ src/
 
 - [discord.js](https://discord.js.org/): The primary library for interacting with the Discord API.
 - [lavalink-client](https://github.com/freyacodes/lavalink-client): Client for interacting with a Lavalink server.
-- [nodemailer](https://nodemailer.com/): For sending emails.
+- [nodemailer](https://nodemailer.com/): Optional; only required if you re-enable the disabled `/suggest` command.
 
 ## License
 

--- a/docker/ytdlp-requirements.txt
+++ b/docker/ytdlp-requirements.txt
@@ -1,2 +1,2 @@
 # Pinned for reproducible Docker builds (see Dockerfile).
-yt-dlp==2026.2.21
+yt-dlp==2026.6.9

--- a/package.json
+++ b/package.json
@@ -49,11 +49,10 @@
         "express": "^5.2.1",
         "ffmpeg-static": "^5.3.0",
         "lavalink-client": "^2.9.9",
-        "nodemailer": "^8.0.5",
         "opusscript": "^0.1.1",
         "sodium": "^3.0.2",
         "winston": "^3.19.0",
-        "ws": "^8.20.1"
+        "ws": "^8.21.0"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -74,11 +73,11 @@
         "typescript-eslint": "^8.26.1"
     },
     "resolutions": {
-        "ws": "^8.20.1",
-        "undici": "^6.24.0",
+        "ws": "^8.21.0",
+        "undici": "^6.27.0",
         "kysely": "^0.28.17",
         "fast-uri": "^3.1.2",
-        "hono": "^4.12.21",
+        "hono": "^4.12.25",
         "qs": "^6.15.2",
         "@hono/node-server": "^1.19.13",
         "lodash": "^4.18.0",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -25,7 +25,7 @@
         "react-dom": "^19.2.5",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
-        "ws": "^8.20.0"
+        "ws": "^8.21.0"
     },
     "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
@@ -43,6 +43,8 @@
     "resolutions": {
         "kysely": "^0.28.17",
         "fast-uri": "^3.1.2",
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.10",
+        "js-yaml": "^4.2.0",
+        "ws": "^8.21.0"
     }
 }

--- a/src/web/yarn.lock
+++ b/src/web/yarn.lock
@@ -1084,10 +1084,10 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@^4.1.0, js-yaml@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 
@@ -1778,10 +1778,10 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@^8.20.0:
-  version "8.20.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@^8.20.0, ws@^8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xtend@^4.0.0:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,10 +1799,10 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-hono@^4.12.21, hono@^4.12.8:
-  version "4.12.23"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.23.tgz#998b91651686149f0e6edbb8564d604da04f3cf8"
-  integrity sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==
+hono@^4.12.25, hono@^4.12.8:
+  version "4.12.26"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.26.tgz#450edfd64aad96cccc36829d63ec1430272e3ef8"
+  integrity sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==
 
 http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
   version "2.0.1"
@@ -2113,11 +2113,6 @@ node-fetch-native@^1.6.6:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.7.tgz#9d09ca63066cc48423211ed4caf5d70075d76a71"
   integrity sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==
-
-nodemailer@^8.0.5:
-  version "8.0.7"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-8.0.7.tgz#538729a79444e538331bca8a6fc3e5c034eaebc6"
-  integrity sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==
 
 nodemon@^3.1.14:
   version "3.1.14"
@@ -2848,10 +2843,10 @@ undici-types@~7.18.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
-undici@6.21.3, undici@^6.24.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.25.0.tgz#8c4efb8c998dc187fc1cfb5dde1ef19a211849fb"
-  integrity sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==
+undici@6.21.3, undici@^6.27.0:
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
+  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -2932,10 +2927,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.17.0, ws@^8.19.0, ws@^8.20.1:
-  version "8.20.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@^8.17.0, ws@^8.19.0, ws@^8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
## Summary
- Bump ws to ^8.21.0 (root + web resolutions)
- Bump hono to ^4.12.25 and undici to ^6.27.0 via root resolutions
- Bump js-yaml to ^4.2.0 via web resolution
- Bump yt-dlp to 2026.6.9 in docker/ytdlp-requirements.txt
- Remove unused nodemailer (disabled /suggest only)

## Test plan
- [x] yarn typecheck
- [x] yarn lint
- [x] yarn audit (root + web): 0 vulnerabilities
- [ ] CI deploy builds bot image with new yt-dlp pin
- [ ] Dependabot alerts #82-#95 close after merge

Made with [Cursor](https://cursor.com)