### PR TITLE
fix: stop writePlayerSession from deleting sessions on empty snapshot

### DIFF
--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -68,10 +68,9 @@ async function writePlayerSession(player: Player): Promise<void> {
     const voiceChannelId = player.voiceChannelId
     if (!voiceChannelId) return
 
-    if (!snapshot) {
-        await deletePlayerSession(player.guildId)
-        return
-    }
+    // Transient empty queue (autoplay handoff, between tracks) must not delete the last
+    // good snapshot — only clearPlayerSession removes rows on intentional playerDestroy.
+    if (!snapshot) return
 
     await upsertPlayerSession(
         player.guildId,


### PR DESCRIPTION
## Summary
- Consolidates identical draft PRs #110–#125 into one reviewable change.
- `writePlayerSession` no longer calls `deletePlayerSession` when `snapshotFromPlayer` is null (transient empty queue during autoplay handoff / between tracks / SIGTERM flush).
- Intentional teardown still deletes via `clearPlayerSession` on `playerDestroy`.

## Supersedes
Closes as superseded: #110 #111 #112 #113 #114 #115 #116 #117 #118 #119 #120 #121 #122 #123 #124 #125

## Test plan
- [ ] With autoplay on, play until last track ends; confirm DB `PlayerSession` row is not deleted during the empty-queue search window
- [ ] Deploy/SIGTERM while between tracks; confirm session restores after restart
- [ ] `/stop` or idle destroy still clears the session row
- [ ] `yarn typecheck` / `yarn lint` clean on changed file