### PR TITLE
fix: consolidate session persistence, guild-settings deletes, and regression tests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -39,7 +39,8 @@ reviews:
         enabled: true
         drafts: false
         auto_incremental_review: true
-        auto_pause_after_reviewed_commits: 5
+        # 0 = never auto-pause incremental reviews (review every eligible push)
+        auto_pause_after_reviewed_commits: 0
         ignore_title_keywords:
             - "WIP"
             - "DO NOT MERGE"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,9 +74,6 @@ jobs:
                   yarn typecheck
                   yarn lint
 
-            - name: Typecheck bot unit tests
-              run: yarn tsc --noEmit -p tsconfig.tests.json
-
     build-and-push:
         needs: validate-node-lts
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skip_build }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,9 @@ jobs:
                   yarn typecheck
                   yarn lint
 
+            - name: Typecheck bot unit tests
+              run: yarn tsc --noEmit -p tsconfig.tests.json
+
     build-and-push:
         needs: validate-node-lts
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skip_build }}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ export default tseslint.config(
             "dist/**",
             ".next/**",
             "src/web/.next/**",
+            "src/**/*.test.ts",
         ],
     },
     js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "build": "yarn build:bot && yarn build:web",
         "build:bot": "tsc",
         "build:web": "yarn web:install && yarn --cwd src/web build",
-        "typecheck": "tsc --noEmit && yarn web:install && yarn --cwd src/web typecheck",
+        "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json && yarn web:install && yarn --cwd src/web typecheck",
         "lint": "eslint .",
         "test": "tsx --test \"src/**/*.test.ts\"",
         "prisma": "prisma",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "build:web": "yarn web:install && yarn --cwd src/web build",
         "typecheck": "tsc --noEmit && yarn web:install && yarn --cwd src/web typecheck",
         "lint": "eslint .",
+        "test": "tsx --test \"src/**/*.test.ts\"",
         "prisma": "prisma",
         "db:generate": "prisma generate",
         "db:migrate:deploy": "prisma migrate deploy --schema prisma/schema.prisma",
@@ -69,6 +70,7 @@
         "nodemon": "^3.1.14",
         "prettier": "3.8.1",
         "prisma": "^7.6.0",
+        "tsx": "^4.20.5",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.26.1"
     },

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -143,8 +143,7 @@ export async function playerPlaylistPlayPOST(
         )
 
         if (resolved.length === 0) {
-            const hasQueueContent =
-                Boolean(player.queue.current) || player.queue.tracks.length > 0
+            const hasQueueContent = Boolean(player.queue.current) || player.queue.tracks.length > 0
             if (!hasQueueContent) {
                 suppressNextPlayerSessionClear(guildId)
                 await client.lavalink.destroyPlayer(guildId).catch(() => undefined)

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -15,7 +15,10 @@ import {
     restoreUpcomingQueue,
     snapshotUpcomingQueue,
 } from "../../util/playlistQueue.js"
-import { suppressNextPlayerSessionClear } from "../../util/playerSessionPersistence.js"
+import {
+    clearSuppressNextPlayerSessionClear,
+    suppressNextPlayerSessionClear,
+} from "../../util/playerSessionPersistence.js"
 
 export async function playerPlaylistPlayPOST(
     headers: Headers,
@@ -146,7 +149,9 @@ export async function playerPlaylistPlayPOST(
             const hasQueueContent = Boolean(player.queue.current) || player.queue.tracks.length > 0
             if (!hasQueueContent) {
                 suppressNextPlayerSessionClear(guildId)
-                await client.lavalink.destroyPlayer(guildId).catch(() => undefined)
+                await client.lavalink.destroyPlayer(guildId).catch(() => {
+                    clearSuppressNextPlayerSessionClear(guildId)
+                })
             }
             return {
                 status: 404,

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -11,10 +11,12 @@ import {
     clearUpcomingQueue,
     enqueueResolvedPlaylistTracks,
     type EnqueuePlaylistResult,
+    playerHasQueueContent,
     resolveStoredPlaylistTracks,
     restoreUpcomingQueue,
     snapshotUpcomingQueue,
 } from "../../util/playlistQueue.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
 import { acquirePlayerSessionClearSuppressLease } from "../../util/playerSessionPersistence.js"
 
 export async function playerPlaylistPlayPOST(
@@ -143,14 +145,16 @@ export async function playerPlaylistPlayPOST(
         )
 
         if (resolved.length === 0) {
-            const hasQueueContent = Boolean(player.queue.current) || player.queue.tracks.length > 0
-            if (!hasQueueContent) {
+            // Serialize emptiness check + destroy with enqueue so a concurrent queue add cannot
+            // land between the check and teardown.
+            await withGuildPlayerQueueLock(guildId, async () => {
+                if (playerHasQueueContent(player)) return
                 const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
                 await client.lavalink.destroyPlayer(guildId).catch(() => {
                     // Release only this attempt's lease; clearPlayerSession consumes on success.
                     suppressLease.release()
                 })
-            }
+            })
             return {
                 status: 404,
                 body: {

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -15,6 +15,7 @@ import {
     restoreUpcomingQueue,
     snapshotUpcomingQueue,
 } from "../../util/playlistQueue.js"
+import { suppressNextPlayerSessionClear } from "../../util/playerSessionPersistence.js"
 
 export async function playerPlaylistPlayPOST(
     headers: Headers,
@@ -142,6 +143,12 @@ export async function playerPlaylistPlayPOST(
         )
 
         if (resolved.length === 0) {
+            const hasQueueContent =
+                Boolean(player.queue.current) || player.queue.tracks.length > 0
+            if (!hasQueueContent) {
+                suppressNextPlayerSessionClear(guildId)
+                await client.lavalink.destroyPlayer(guildId).catch(() => undefined)
+            }
             return {
                 status: 404,
                 body: {

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -15,10 +15,7 @@ import {
     restoreUpcomingQueue,
     snapshotUpcomingQueue,
 } from "../../util/playlistQueue.js"
-import {
-    clearSuppressNextPlayerSessionClear,
-    suppressNextPlayerSessionClear,
-} from "../../util/playerSessionPersistence.js"
+import { acquirePlayerSessionClearSuppressLease } from "../../util/playerSessionPersistence.js"
 
 export async function playerPlaylistPlayPOST(
     headers: Headers,
@@ -148,9 +145,10 @@ export async function playerPlaylistPlayPOST(
         if (resolved.length === 0) {
             const hasQueueContent = Boolean(player.queue.current) || player.queue.tracks.length > 0
             if (!hasQueueContent) {
-                suppressNextPlayerSessionClear(guildId)
+                const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
                 await client.lavalink.destroyPlayer(guildId).catch(() => {
-                    clearSuppressNextPlayerSessionClear(guildId)
+                    // Release only this attempt's lease; clearPlayerSession consumes on success.
+                    suppressLease.release()
                 })
             }
             return {

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -7,9 +7,8 @@ import { stampRequesterUserIdOnTracks } from "../../util/rrqDisconnect.js"
 import type { PermissionGuardSuccess } from "../../shared/api-auth.js"
 import { resolveWebDashboardTextChannelId } from "../webDashboardTextChannel.js"
 import {
-    clearSuppressNextPlayerSessionClear,
+    acquirePlayerSessionClearSuppressLease,
     schedulePlayerSessionSave,
-    suppressNextPlayerSessionClear,
 } from "../../util/playerSessionPersistence.js"
 
 export type SearchAndEnqueueGuard = Pick<PermissionGuardSuccess, "session">
@@ -152,9 +151,10 @@ export async function searchAndEnqueue(
 
     const cleanupCreatedPlayer = async (): Promise<void> => {
         if (!createdHere) return
-        suppressNextPlayerSessionClear(guildId)
+        const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
         await client.lavalink.destroyPlayer(guildId).catch(() => {
-            clearSuppressNextPlayerSessionClear(guildId)
+            // Release only this attempt's lease; clearPlayerSession consumes on success.
+            suppressLease.release()
         })
     }
 

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -12,7 +12,7 @@ import {
 } from "../../util/playerSessionPersistence.js"
 import {
     acquireGuildPlayerLifecycleReservation,
-    getGuildPlayerLifecycleReservationCount,
+    tryDestroyOrphanGuildPlayer,
     withGuildPlayerQueueLock,
 } from "../../util/guildPlayerQueueLock.js"
 import { playerHasQueueContent } from "../../util/playlistQueue.js"
@@ -160,16 +160,19 @@ export async function searchAndEnqueue(
 
         const cleanupCreatedPlayer = async (): Promise<void> => {
             if (!createdHere) return
-            // Serialize with enqueue; skip destroy while other requests still reserve this player.
-            await withGuildPlayerQueueLock(guildId, async () => {
-                if (playerHasQueueContent(player)) return
-                // Count includes this request; >1 means another in-flight search/enqueue still needs it.
-                if (getGuildPlayerLifecycleReservationCount(guildId) > 1) return
-                const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
-                await client.lavalink.destroyPlayer(guildId).catch(() => {
-                    // Release only this attempt's lease; clearPlayerSession consumes on success.
-                    suppressLease.release()
-                })
+            // Destroy now if idle; if other requests still reserve the player, defer until count is 0.
+            await tryDestroyOrphanGuildPlayer(guildId, {
+                hasQueueContent: () => {
+                    const live = client.lavalink.getPlayer(guildId) ?? player
+                    return playerHasQueueContent(live)
+                },
+                destroyPlayer: async () => {
+                    const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
+                    await client.lavalink.destroyPlayer(guildId).catch(() => {
+                        // Release only this attempt's lease; clearPlayerSession consumes on success.
+                        suppressLease.release()
+                    })
+                },
             })
         }
 

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -10,7 +10,11 @@ import {
     acquirePlayerSessionClearSuppressLease,
     schedulePlayerSessionSave,
 } from "../../util/playerSessionPersistence.js"
-import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
+import {
+    acquireGuildPlayerLifecycleReservation,
+    getGuildPlayerLifecycleReservationCount,
+    withGuildPlayerQueueLock,
+} from "../../util/guildPlayerQueueLock.js"
 import { playerHasQueueContent } from "../../util/playlistQueue.js"
 
 export type SearchAndEnqueueGuard = Pick<PermissionGuardSuccess, "session">
@@ -147,68 +151,42 @@ export async function searchAndEnqueue(
         }
     }
 
-    if (textChannelId) {
-        player.textChannelId = textChannelId
-    }
-
-    const cleanupCreatedPlayer = async (): Promise<void> => {
-        if (!createdHere) return
-        // Serialize with enqueue; re-check emptiness so we never tear down active playback.
-        await withGuildPlayerQueueLock(guildId, async () => {
-            if (playerHasQueueContent(player)) return
-            const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
-            await client.lavalink.destroyPlayer(guildId).catch(() => {
-                // Release only this attempt's lease; clearPlayerSession consumes on success.
-                suppressLease.release()
-            })
-        })
-    }
-
-    if (!createdHere) {
-        let refreshedMemberEarly = null
-        try {
-            refreshedMemberEarly = await guild.members.fetch(requesterId)
-        } catch (error: unknown) {
-            if (!isMemberFetchNotFound(error)) {
-                console.error(
-                    "[searchAndEnqueue] requester member refresh failed (existing player)",
-                    {
-                        guildId,
-                        requesterId,
-                        error,
-                    }
-                )
-                return {
-                    ok: false,
-                    status: 503,
-                    error: { error: "Unable to verify voice state, please try again." },
-                }
-            }
-        }
-        const refreshedVoiceEarly = refreshedMemberEarly?.voice?.channel
-        if (!refreshedVoiceEarly || refreshedVoiceEarly.id !== voiceChannel.id) {
-            return {
-                ok: false,
-                status: 400,
-                error: { error: "Join a voice channel first." },
-            }
-        }
-    }
-
+    // Cover acquisition → search/enqueue so concurrent orphan cleanup cannot destroy mid-use.
+    const lifecycleReservation = acquireGuildPlayerLifecycleReservation(guildId)
     try {
-        await ensurePlayerConnected(client, player, voiceChannel)
-        if (createdHere) {
-            let refreshedMember = null
+        if (textChannelId) {
+            player.textChannelId = textChannelId
+        }
+
+        const cleanupCreatedPlayer = async (): Promise<void> => {
+            if (!createdHere) return
+            // Serialize with enqueue; skip destroy while other requests still reserve this player.
+            await withGuildPlayerQueueLock(guildId, async () => {
+                if (playerHasQueueContent(player)) return
+                // Count includes this request; >1 means another in-flight search/enqueue still needs it.
+                if (getGuildPlayerLifecycleReservationCount(guildId) > 1) return
+                const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
+                await client.lavalink.destroyPlayer(guildId).catch(() => {
+                    // Release only this attempt's lease; clearPlayerSession consumes on success.
+                    suppressLease.release()
+                })
+            })
+        }
+
+        if (!createdHere) {
+            let refreshedMemberEarly = null
             try {
-                refreshedMember = await guild.members.fetch(requesterId)
+                refreshedMemberEarly = await guild.members.fetch(requesterId)
             } catch (error: unknown) {
                 if (!isMemberFetchNotFound(error)) {
-                    console.error("[searchAndEnqueue] requester member refresh failed", {
-                        guildId,
-                        requesterId,
-                        error,
-                    })
-                    await cleanupCreatedPlayer()
+                    console.error(
+                        "[searchAndEnqueue] requester member refresh failed (existing player)",
+                        {
+                            guildId,
+                            requesterId,
+                            error,
+                        }
+                    )
                     return {
                         ok: false,
                         status: 503,
@@ -216,9 +194,8 @@ export async function searchAndEnqueue(
                     }
                 }
             }
-            const refreshedVoiceChannel = refreshedMember?.voice?.channel
-            if (!refreshedVoiceChannel || refreshedVoiceChannel.id !== voiceChannel.id) {
-                await cleanupCreatedPlayer()
+            const refreshedVoiceEarly = refreshedMemberEarly?.voice?.channel
+            if (!refreshedVoiceEarly || refreshedVoiceEarly.id !== voiceChannel.id) {
                 return {
                     ok: false,
                     status: 400,
@@ -226,74 +203,112 @@ export async function searchAndEnqueue(
                 }
             }
         }
-    } catch (err: unknown) {
-        await cleanupCreatedPlayer()
-        const message = err instanceof Error ? err.message : "Voice connection failed."
-        return {
-            ok: false,
-            status: 503,
-            error: {
-                error: "Could not connect the player to your voice channel.",
-                details: message,
-            },
-        }
-    }
-
-    if (options?.connectOnly) {
-        return { ok: true, player, playbackStarted: false }
-    }
-
-    const requesterName =
-        member?.user.globalName ?? member?.user.username ?? guard.session.user?.name ?? "web-user"
-    let searchResult
-    try {
-        searchResult = await player.search(query, {
-            requester: {
-                id: requesterId,
-                username: requesterName,
-            },
-        })
-    } catch (err: unknown) {
-        await cleanupCreatedPlayer()
-        console.error("[searchAndEnqueue] player.search failed", { guildId, requesterId, err })
-        return {
-            ok: false,
-            status: 503,
-            error: { error: "Search failed.", details: "Internal server error." },
-        }
-    }
-
-    if (!searchResult.tracks.length) {
-        await cleanupCreatedPlayer()
-        return {
-            ok: false,
-            status: 404,
-            error: { error: "No matches found." },
-        }
-    }
-
-    return withGuildPlayerQueueLock(guildId, async () => {
-        if (searchResult.loadType === "playlist") {
-            stampRequesterUserIdOnTracks(searchResult.tracks, requesterId)
-            player.queue.add(searchResult.tracks)
-        } else {
-            stampRequesterUserIdOnTracks([searchResult.tracks[0]], requesterId)
-            player.queue.add(searchResult.tracks[0])
-        }
 
         try {
-            await startPlaybackIfNeeded(player)
-            schedulePlayerSessionSave(player)
-            return { ok: true, player, playbackStarted: true }
-        } catch (error: unknown) {
-            const playbackError = error instanceof Error ? error.message : String(error)
-            schedulePlayerSessionSave(player)
+            await ensurePlayerConnected(client, player, voiceChannel)
+            if (createdHere) {
+                let refreshedMember = null
+                try {
+                    refreshedMember = await guild.members.fetch(requesterId)
+                } catch (error: unknown) {
+                    if (!isMemberFetchNotFound(error)) {
+                        console.error("[searchAndEnqueue] requester member refresh failed", {
+                            guildId,
+                            requesterId,
+                            error,
+                        })
+                        await cleanupCreatedPlayer()
+                        return {
+                            ok: false,
+                            status: 503,
+                            error: { error: "Unable to verify voice state, please try again." },
+                        }
+                    }
+                }
+                const refreshedVoiceChannel = refreshedMember?.voice?.channel
+                if (!refreshedVoiceChannel || refreshedVoiceChannel.id !== voiceChannel.id) {
+                    await cleanupCreatedPlayer()
+                    return {
+                        ok: false,
+                        status: 400,
+                        error: { error: "Join a voice channel first." },
+                    }
+                }
+            }
+        } catch (err: unknown) {
+            await cleanupCreatedPlayer()
+            const message = err instanceof Error ? err.message : "Voice connection failed."
             return {
-                ok: true,
-                player,
-                playbackStarted: false,
-                playbackError,
+                ok: false,
+                status: 503,
+                error: {
+                    error: "Could not connect the player to your voice channel.",
+                    details: message,
+                },
             }
         }
-    })
+
+        if (options?.connectOnly) {
+            return { ok: true, player, playbackStarted: false }
+        }
+
+        const requesterName =
+            member?.user.globalName ??
+            member?.user.username ??
+            guard.session.user?.name ??
+            "web-user"
+        let searchResult
+        try {
+            searchResult = await player.search(query, {
+                requester: {
+                    id: requesterId,
+                    username: requesterName,
+                },
+            })
+        } catch (err: unknown) {
+            await cleanupCreatedPlayer()
+            console.error("[searchAndEnqueue] player.search failed", { guildId, requesterId, err })
+            return {
+                ok: false,
+                status: 503,
+                error: { error: "Search failed.", details: "Internal server error." },
+            }
+        }
+
+        if (!searchResult.tracks.length) {
+            await cleanupCreatedPlayer()
+            return {
+                ok: false,
+                status: 404,
+                error: { error: "No matches found." },
+            }
+        }
+
+        return await withGuildPlayerQueueLock(guildId, async () => {
+            if (searchResult.loadType === "playlist") {
+                stampRequesterUserIdOnTracks(searchResult.tracks, requesterId)
+                player.queue.add(searchResult.tracks)
+            } else {
+                stampRequesterUserIdOnTracks([searchResult.tracks[0]], requesterId)
+                player.queue.add(searchResult.tracks[0])
+            }
+
+            try {
+                await startPlaybackIfNeeded(player)
+                schedulePlayerSessionSave(player)
+                return { ok: true, player, playbackStarted: true }
+            } catch (error: unknown) {
+                const playbackError = error instanceof Error ? error.message : String(error)
+                schedulePlayerSessionSave(player)
+                return {
+                    ok: true,
+                    player,
+                    playbackStarted: false,
+                    playbackError,
+                }
+            }
+        })
+    } finally {
+        lifecycleReservation.release()
+    }
 }

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -11,6 +11,7 @@ import {
     schedulePlayerSessionSave,
 } from "../../util/playerSessionPersistence.js"
 import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
+import { playerHasQueueContent } from "../../util/playlistQueue.js"
 
 export type SearchAndEnqueueGuard = Pick<PermissionGuardSuccess, "session">
 
@@ -152,10 +153,14 @@ export async function searchAndEnqueue(
 
     const cleanupCreatedPlayer = async (): Promise<void> => {
         if (!createdHere) return
-        const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
-        await client.lavalink.destroyPlayer(guildId).catch(() => {
-            // Release only this attempt's lease; clearPlayerSession consumes on success.
-            suppressLease.release()
+        // Serialize with enqueue; re-check emptiness so we never tear down active playback.
+        await withGuildPlayerQueueLock(guildId, async () => {
+            if (playerHasQueueContent(player)) return
+            const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
+            await client.lavalink.destroyPlayer(guildId).catch(() => {
+                // Release only this attempt's lease; clearPlayerSession consumes on success.
+                suppressLease.release()
+            })
         })
     }
 

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -10,6 +10,7 @@ import {
     acquirePlayerSessionClearSuppressLease,
     schedulePlayerSessionSave,
 } from "../../util/playerSessionPersistence.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
 
 export type SearchAndEnqueueGuard = Pick<PermissionGuardSuccess, "session">
 
@@ -266,26 +267,28 @@ export async function searchAndEnqueue(
         }
     }
 
-    if (searchResult.loadType === "playlist") {
-        stampRequesterUserIdOnTracks(searchResult.tracks, requesterId)
-        player.queue.add(searchResult.tracks)
-    } else {
-        stampRequesterUserIdOnTracks([searchResult.tracks[0]], requesterId)
-        player.queue.add(searchResult.tracks[0])
-    }
-
-    try {
-        await startPlaybackIfNeeded(player)
-        schedulePlayerSessionSave(player)
-        return { ok: true, player, playbackStarted: true }
-    } catch (error: unknown) {
-        const playbackError = error instanceof Error ? error.message : String(error)
-        schedulePlayerSessionSave(player)
-        return {
-            ok: true,
-            player,
-            playbackStarted: false,
-            playbackError,
+    return withGuildPlayerQueueLock(guildId, async () => {
+        if (searchResult.loadType === "playlist") {
+            stampRequesterUserIdOnTracks(searchResult.tracks, requesterId)
+            player.queue.add(searchResult.tracks)
+        } else {
+            stampRequesterUserIdOnTracks([searchResult.tracks[0]], requesterId)
+            player.queue.add(searchResult.tracks[0])
         }
-    }
+
+        try {
+            await startPlaybackIfNeeded(player)
+            schedulePlayerSessionSave(player)
+            return { ok: true, player, playbackStarted: true }
+        } catch (error: unknown) {
+            const playbackError = error instanceof Error ? error.message : String(error)
+            schedulePlayerSessionSave(player)
+            return {
+                ok: true,
+                player,
+                playbackStarted: false,
+                playbackError,
+            }
+        }
+    })
 }

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -152,7 +152,7 @@ export async function searchAndEnqueue(
     }
 
     // Cover acquisition → search/enqueue so concurrent orphan cleanup cannot destroy mid-use.
-    const lifecycleReservation = acquireGuildPlayerLifecycleReservation(guildId)
+    const lifecycleReservation = await acquireGuildPlayerLifecycleReservation(guildId)
     try {
         if (textChannelId) {
             player.textChannelId = textChannelId

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -7,6 +7,7 @@ import { stampRequesterUserIdOnTracks } from "../../util/rrqDisconnect.js"
 import type { PermissionGuardSuccess } from "../../shared/api-auth.js"
 import { resolveWebDashboardTextChannelId } from "../webDashboardTextChannel.js"
 import {
+    clearSuppressNextPlayerSessionClear,
     schedulePlayerSessionSave,
     suppressNextPlayerSessionClear,
 } from "../../util/playerSessionPersistence.js"
@@ -152,7 +153,9 @@ export async function searchAndEnqueue(
     const cleanupCreatedPlayer = async (): Promise<void> => {
         if (!createdHere) return
         suppressNextPlayerSessionClear(guildId)
-        await client.lavalink.destroyPlayer(guildId).catch(() => undefined)
+        await client.lavalink.destroyPlayer(guildId).catch(() => {
+            clearSuppressNextPlayerSessionClear(guildId)
+        })
     }
 
     if (!createdHere) {

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -6,7 +6,10 @@ import { ensurePlayerConnected, startPlaybackIfNeeded } from "../../util/musicMa
 import { stampRequesterUserIdOnTracks } from "../../util/rrqDisconnect.js"
 import type { PermissionGuardSuccess } from "../../shared/api-auth.js"
 import { resolveWebDashboardTextChannelId } from "../webDashboardTextChannel.js"
-import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
+import {
+    schedulePlayerSessionSave,
+    suppressNextPlayerSessionClear,
+} from "../../util/playerSessionPersistence.js"
 
 export type SearchAndEnqueueGuard = Pick<PermissionGuardSuccess, "session">
 
@@ -148,6 +151,7 @@ export async function searchAndEnqueue(
 
     const cleanupCreatedPlayer = async (): Promise<void> => {
         if (!createdHere) return
+        suppressNextPlayerSessionClear(guildId)
         await client.lavalink.destroyPlayer(guildId).catch(() => undefined)
     }
 

--- a/src/repositories/playerSessionRepository.ts
+++ b/src/repositories/playerSessionRepository.ts
@@ -1,85 +1,7 @@
 import { Prisma } from "@prisma/client"
 import { getPrismaClient } from "../lib/database.js"
-import type {
-    PlayerSessionData,
-    PlayerSessionSnapshotV1,
-    PersistedQueueTrack,
-} from "../types/index.js"
-
-function parsePersistedQueueTrack(value: unknown): PersistedQueueTrack | null {
-    if (!value || typeof value !== "object" || Array.isArray(value)) return null
-    const raw = value as Record<string, unknown>
-    if (typeof raw.title !== "string" || !raw.title.trim()) return null
-    if (typeof raw.author !== "string" || !raw.author.trim()) return null
-    if (typeof raw.uri !== "string" || !raw.uri.trim()) return null
-    if (typeof raw.duration !== "number" || !Number.isFinite(raw.duration)) return null
-    if (typeof raw.isStream !== "boolean") return null
-
-    let encoded: string | null = null
-    if (raw.encoded !== null && raw.encoded !== undefined) {
-        if (typeof raw.encoded !== "string") return null
-        encoded = raw.encoded
-    }
-    let requesterId: string | null = null
-    if (raw.requesterId !== null && raw.requesterId !== undefined) {
-        if (typeof raw.requesterId !== "string") return null
-        requesterId = raw.requesterId
-    }
-    let thumbnailUrl: string | null = null
-    if (raw.thumbnailUrl !== null && raw.thumbnailUrl !== undefined) {
-        if (typeof raw.thumbnailUrl !== "string") return null
-        thumbnailUrl = raw.thumbnailUrl
-    }
-
-    return {
-        title: raw.title.trim(),
-        author: raw.author.trim(),
-        uri: raw.uri.trim(),
-        duration: raw.duration,
-        encoded,
-        requesterId,
-        thumbnailUrl,
-        isStream: raw.isStream,
-    }
-}
-
-function parseSnapshot(value: Prisma.JsonValue): PlayerSessionSnapshotV1 | null {
-    if (!value || typeof value !== "object" || Array.isArray(value)) return null
-    const raw = value as Record<string, unknown>
-    if (raw.version !== 1) return null
-    if (typeof raw.volume !== "number" || !Number.isFinite(raw.volume)) return null
-    if (raw.repeatMode !== "off" && raw.repeatMode !== "track" && raw.repeatMode !== "queue") {
-        return null
-    }
-    if (typeof raw.paused !== "boolean" || typeof raw.playing !== "boolean") return null
-    if (typeof raw.autoplay !== "boolean" || typeof raw.rrqEnabled !== "boolean") return null
-    if (!Array.isArray(raw.queue)) return null
-
-    let current: PersistedQueueTrack | null = null
-    if (raw.current !== null) {
-        current = parsePersistedQueueTrack(raw.current)
-        if (!current) return null
-    }
-
-    const queue: PersistedQueueTrack[] = []
-    for (const item of raw.queue) {
-        const track = parsePersistedQueueTrack(item)
-        if (!track) return null
-        queue.push(track)
-    }
-
-    return {
-        version: 1,
-        volume: raw.volume,
-        repeatMode: raw.repeatMode,
-        paused: raw.paused,
-        playing: raw.playing,
-        autoplay: raw.autoplay,
-        rrqEnabled: raw.rrqEnabled,
-        current,
-        queue,
-    }
-}
+import type { PlayerSessionData, PlayerSessionSnapshotV1 } from "../types/index.js"
+import { parsePlayerSessionSnapshot } from "../util/playerSessionSnapshotParse.js"
 
 function toPlayerSessionData(row: {
     guildId: string
@@ -88,7 +10,7 @@ function toPlayerSessionData(row: {
     snapshot: Prisma.JsonValue
     updatedAt: Date
 }): PlayerSessionData | null {
-    const snapshot = parseSnapshot(row.snapshot)
+    const snapshot = parsePlayerSessionSnapshot(row.snapshot)
     if (!snapshot) return null
     return {
         guildId: row.guildId,

--- a/src/shared/websocket/ws-connect-token.test.ts
+++ b/src/shared/websocket/ws-connect-token.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict"
+import { createHmac } from "node:crypto"
+import { describe, it } from "node:test"
+import { createWsConnectToken, parseWsConnectToken } from "./ws-connect-token.js"
+
+describe("ws-connect-token", () => {
+    const secret = "test-ws-secret-key"
+
+    it("round-trips a valid token", () => {
+        const token = createWsConnectToken("123456789012345678", secret, 60)
+        assert.equal(parseWsConnectToken(token, secret), "123456789012345678")
+    })
+
+    it("rejects tampered signatures, wrong secrets, and malformed tokens", () => {
+        const token = createWsConnectToken("user-1", secret, 60)
+        assert.equal(parseWsConnectToken(token, "other-secret"), null)
+        assert.equal(parseWsConnectToken(token.slice(0, -1) + "x", secret), null)
+        assert.equal(parseWsConnectToken("not-a-token", secret), null)
+        assert.equal(parseWsConnectToken("", secret), null)
+    })
+
+    it("rejects expired tokens", () => {
+        const token = createWsConnectToken("user-1", secret, 60)
+        const i = token.lastIndexOf(".")
+        const payload = JSON.parse(Buffer.from(token.slice(0, i), "base64url").toString("utf8"))
+        payload.exp = Math.floor(Date.now() / 1000) - 1
+        const expiredPayload = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url")
+        const sig = createHmac("sha256", Buffer.from(secret, "utf8"))
+            .update(expiredPayload)
+            .digest("base64url")
+        assert.equal(parseWsConnectToken(`${expiredPayload}.${sig}`, secret), null)
+    })
+
+    it("rejects non-positive ttl on create", () => {
+        assert.throws(() => createWsConnectToken("u", secret, 0))
+        assert.throws(() => createWsConnectToken("u", secret, -1))
+        assert.throws(() => createWsConnectToken("u", secret, 1.5))
+        assert.throws(() => createWsConnectToken("u", "", 60))
+    })
+})

--- a/src/shared/websocket/ws-connect-token.test.ts
+++ b/src/shared/websocket/ws-connect-token.test.ts
@@ -13,8 +13,12 @@ describe("ws-connect-token", () => {
 
     it("rejects tampered signatures, wrong secrets, and malformed tokens", () => {
         const token = createWsConnectToken("user-1", secret, 60)
+        const sep = token.lastIndexOf(".")
+        const sig = token.slice(sep + 1)
+        // Flip the first sig char — last-char edits can be no-ops under base64url decode.
+        const tamperedSig = (sig[0] === "a" ? "b" : "a") + sig.slice(1)
         assert.equal(parseWsConnectToken(token, "other-secret"), null)
-        assert.equal(parseWsConnectToken(token.slice(0, -1) + "x", secret), null)
+        assert.equal(parseWsConnectToken(`${token.slice(0, sep + 1)}${tamperedSig}`, secret), null)
         assert.equal(parseWsConnectToken("not-a-token", secret), null)
         assert.equal(parseWsConnectToken("", secret), null)
     })

--- a/src/util/botApiPrivatePeer.test.ts
+++ b/src/util/botApiPrivatePeer.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    isPrivateLanOrLoopbackPeer,
+    shouldEnforceBotApiPrivateClientIp,
+} from "./botApiPrivatePeer.js"
+
+describe("botApiPrivatePeer", () => {
+    it("allows RFC1918, loopback, and IPv4-mapped private peers", () => {
+        assert.equal(isPrivateLanOrLoopbackPeer("10.0.0.1"), true)
+        assert.equal(isPrivateLanOrLoopbackPeer("172.16.5.1"), true)
+        assert.equal(isPrivateLanOrLoopbackPeer("192.168.1.20"), true)
+        assert.equal(isPrivateLanOrLoopbackPeer("127.0.0.1"), true)
+        assert.equal(isPrivateLanOrLoopbackPeer("::1"), true)
+        assert.equal(isPrivateLanOrLoopbackPeer("::ffff:10.1.2.3"), true)
+    })
+
+    it("rejects public, malformed, and empty peers", () => {
+        assert.equal(isPrivateLanOrLoopbackPeer("8.8.8.8"), false)
+        assert.equal(isPrivateLanOrLoopbackPeer("172.15.0.1"), false)
+        assert.equal(isPrivateLanOrLoopbackPeer("01.2.3.4"), false)
+        assert.equal(isPrivateLanOrLoopbackPeer("not-an-ip"), false)
+        assert.equal(isPrivateLanOrLoopbackPeer(""), false)
+        assert.equal(isPrivateLanOrLoopbackPeer(undefined), false)
+    })
+
+    it("reads BOT_API_REQUIRE_PRIVATE_CLIENT_IP truthy flags", () => {
+        const prev = process.env.BOT_API_REQUIRE_PRIVATE_CLIENT_IP
+        try {
+            process.env.BOT_API_REQUIRE_PRIVATE_CLIENT_IP = "true"
+            assert.equal(shouldEnforceBotApiPrivateClientIp(), true)
+            process.env.BOT_API_REQUIRE_PRIVATE_CLIENT_IP = "0"
+            assert.equal(shouldEnforceBotApiPrivateClientIp(), false)
+            process.env.BOT_API_REQUIRE_PRIVATE_CLIENT_IP = "yes"
+            assert.equal(shouldEnforceBotApiPrivateClientIp(), true)
+        } finally {
+            if (prev === undefined) delete process.env.BOT_API_REQUIRE_PRIVATE_CLIENT_IP
+            else process.env.BOT_API_REQUIRE_PRIVATE_CLIENT_IP = prev
+        }
+    })
+})

--- a/src/util/guildAsyncChain.test.ts
+++ b/src/util/guildAsyncChain.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { createGuildAsyncChain } from "./guildAsyncChain.js"
+
+describe("createGuildAsyncChain", () => {
+    it("removes the guild entry after the tail settles", async () => {
+        const withLock = createGuildAsyncChain()
+        // Access map indirectly: after settle, a new call should not wait on a retained resolved tail
+        // beyond a fresh Promise.resolve() — verified by ordering a second guild-independent burst.
+        const events: string[] = []
+        await withLock("g1", async () => {
+            events.push("a")
+        })
+        await withLock("g1", async () => {
+            events.push("b")
+        })
+        assert.deepEqual(events, ["a", "b"])
+    })
+
+    it("does not drop a newer tail when an older tail settles later", async () => {
+        const withLock = createGuildAsyncChain()
+        const events: string[] = []
+        let releaseOld!: () => void
+        const oldGate = new Promise<void>((resolve) => {
+            releaseOld = resolve
+        })
+
+        const older = withLock("g1", async () => {
+            events.push("old-start")
+            await oldGate
+            events.push("old-end")
+        })
+        const newer = withLock("g1", async () => {
+            events.push("new")
+        })
+
+        await Promise.resolve()
+        assert.deepEqual(events, ["old-start"])
+        releaseOld()
+        await Promise.all([older, newer])
+        assert.deepEqual(events, ["old-start", "old-end", "new"])
+    })
+})

--- a/src/util/guildAsyncChain.test.ts
+++ b/src/util/guildAsyncChain.test.ts
@@ -3,41 +3,71 @@ import { describe, it } from "node:test"
 import { createGuildAsyncChain } from "./guildAsyncChain.js"
 
 describe("createGuildAsyncChain", () => {
-    it("removes the guild entry after the tail settles", async () => {
+    it("evicts the guild map entry after the sole tail promise settles", async () => {
         const withLock = createGuildAsyncChain()
-        // Access map indirectly: after settle, a new call should not wait on a retained resolved tail
-        // beyond a fresh Promise.resolve() — verified by ordering a second guild-independent burst.
-        const events: string[] = []
-        await withLock("g1", async () => {
-            events.push("a")
+        assert.equal(withLock.pendingGuildCountForTests(), 0)
+
+        let release!: () => void
+        const gate = new Promise<void>((resolve) => {
+            release = resolve
         })
-        await withLock("g1", async () => {
-            events.push("b")
+        const running = withLock("g1", async () => {
+            await gate
         })
-        assert.deepEqual(events, ["a", "b"])
+        assert.equal(withLock.pendingGuildCountForTests(), 1)
+        release()
+        await running
+        // Eviction runs in tail.finally after the result promise settles.
+        await Promise.resolve()
+        assert.equal(withLock.pendingGuildCountForTests(), 0)
     })
 
-    it("does not drop a newer tail when an older tail settles later", async () => {
+    it("keeps a newer tail registered when an older tail settles (identity-guarded eviction)", async () => {
         const withLock = createGuildAsyncChain()
         const events: string[] = []
-        let releaseOld!: () => void
-        const oldGate = new Promise<void>((resolve) => {
-            releaseOld = resolve
+        let releaseFirst!: () => void
+        let releaseSecond!: () => void
+        const firstGate = new Promise<void>((resolve) => {
+            releaseFirst = resolve
+        })
+        const secondGate = new Promise<void>((resolve) => {
+            releaseSecond = resolve
         })
 
-        const older = withLock("g1", async () => {
-            events.push("old-start")
-            await oldGate
-            events.push("old-end")
+        const first = withLock("g1", async () => {
+            events.push("1-start")
+            await firstGate
+            events.push("1-end")
         })
-        const newer = withLock("g1", async () => {
-            events.push("new")
+        const second = withLock("g1", async () => {
+            events.push("2-start")
+            await secondGate
+            events.push("2-end")
         })
 
         await Promise.resolve()
-        assert.deepEqual(events, ["old-start"])
-        releaseOld()
-        await Promise.all([older, newer])
-        assert.deepEqual(events, ["old-start", "old-end", "new"])
+        assert.deepEqual(events, ["1-start"])
+        assert.equal(withLock.pendingGuildCountForTests(), 1)
+
+        // First settles; second is still the live tail and must remain registered.
+        releaseFirst()
+        await first
+        await Promise.resolve()
+        assert.deepEqual(events, ["1-start", "1-end", "2-start"])
+        assert.equal(withLock.pendingGuildCountForTests(), 1)
+
+        // Enqueue a third while second is still blocked — it must wait for second.
+        const third = withLock("g1", async () => {
+            events.push("3")
+        })
+        await Promise.resolve()
+        assert.deepEqual(events, ["1-start", "1-end", "2-start"])
+        assert.equal(withLock.pendingGuildCountForTests(), 1)
+
+        releaseSecond()
+        await Promise.all([second, third])
+        assert.deepEqual(events, ["1-start", "1-end", "2-start", "2-end", "3"])
+        await Promise.resolve()
+        assert.equal(withLock.pendingGuildCountForTests(), 0)
     })
 })

--- a/src/util/guildAsyncChain.ts
+++ b/src/util/guildAsyncChain.ts
@@ -1,0 +1,26 @@
+/**
+ * Per-key FIFO async chain. Removes the registry entry when the tail settles,
+ * but only if the map still points at that same tail (newer work may have replaced it).
+ */
+export function createGuildAsyncChain(): <T>(
+    guildId: string,
+    work: () => Promise<T>
+) => Promise<T> {
+    const chainByGuild = new Map<string, Promise<unknown>>()
+
+    return function withGuildAsyncChain<T>(guildId: string, work: () => Promise<T>): Promise<T> {
+        const prior = chainByGuild.get(guildId) ?? Promise.resolve()
+        const result = prior.then(() => work())
+        const tail = result.then(
+            () => undefined,
+            () => undefined
+        )
+        chainByGuild.set(guildId, tail)
+        void tail.finally(() => {
+            if (chainByGuild.get(guildId) === tail) {
+                chainByGuild.delete(guildId)
+            }
+        })
+        return result
+    }
+}

--- a/src/util/guildAsyncChain.ts
+++ b/src/util/guildAsyncChain.ts
@@ -2,13 +2,16 @@
  * Per-key FIFO async chain. Removes the registry entry when the tail settles,
  * but only if the map still points at that same tail (newer work may have replaced it).
  */
-export function createGuildAsyncChain(): <T>(
-    guildId: string,
-    work: () => Promise<T>
-) => Promise<T> {
+export type GuildAsyncChain = {
+    <T>(guildId: string, work: () => Promise<T>): Promise<T>
+    /** Test-only: how many guilds currently have a live chain tail registered. */
+    pendingGuildCountForTests(): number
+}
+
+export function createGuildAsyncChain(): GuildAsyncChain {
     const chainByGuild = new Map<string, Promise<unknown>>()
 
-    return function withGuildAsyncChain<T>(guildId: string, work: () => Promise<T>): Promise<T> {
+    function withGuildAsyncChain<T>(guildId: string, work: () => Promise<T>): Promise<T> {
         const prior = chainByGuild.get(guildId) ?? Promise.resolve()
         const result = prior.then(() => work())
         const tail = result.then(
@@ -23,4 +26,8 @@ export function createGuildAsyncChain(): <T>(
         })
         return result
     }
+
+    return Object.assign(withGuildAsyncChain, {
+        pendingGuildCountForTests: () => chainByGuild.size,
+    })
 }

--- a/src/util/guildPlayerLifecycle.test.ts
+++ b/src/util/guildPlayerLifecycle.test.ts
@@ -9,9 +9,9 @@ import {
 } from "./guildPlayerQueueLock.js"
 
 describe("guild player lifecycle reservation", () => {
-    it("tracks concurrent reservations and releases independently", () => {
-        const a = acquireGuildPlayerLifecycleReservation("guild-life")
-        const b = acquireGuildPlayerLifecycleReservation("guild-life")
+    it("tracks concurrent reservations and releases independently", async () => {
+        const a = await acquireGuildPlayerLifecycleReservation("guild-life")
+        const b = await acquireGuildPlayerLifecycleReservation("guild-life")
         assert.equal(getGuildPlayerLifecycleReservationCount("guild-life"), 2)
         a.release()
         assert.equal(getGuildPlayerLifecycleReservationCount("guild-life"), 1)
@@ -27,8 +27,8 @@ describe("deferred orphan player cleanup", () => {
         let destroyed = false
         let hasContent = false
 
-        const creator = acquireGuildPlayerLifecycleReservation(guildId)
-        const other = acquireGuildPlayerLifecycleReservation(guildId)
+        const creator = await acquireGuildPlayerLifecycleReservation(guildId)
+        const other = await acquireGuildPlayerLifecycleReservation(guildId)
 
         // Creator fails while the other request still holds a reservation → defer, do not destroy yet.
         await tryDestroyOrphanGuildPlayer(guildId, {
@@ -56,8 +56,8 @@ describe("deferred orphan player cleanup", () => {
         let destroyed = false
         let hasContent = false
 
-        const creator = acquireGuildPlayerLifecycleReservation(guildId)
-        const other = acquireGuildPlayerLifecycleReservation(guildId)
+        const creator = await acquireGuildPlayerLifecycleReservation(guildId)
+        const other = await acquireGuildPlayerLifecycleReservation(guildId)
 
         await tryDestroyOrphanGuildPlayer(guildId, {
             hasQueueContent: () => hasContent,
@@ -73,5 +73,49 @@ describe("deferred orphan player cleanup", () => {
         await waitForPendingOrphanDestroyForTests(guildId)
         assert.equal(destroyed, false)
         assert.equal(hasPendingOrphanDestroyForTests(guildId), false)
+    })
+
+    it("blocks new reservations while destroyPlayer is in progress", async () => {
+        const guildId = "guild-orphan-serialize"
+        let releaseDestroy!: () => void
+        const destroyGate = new Promise<void>((resolve) => {
+            releaseDestroy = resolve
+        })
+        let destroyEntered = false
+        let reservedDuringDestroy = false
+
+        const holder = await acquireGuildPlayerLifecycleReservation(guildId)
+
+        const destroyP = tryDestroyOrphanGuildPlayer(guildId, {
+            hasQueueContent: () => false,
+            destroyPlayer: async () => {
+                destroyEntered = true
+                await destroyGate
+            },
+        })
+
+        while (!destroyEntered) {
+            await Promise.resolve()
+        }
+
+        const acquireP = acquireGuildPlayerLifecycleReservation(guildId).then((lease) => {
+            reservedDuringDestroy = true
+            return lease
+        })
+
+        await Promise.resolve()
+        await Promise.resolve()
+        assert.equal(reservedDuringDestroy, false)
+        // Holder still counts; acquire must not have granted yet while destroy holds the lock.
+        assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 1)
+
+        releaseDestroy()
+        await destroyP
+        const next = await acquireP
+        assert.equal(reservedDuringDestroy, true)
+        assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 2)
+        next.release()
+        holder.release()
+        await waitForPendingOrphanDestroyForTests(guildId)
     })
 })

--- a/src/util/guildPlayerLifecycle.test.ts
+++ b/src/util/guildPlayerLifecycle.test.ts
@@ -3,6 +3,9 @@ import { describe, it } from "node:test"
 import {
     acquireGuildPlayerLifecycleReservation,
     getGuildPlayerLifecycleReservationCount,
+    hasPendingOrphanDestroyForTests,
+    tryDestroyOrphanGuildPlayer,
+    waitForPendingOrphanDestroyForTests,
 } from "./guildPlayerQueueLock.js"
 
 describe("guild player lifecycle reservation", () => {
@@ -12,9 +15,63 @@ describe("guild player lifecycle reservation", () => {
         assert.equal(getGuildPlayerLifecycleReservationCount("guild-life"), 2)
         a.release()
         assert.equal(getGuildPlayerLifecycleReservationCount("guild-life"), 1)
-        // Orphan cleanup would skip destroy while count > 1; after one release, only one remains.
         assert.ok(getGuildPlayerLifecycleReservationCount("guild-life") > 0)
         b.release()
         assert.equal(getGuildPlayerLifecycleReservationCount("guild-life"), 0)
+    })
+})
+
+describe("deferred orphan player cleanup", () => {
+    it("destroys an empty player after the other concurrent request finishes", async () => {
+        const guildId = "guild-orphan-defer"
+        let destroyed = false
+        let hasContent = false
+
+        const creator = acquireGuildPlayerLifecycleReservation(guildId)
+        const other = acquireGuildPlayerLifecycleReservation(guildId)
+
+        // Creator fails while the other request still holds a reservation → defer, do not destroy yet.
+        await tryDestroyOrphanGuildPlayer(guildId, {
+            hasQueueContent: () => hasContent,
+            destroyPlayer: async () => {
+                destroyed = true
+            },
+        })
+        assert.equal(destroyed, false)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), true)
+
+        creator.release()
+        assert.equal(destroyed, false)
+        assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 1)
+
+        // Other request also fails / finishes with an empty queue → deferred cleanup runs.
+        other.release()
+        await waitForPendingOrphanDestroyForTests(guildId)
+        assert.equal(destroyed, true)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), false)
+    })
+
+    it("skips deferred destroy when the player gained queue content before retry", async () => {
+        const guildId = "guild-orphan-skip"
+        let destroyed = false
+        let hasContent = false
+
+        const creator = acquireGuildPlayerLifecycleReservation(guildId)
+        const other = acquireGuildPlayerLifecycleReservation(guildId)
+
+        await tryDestroyOrphanGuildPlayer(guildId, {
+            hasQueueContent: () => hasContent,
+            destroyPlayer: async () => {
+                destroyed = true
+            },
+        })
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), true)
+
+        creator.release()
+        hasContent = true
+        other.release()
+        await waitForPendingOrphanDestroyForTests(guildId)
+        assert.equal(destroyed, false)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), false)
     })
 })

--- a/src/util/guildPlayerLifecycle.test.ts
+++ b/src/util/guildPlayerLifecycle.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    acquireGuildPlayerLifecycleReservation,
+    getGuildPlayerLifecycleReservationCount,
+} from "./guildPlayerQueueLock.js"
+
+describe("guild player lifecycle reservation", () => {
+    it("tracks concurrent reservations and releases independently", () => {
+        const a = acquireGuildPlayerLifecycleReservation("guild-life")
+        const b = acquireGuildPlayerLifecycleReservation("guild-life")
+        assert.equal(getGuildPlayerLifecycleReservationCount("guild-life"), 2)
+        a.release()
+        assert.equal(getGuildPlayerLifecycleReservationCount("guild-life"), 1)
+        // Orphan cleanup would skip destroy while count > 1; after one release, only one remains.
+        assert.ok(getGuildPlayerLifecycleReservationCount("guild-life") > 0)
+        b.release()
+        assert.equal(getGuildPlayerLifecycleReservationCount("guild-life"), 0)
+    })
+})

--- a/src/util/guildPlayerQueueLock.ts
+++ b/src/util/guildPlayerQueueLock.ts
@@ -1,16 +1,8 @@
-/** Per-guild FIFO chain for player queue mutations (enqueue vs orphan teardown). */
-const guildPlayerQueueChain = new Map<string, Promise<unknown>>()
+import { createGuildAsyncChain } from "./guildAsyncChain.js"
+
+const withGuildPlayerQueueChain = createGuildAsyncChain()
 
 /** Runs `work` after prior guild queue mutations finish (completion order matches request order). */
 export function withGuildPlayerQueueLock<T>(guildId: string, work: () => Promise<T>): Promise<T> {
-    const prior = guildPlayerQueueChain.get(guildId) ?? Promise.resolve()
-    const result = prior.then(() => work())
-    guildPlayerQueueChain.set(
-        guildId,
-        result.then(
-            () => undefined,
-            () => undefined
-        )
-    )
-    return result
+    return withGuildPlayerQueueChain(guildId, work)
 }

--- a/src/util/guildPlayerQueueLock.ts
+++ b/src/util/guildPlayerQueueLock.ts
@@ -2,7 +2,36 @@ import { createGuildAsyncChain } from "./guildAsyncChain.js"
 
 const withGuildPlayerQueueChain = createGuildAsyncChain()
 
+/** In-flight search/enqueue (and similar) reservations — orphan cleanup must not destroy while >0 others. */
+const guildPlayerLifecycleReservations = new Map<string, number>()
+
 /** Runs `work` after prior guild queue mutations finish (completion order matches request order). */
 export function withGuildPlayerQueueLock<T>(guildId: string, work: () => Promise<T>): Promise<T> {
     return withGuildPlayerQueueChain(guildId, work)
+}
+
+/**
+ * Reserves the guild player for one request from acquisition through search/enqueue.
+ * Orphan cleanup should skip destroy while more than one reservation is held.
+ */
+export function acquireGuildPlayerLifecycleReservation(guildId: string): { release(): void } {
+    guildPlayerLifecycleReservations.set(
+        guildId,
+        (guildPlayerLifecycleReservations.get(guildId) ?? 0) + 1
+    )
+    let released = false
+    return {
+        release() {
+            if (released) return
+            released = true
+            const next = (guildPlayerLifecycleReservations.get(guildId) ?? 1) - 1
+            if (next <= 0) guildPlayerLifecycleReservations.delete(guildId)
+            else guildPlayerLifecycleReservations.set(guildId, next)
+        },
+    }
+}
+
+/** Active lifecycle reservations for a guild (includes the calling request while it holds one). */
+export function getGuildPlayerLifecycleReservationCount(guildId: string): number {
+    return guildPlayerLifecycleReservations.get(guildId) ?? 0
 }

--- a/src/util/guildPlayerQueueLock.ts
+++ b/src/util/guildPlayerQueueLock.ts
@@ -1,0 +1,16 @@
+/** Per-guild FIFO chain for player queue mutations (enqueue vs orphan teardown). */
+const guildPlayerQueueChain = new Map<string, Promise<unknown>>()
+
+/** Runs `work` after prior guild queue mutations finish (completion order matches request order). */
+export function withGuildPlayerQueueLock<T>(guildId: string, work: () => Promise<T>): Promise<T> {
+    const prior = guildPlayerQueueChain.get(guildId) ?? Promise.resolve()
+    const result = prior.then(() => work())
+    guildPlayerQueueChain.set(
+        guildId,
+        result.then(
+            () => undefined,
+            () => undefined
+        )
+    )
+    return result
+}

--- a/src/util/guildPlayerQueueLock.ts
+++ b/src/util/guildPlayerQueueLock.ts
@@ -5,6 +5,15 @@ const withGuildPlayerQueueChain = createGuildAsyncChain()
 /** In-flight search/enqueue (and similar) reservations — orphan cleanup must not destroy while >0 others. */
 const guildPlayerLifecycleReservations = new Map<string, number>()
 
+/** Orphan destroy deferred because other lifecycle reservations were still held. */
+type PendingOrphanDestroy = {
+    hasQueueContent: () => boolean
+    destroyPlayer: () => Promise<void>
+}
+
+const pendingOrphanDestroyByGuild = new Map<string, PendingOrphanDestroy>()
+const pendingOrphanDestroyRunsByGuild = new Map<string, Promise<void>>()
+
 /** Runs `work` after prior guild queue mutations finish (completion order matches request order). */
 export function withGuildPlayerQueueLock<T>(guildId: string, work: () => Promise<T>): Promise<T> {
     return withGuildPlayerQueueChain(guildId, work)
@@ -25,8 +34,14 @@ export function acquireGuildPlayerLifecycleReservation(guildId: string): { relea
             if (released) return
             released = true
             const next = (guildPlayerLifecycleReservations.get(guildId) ?? 1) - 1
-            if (next <= 0) guildPlayerLifecycleReservations.delete(guildId)
-            else guildPlayerLifecycleReservations.set(guildId, next)
+            if (next <= 0) {
+                guildPlayerLifecycleReservations.delete(guildId)
+                // Creator cleanup may have deferred while we (or others) were still reserved.
+                const run = runPendingOrphanDestroy(guildId).catch(() => undefined)
+                pendingOrphanDestroyRunsByGuild.set(guildId, run)
+            } else {
+                guildPlayerLifecycleReservations.set(guildId, next)
+            }
         },
     }
 }
@@ -34,4 +49,55 @@ export function acquireGuildPlayerLifecycleReservation(guildId: string): { relea
 /** Active lifecycle reservations for a guild (includes the calling request while it holds one). */
 export function getGuildPlayerLifecycleReservationCount(guildId: string): number {
     return guildPlayerLifecycleReservations.get(guildId) ?? 0
+}
+
+/**
+ * Destroys an empty orphan player when safe. If other lifecycle reservations are held,
+ * records a pending cleanup and retries under the queue lock when the count reaches zero.
+ */
+export async function tryDestroyOrphanGuildPlayer(
+    guildId: string,
+    hooks: PendingOrphanDestroy
+): Promise<void> {
+    await withGuildPlayerQueueLock(guildId, async () => {
+        if (hooks.hasQueueContent()) {
+            pendingOrphanDestroyByGuild.delete(guildId)
+            return
+        }
+        // Count includes the caller; >1 means another in-flight request still needs the player.
+        if (getGuildPlayerLifecycleReservationCount(guildId) > 1) {
+            pendingOrphanDestroyByGuild.set(guildId, hooks)
+            return
+        }
+        pendingOrphanDestroyByGuild.delete(guildId)
+        await hooks.destroyPlayer()
+    })
+}
+
+async function runPendingOrphanDestroy(guildId: string): Promise<void> {
+    const hooks = pendingOrphanDestroyByGuild.get(guildId)
+    if (!hooks) return
+
+    await withGuildPlayerQueueLock(guildId, async () => {
+        const pending = pendingOrphanDestroyByGuild.get(guildId)
+        if (!pending) return
+        // A new reservation may have landed between release and acquiring the queue lock.
+        if (getGuildPlayerLifecycleReservationCount(guildId) > 0) return
+        if (pending.hasQueueContent()) {
+            pendingOrphanDestroyByGuild.delete(guildId)
+            return
+        }
+        pendingOrphanDestroyByGuild.delete(guildId)
+        await pending.destroyPlayer()
+    })
+}
+
+/** Test-only: await the deferred orphan-destroy run kicked off by the last reservation release. */
+export function waitForPendingOrphanDestroyForTests(guildId: string): Promise<void> {
+    return pendingOrphanDestroyRunsByGuild.get(guildId) ?? Promise.resolve()
+}
+
+/** Test-only: whether a deferred orphan destroy is recorded for the guild. */
+export function hasPendingOrphanDestroyForTests(guildId: string): boolean {
+    return pendingOrphanDestroyByGuild.has(guildId)
 }

--- a/src/util/guildPlayerQueueLock.ts
+++ b/src/util/guildPlayerQueueLock.ts
@@ -19,31 +19,44 @@ export function withGuildPlayerQueueLock<T>(guildId: string, work: () => Promise
     return withGuildPlayerQueueChain(guildId, work)
 }
 
+function trackOrphanDestroyRun(guildId: string, run: Promise<void>): void {
+    pendingOrphanDestroyRunsByGuild.set(guildId, run)
+    void run.finally(() => {
+        if (pendingOrphanDestroyRunsByGuild.get(guildId) === run) {
+            pendingOrphanDestroyRunsByGuild.delete(guildId)
+        }
+    })
+}
+
 /**
  * Reserves the guild player for one request from acquisition through search/enqueue.
- * Orphan cleanup should skip destroy while more than one reservation is held.
+ * Serialized with orphan destroy under the guild queue lock so grants cannot race destruction.
  */
-export function acquireGuildPlayerLifecycleReservation(guildId: string): { release(): void } {
-    guildPlayerLifecycleReservations.set(
-        guildId,
-        (guildPlayerLifecycleReservations.get(guildId) ?? 0) + 1
-    )
-    let released = false
-    return {
-        release() {
-            if (released) return
-            released = true
-            const next = (guildPlayerLifecycleReservations.get(guildId) ?? 1) - 1
-            if (next <= 0) {
-                guildPlayerLifecycleReservations.delete(guildId)
-                // Creator cleanup may have deferred while we (or others) were still reserved.
-                const run = runPendingOrphanDestroy(guildId).catch(() => undefined)
-                pendingOrphanDestroyRunsByGuild.set(guildId, run)
-            } else {
-                guildPlayerLifecycleReservations.set(guildId, next)
-            }
-        },
-    }
+export async function acquireGuildPlayerLifecycleReservation(
+    guildId: string
+): Promise<{ release(): void }> {
+    return withGuildPlayerQueueLock(guildId, async () => {
+        guildPlayerLifecycleReservations.set(
+            guildId,
+            (guildPlayerLifecycleReservations.get(guildId) ?? 0) + 1
+        )
+        let released = false
+        return {
+            release() {
+                if (released) return
+                released = true
+                const next = (guildPlayerLifecycleReservations.get(guildId) ?? 1) - 1
+                if (next <= 0) {
+                    guildPlayerLifecycleReservations.delete(guildId)
+                    // Creator cleanup may have deferred while we (or others) were still reserved.
+                    const run = runPendingOrphanDestroy(guildId).catch(() => undefined)
+                    trackOrphanDestroyRun(guildId, run)
+                } else {
+                    guildPlayerLifecycleReservations.set(guildId, next)
+                }
+            },
+        }
+    })
 }
 
 /** Active lifecycle reservations for a guild (includes the calling request while it holds one). */
@@ -54,6 +67,7 @@ export function getGuildPlayerLifecycleReservationCount(guildId: string): number
 /**
  * Destroys an empty orphan player when safe. If other lifecycle reservations are held,
  * records a pending cleanup and retries under the queue lock when the count reaches zero.
+ * Destroy runs under the same lock as reservation grants, so acquire waits until it finishes.
  */
 export async function tryDestroyOrphanGuildPlayer(
     guildId: string,

--- a/src/util/guildSettingsDeleteFilter.test.ts
+++ b/src/util/guildSettingsDeleteFilter.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { guildIdsEligibleForSettingsDelete } from "./guildSettingsDeleteFilter.js"
+
+describe("guildIdsEligibleForSettingsDelete", () => {
+    it("skips guilds that still have settings after merge (stale deleteGuildIds regression)", () => {
+        const eligible = guildIdsEligibleForSettingsDelete(["g1", "g2", "g3"], {
+            g1: { controlChannelId: "c1" },
+            g2: {},
+        })
+        assert.deepEqual(eligible.sort(), ["g2", "g3"])
+    })
+
+    it("allows delete when the merged row is empty or absent", () => {
+        assert.deepEqual(guildIdsEligibleForSettingsDelete(["missing"], {}), ["missing"])
+        assert.deepEqual(guildIdsEligibleForSettingsDelete(["empty"], { empty: {} }), ["empty"])
+    })
+
+    it("returns empty when every candidate still has fields", () => {
+        assert.deepEqual(
+            guildIdsEligibleForSettingsDelete(["a"], { a: { controlMessageId: "m1" } }),
+            []
+        )
+    })
+})

--- a/src/util/guildSettingsDeleteFilter.ts
+++ b/src/util/guildSettingsDeleteFilter.ts
@@ -1,0 +1,16 @@
+import type { GuildSettingsStore } from "../types/index.js"
+
+/**
+ * Returns delete targets that are safe after a settings merge: only guilds with an empty
+ * or absent row. Callers that pass stale `deleteGuildIds` from a partial local snapshot must
+ * not wipe rows another concurrent save just wrote.
+ */
+export function guildIdsEligibleForSettingsDelete(
+    deleteGuildIds: string[],
+    merged: GuildSettingsStore
+): string[] {
+    return deleteGuildIds.filter((guildId) => {
+        const row = merged[guildId]
+        return row === undefined || Object.keys(row).length === 0
+    })
+}

--- a/src/util/guildSettingsDeleteFilter.ts
+++ b/src/util/guildSettingsDeleteFilter.ts
@@ -1,4 +1,5 @@
 import type { GuildSettingsStore } from "../types/index.js"
+import { resolveGuildSettingsDeleteIds } from "./guildSettingsDeleteIds.js"
 
 /**
  * Returns delete targets that are safe after a settings merge: only guilds with an empty
@@ -9,8 +10,5 @@ export function guildIdsEligibleForSettingsDelete(
     deleteGuildIds: string[],
     merged: GuildSettingsStore
 ): string[] {
-    return deleteGuildIds.filter((guildId) => {
-        const row = merged[guildId]
-        return row === undefined || Object.keys(row).length === 0
-    })
+    return resolveGuildSettingsDeleteIds(deleteGuildIds, [], merged)
 }

--- a/src/util/guildSettingsDeleteIds.test.ts
+++ b/src/util/guildSettingsDeleteIds.test.ts
@@ -23,7 +23,7 @@ describe("resolveGuildSettingsDeleteIds", () => {
 
     it("unions explicit empty deletes with inferred empty-after-merge deletes", () => {
         assert.deepEqual(
-            resolveGuildSettingsDeleteIds(["a", "b"], ["b", "c"], { a: {}, /* b absent */ }),
+            resolveGuildSettingsDeleteIds(["a", "b"], ["b", "c"], { a: {} /* b absent */ }),
             ["a", "b", "c"]
         )
     })

--- a/src/util/guildSettingsDeleteIds.test.ts
+++ b/src/util/guildSettingsDeleteIds.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { resolveGuildSettingsDeleteIds } from "./guildSettingsDeleteIds.js"
+
+describe("resolveGuildSettingsDeleteIds", () => {
+    it("skips explicit deletes when the merged row still has fields (stale deleteGuildIds)", () => {
+        assert.deepEqual(
+            resolveGuildSettingsDeleteIds(["g1", "g2"], [], {
+                g1: { controlChannelId: "c1" },
+                g2: {},
+            }),
+            ["g2"]
+        )
+    })
+
+    it("deletes touched guilds that became empty after clearedGuildFields without deleteGuildIds", () => {
+        // Regression: PR #109 removed caller-side deleteGuildIds from control-channel unset /
+        // download-limit clear. Empty-after-merge guilds must still hit the DB delete path.
+        assert.deepEqual(resolveGuildSettingsDeleteIds([], ["guild-only-control"], {}), [
+            "guild-only-control",
+        ])
+    })
+
+    it("unions explicit empty deletes with inferred empty-after-merge deletes", () => {
+        assert.deepEqual(
+            resolveGuildSettingsDeleteIds(["a", "b"], ["b", "c"], { a: {}, /* b absent */ }),
+            ["a", "b", "c"]
+        )
+    })
+})

--- a/src/util/guildSettingsDeleteIds.ts
+++ b/src/util/guildSettingsDeleteIds.ts
@@ -1,0 +1,20 @@
+import type { GuildSettingsStore } from "../types/index.js"
+
+/**
+ * Builds the guild IDs that must be deleted from the database after a settings merge.
+ *
+ * Explicit `deleteGuildIds` are filtered so stale callers cannot wipe rows that still have
+ * fields after merge. Touched guilds that became empty after `clearedGuildFields` are always
+ * included — callers may omit `deleteGuildIds` once fields are cleared.
+ */
+export function resolveGuildSettingsDeleteIds(
+    explicitDeleteGuildIds: string[],
+    emptyAfterMergeGuildIds: string[],
+    merged: GuildSettingsStore
+): string[] {
+    const safeExplicit = explicitDeleteGuildIds.filter((guildId) => {
+        const row = merged[guildId]
+        return row === undefined || Object.keys(row).length === 0
+    })
+    return [...new Set([...safeExplicit, ...emptyAfterMergeGuildIds])]
+}

--- a/src/util/parseEventDateTime.test.ts
+++ b/src/util/parseEventDateTime.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { parseEventDateTime } from "./parseEventDateTime.js"
+import { formatDuration } from "./formatDuration.js"
+
+describe("parseEventDateTime", () => {
+    it("converts a Chicago wall time to an epoch second", () => {
+        const result = parseEventDateTime("2026-01-15", "18:30", "America/Chicago")
+        assert.equal(result.ok, true)
+        if (!result.ok) return
+        // 2026-01-15 18:30 CST = 2026-01-16 00:30 UTC
+        assert.equal(result.epochSeconds, Date.UTC(2026, 0, 16, 0, 30) / 1000)
+    })
+
+    it("rejects bad formats, unknown zones, and impossible calendar dates", () => {
+        assert.equal(parseEventDateTime("15-01-2026", "18:30", "UTC").ok, false)
+        assert.equal(parseEventDateTime("2026-01-15", "25:00", "UTC").ok, false)
+        assert.equal(parseEventDateTime("2026-01-15", "18:30", "Not/AZone").ok, false)
+        assert.equal(parseEventDateTime("2026-02-30", "12:00", "UTC").ok, false)
+    })
+})
+
+describe("formatDuration", () => {
+    it("formats mm:ss and hh:mm:ss, and guards non-finite input", () => {
+        assert.equal(formatDuration(65_000), "01:05")
+        assert.equal(formatDuration(3_661_000), "01:01:01")
+        assert.equal(formatDuration(0), "00:00")
+        assert.equal(formatDuration(Number.NaN), "00:00")
+        assert.equal(formatDuration(Number.POSITIVE_INFINITY), "00:00")
+    })
+})

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it } from "node:test"
 import type { Player, Track } from "lavalink-client"
 import {
     clearPlayerSessionRestoreInProgress,
+    clearSuppressNextPlayerSessionClear,
     markPlayerSessionRestoreInProgress,
     shouldSkipPlayerSessionClear,
     shouldSkipPlayerSessionClearForState,
@@ -30,7 +31,7 @@ function mockTrack(overrides: Partial<Track["info"]> & { encoded?: string } = {}
             ...infoOverrides,
         },
         requester: "user-1",
-    } as Track
+    } as unknown as Track
 }
 
 function mockPlayer(opts: {
@@ -139,5 +140,7 @@ describe("shouldSkipPlayerSessionClear", () => {
         assert.equal(shouldSkipPlayerSessionClear("guild-ephemeral"), false)
         suppressNextPlayerSessionClear("guild-ephemeral")
         assert.equal(shouldSkipPlayerSessionClear("guild-ephemeral"), true)
+        clearSuppressNextPlayerSessionClear("guild-ephemeral")
+        assert.equal(shouldSkipPlayerSessionClear("guild-ephemeral"), false)
     })
 })

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -7,6 +7,7 @@ import {
     shouldSkipPlayerSessionClear,
     shouldSkipPlayerSessionClearForState,
     snapshotFromPlayer,
+    suppressNextPlayerSessionClear,
 } from "./playerSessionPersistence.js"
 import { persistedTrackFromLavalink } from "./playerSessionTracks.js"
 import { getRequesterUserId } from "./rrqDisconnect.js"
@@ -126,10 +127,17 @@ describe("shouldSkipPlayerSessionClear", () => {
         assert.equal(shouldSkipPlayerSessionClear("guild-restore"), false)
     })
 
-    it("skips clear for shutdown or restore state combinations", () => {
+    it("skips clear for shutdown, restore, or suppress combinations", () => {
         assert.equal(shouldSkipPlayerSessionClearForState(false, false), false)
         assert.equal(shouldSkipPlayerSessionClearForState(true, false), true)
         assert.equal(shouldSkipPlayerSessionClearForState(false, true), true)
         assert.equal(shouldSkipPlayerSessionClearForState(true, true), true)
+        assert.equal(shouldSkipPlayerSessionClearForState(false, false, true), true)
+    })
+
+    it("skips clear after suppressNextPlayerSessionClear (ephemeral web teardown)", () => {
+        assert.equal(shouldSkipPlayerSessionClear("guild-ephemeral"), false)
+        suppressNextPlayerSessionClear("guild-ephemeral")
+        assert.equal(shouldSkipPlayerSessionClear("guild-ephemeral"), true)
     })
 })

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -3,13 +3,18 @@ import { afterEach, describe, it } from "node:test"
 import type { Player, Track } from "lavalink-client"
 import {
     acquirePlayerSessionClearSuppressLease,
+    clearPlayerSession,
     clearPlayerSessionRestoreInProgress,
+    getSessionClearEpochForTests,
     markPlayerSessionRestoreInProgress,
+    setPlayerSessionPersistenceDbForTests,
     shouldSkipPlayerSessionClear,
     shouldSkipPlayerSessionClearForState,
     shouldUndoStaleSessionUpsert,
     snapshotFromPlayer,
+    writePlayerSessionForTests,
 } from "./playerSessionPersistence.js"
+import type { PlayerSessionSnapshotV1 } from "../types/index.js"
 import { persistedTrackFromLavalink } from "./playerSessionTracks.js"
 import { getRequesterUserId } from "./rrqDisconnect.js"
 
@@ -168,5 +173,86 @@ describe("shouldUndoStaleSessionUpsert", () => {
 
     it("does not undo when clear epoch still matches the save epoch", () => {
         assert.equal(shouldUndoStaleSessionUpsert(1, 1, 3, 3), false)
+    })
+})
+
+describe("guild persistence serialization", () => {
+    afterEach(() => {
+        setPlayerSessionPersistenceDbForTests(null)
+    })
+
+    it("waits for a slow older upsert to finish before a newer upsert starts", async () => {
+        const guildId = "guild-persist-upsert-order"
+        const events: string[] = []
+        let releaseOld!: () => void
+        const oldUpsertGate = new Promise<void>((resolve) => {
+            releaseOld = resolve
+        })
+        let upsertCalls = 0
+
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => {
+                upsertCalls += 1
+                if (upsertCalls === 1) {
+                    events.push("old-upsert-start")
+                    await oldUpsertGate
+                    events.push("old-upsert-end")
+                    return
+                }
+                events.push("new-upsert")
+            },
+            deletePlayerSession: async () => {
+                events.push("delete")
+            },
+        })
+
+        const player = mockPlayer({})
+        player.guildId = guildId
+        const epoch = getSessionClearEpochForTests(guildId)
+        const older = writePlayerSessionForTests(player, epoch)
+        const newer = writePlayerSessionForTests(player, epoch)
+        await Promise.resolve()
+        assert.deepEqual(events, ["old-upsert-start"])
+        releaseOld()
+        await Promise.all([older, newer])
+        assert.deepEqual(events, ["old-upsert-start", "old-upsert-end", "new-upsert"])
+    })
+
+    it("finishes clear delete before a subsequent upsert (clear-then-write order)", async () => {
+        const guildId = "guild-persist-clear-order"
+        const events: string[] = []
+        let releaseDelete!: () => void
+        const deleteGate = new Promise<void>((resolve) => {
+            releaseDelete = resolve
+        })
+
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async (
+                _guildId: string,
+                _voiceChannelId: string,
+                _textChannelId: string | null,
+                _snapshot: PlayerSessionSnapshotV1
+            ) => {
+                events.push("upsert")
+            },
+            deletePlayerSession: async () => {
+                events.push("delete-start")
+                await deleteGate
+                events.push("delete-end")
+            },
+        })
+
+        const player = mockPlayer({})
+        player.guildId = guildId
+        const clearP = clearPlayerSession(guildId)
+        await Promise.resolve()
+        assert.deepEqual(events, ["delete-start"])
+        // Epoch is bumped before the deferred delete awaits; new writes use the post-clear epoch.
+        const writeP = writePlayerSessionForTests(player, getSessionClearEpochForTests(guildId))
+        await Promise.resolve()
+        assert.deepEqual(events, ["delete-start"])
+        releaseDelete()
+        await Promise.all([clearP, writeP])
+        assert.deepEqual(events, ["delete-start", "delete-end", "upsert"])
     })
 })

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict"
+import { afterEach, describe, it } from "node:test"
+import type { Player, Track } from "lavalink-client"
+import {
+    clearPlayerSessionRestoreInProgress,
+    markPlayerSessionRestoreInProgress,
+    shouldSkipPlayerSessionClear,
+    shouldSkipPlayerSessionClearForState,
+    snapshotFromPlayer,
+} from "./playerSessionPersistence.js"
+import { persistedTrackFromLavalink } from "./playerSessionTracks.js"
+import { getRequesterUserId } from "./rrqDisconnect.js"
+
+function mockTrack(overrides: Partial<Track["info"]> & { encoded?: string } = {}): Track {
+    const { encoded, ...infoOverrides } = overrides
+    return {
+        encoded: encoded ?? "enc",
+        info: {
+            title: "Song",
+            author: "Artist",
+            uri: "https://example.com/t",
+            duration: 1000,
+            isStream: false,
+            identifier: "id",
+            isSeekable: true,
+            sourceName: "http",
+            artworkUrl: null,
+            isrc: null,
+            ...infoOverrides,
+        },
+        requester: "user-1",
+    } as Track
+}
+
+function mockPlayer(opts: {
+    current?: Track | null
+    tracks?: Track[]
+    volume?: number
+    voiceChannelId?: string | null
+}): Player {
+    const store = new Map<string, unknown>()
+    return {
+        guildId: "guild-1",
+        voiceChannelId: opts.voiceChannelId === undefined ? "vc-1" : opts.voiceChannelId,
+        textChannelId: "text-1",
+        volume: opts.volume ?? 80,
+        repeatMode: "off",
+        paused: false,
+        playing: true,
+        queue: {
+            current: opts.current === undefined ? mockTrack() : opts.current,
+            tracks: opts.tracks ?? [],
+        },
+        get: (key: string) => store.get(key),
+        set: (key: string, value: unknown) => {
+            store.set(key, value)
+        },
+    } as unknown as Player
+}
+
+describe("getRequesterUserId", () => {
+    it("reads string, object id, and safe numeric ids", () => {
+        assert.equal(getRequesterUserId("abc"), "abc")
+        assert.equal(getRequesterUserId({ id: "xyz" }), "xyz")
+        assert.equal(getRequesterUserId({ id: 42 }), "42")
+        assert.equal(getRequesterUserId({ id: 10n }), "10")
+        assert.equal(getRequesterUserId(null), null)
+        assert.equal(getRequesterUserId({}), null)
+    })
+})
+
+describe("persistedTrackFromLavalink", () => {
+    it("serializes a resolved track", () => {
+        const persisted = persistedTrackFromLavalink(mockTrack())
+        assert.ok(persisted)
+        assert.equal(persisted.title, "Song")
+        assert.equal(persisted.uri, "https://example.com/t")
+        assert.equal(persisted.requesterId, "user-1")
+        assert.equal(persisted.encoded, "enc")
+    })
+
+    it("returns null when uri is missing (nothing restorable)", () => {
+        assert.equal(persistedTrackFromLavalink(mockTrack({ uri: "  " })), null)
+        assert.equal(persistedTrackFromLavalink(mockTrack({ uri: undefined })), null)
+    })
+
+    it("falls back to Unknown for blank title/author", () => {
+        const persisted = persistedTrackFromLavalink(mockTrack({ title: " ", author: "" }))
+        assert.ok(persisted)
+        assert.equal(persisted.title, "Unknown")
+        assert.equal(persisted.author, "Unknown")
+    })
+})
+
+describe("snapshotFromPlayer", () => {
+    it("returns null for an empty player (must not drive session delete on save)", () => {
+        assert.equal(snapshotFromPlayer(mockPlayer({ current: null, tracks: [] })), null)
+    })
+
+    it("builds a v1 snapshot when current or queue has tracks", () => {
+        const withCurrent = snapshotFromPlayer(mockPlayer({}))
+        assert.ok(withCurrent)
+        assert.equal(withCurrent.version, 1)
+        assert.equal(withCurrent.volume, 80)
+        assert.equal(withCurrent.current?.title, "Song")
+
+        const queueOnly = snapshotFromPlayer(
+            mockPlayer({ current: null, tracks: [mockTrack({ title: "Q" })] })
+        )
+        assert.ok(queueOnly)
+        assert.equal(queueOnly.current, null)
+        assert.equal(queueOnly.queue[0]?.title, "Q")
+    })
+})
+
+describe("shouldSkipPlayerSessionClear", () => {
+    afterEach(() => {
+        clearPlayerSessionRestoreInProgress("guild-restore")
+    })
+
+    it("skips clear while restore is in progress (orphan destroy must keep row)", () => {
+        assert.equal(shouldSkipPlayerSessionClear("guild-restore"), false)
+        markPlayerSessionRestoreInProgress("guild-restore")
+        assert.equal(shouldSkipPlayerSessionClear("guild-restore"), true)
+        clearPlayerSessionRestoreInProgress("guild-restore")
+        assert.equal(shouldSkipPlayerSessionClear("guild-restore"), false)
+    })
+
+    it("skips clear for shutdown or restore state combinations", () => {
+        assert.equal(shouldSkipPlayerSessionClearForState(false, false), false)
+        assert.equal(shouldSkipPlayerSessionClearForState(true, false), true)
+        assert.equal(shouldSkipPlayerSessionClearForState(false, true), true)
+        assert.equal(shouldSkipPlayerSessionClearForState(true, true), true)
+    })
+})

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -244,10 +244,8 @@ describe("guild persistence serialization", () => {
 
         const player = mockPlayer({})
         player.guildId = guildId
+        // Epoch bumps synchronously after the skip check (before the delete lock await).
         const clearP = clearPlayerSession(guildId)
-        await Promise.resolve()
-        assert.deepEqual(events, ["delete-start"])
-        // Epoch is bumped before the deferred delete awaits; new writes use the post-clear epoch.
         const writeP = writePlayerSessionForTests(player, getSessionClearEpochForTests(guildId))
         await Promise.resolve()
         assert.deepEqual(events, ["delete-start"])

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -2,13 +2,13 @@ import assert from "node:assert/strict"
 import { afterEach, describe, it } from "node:test"
 import type { Player, Track } from "lavalink-client"
 import {
+    acquirePlayerSessionClearSuppressLease,
     clearPlayerSessionRestoreInProgress,
-    clearSuppressNextPlayerSessionClear,
     markPlayerSessionRestoreInProgress,
     shouldSkipPlayerSessionClear,
     shouldSkipPlayerSessionClearForState,
+    shouldUndoStaleSessionUpsert,
     snapshotFromPlayer,
-    suppressNextPlayerSessionClear,
 } from "./playerSessionPersistence.js"
 import { persistedTrackFromLavalink } from "./playerSessionTracks.js"
 import { getRequesterUserId } from "./rrqDisconnect.js"
@@ -136,11 +136,37 @@ describe("shouldSkipPlayerSessionClear", () => {
         assert.equal(shouldSkipPlayerSessionClearForState(false, false, true), true)
     })
 
-    it("skips clear after suppressNextPlayerSessionClear (ephemeral web teardown)", () => {
+    it("skips clear while a suppress lease is held (ephemeral web teardown)", () => {
         assert.equal(shouldSkipPlayerSessionClear("guild-ephemeral"), false)
-        suppressNextPlayerSessionClear("guild-ephemeral")
+        const lease = acquirePlayerSessionClearSuppressLease("guild-ephemeral")
         assert.equal(shouldSkipPlayerSessionClear("guild-ephemeral"), true)
-        clearSuppressNextPlayerSessionClear("guild-ephemeral")
+        lease.release()
         assert.equal(shouldSkipPlayerSessionClear("guild-ephemeral"), false)
+    })
+
+    it("releasing one suppress lease does not clear a concurrent lease", () => {
+        const leaseA = acquirePlayerSessionClearSuppressLease("guild-lease")
+        const leaseB = acquirePlayerSessionClearSuppressLease("guild-lease")
+        assert.equal(shouldSkipPlayerSessionClear("guild-lease"), true)
+        leaseA.release()
+        assert.equal(shouldSkipPlayerSessionClear("guild-lease"), true)
+        leaseB.release()
+        assert.equal(shouldSkipPlayerSessionClear("guild-lease"), false)
+    })
+})
+
+describe("shouldUndoStaleSessionUpsert", () => {
+    it("undoes when clear invalidated the write and no newer persist claimed generation", () => {
+        // saveEpoch 1, clear bumped to 2, write still owns generation 5
+        assert.equal(shouldUndoStaleSessionUpsert(2, 1, 5, 5), true)
+    })
+
+    it("keeps a newer persist when stale cleanup races after a later write claim", () => {
+        // Stale write claimed gen 5; clear bumped gen; newer write claimed gen 7
+        assert.equal(shouldUndoStaleSessionUpsert(2, 1, 7, 5), false)
+    })
+
+    it("does not undo when clear epoch still matches the save epoch", () => {
+        assert.equal(shouldUndoStaleSessionUpsert(1, 1, 3, 3), false)
     })
 })

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -15,6 +15,8 @@ const pendingPlayers = new Map<string, Player>()
 const restoreInProgressGuilds = new Set<string>()
 /** Bumped on intentional clear so in-flight debounced writes cannot resurrect deleted rows. */
 const sessionClearEpochByGuild = new Map<string, number>()
+/** Skips the next clearPlayerSession DB delete (failed ephemeral web player teardown). */
+const suppressSessionClearGuilds = new Set<string>()
 let persistenceShuttingDown = false
 
 function getSessionClearEpoch(guildId: string): number {
@@ -25,6 +27,11 @@ function bumpSessionClearEpoch(guildId: string): number {
     const next = getSessionClearEpoch(guildId) + 1
     sessionClearEpochByGuild.set(guildId, next)
     return next
+}
+
+/** Prevents playerDestroy from deleting a persisted snapshot after ephemeral player cleanup. */
+export function suppressNextPlayerSessionClear(guildId: string): void {
+    suppressSessionClearGuilds.add(guildId)
 }
 
 /** Set during SIGINT/SIGTERM so playerDestroy does not wipe flushed session rows. */
@@ -174,7 +181,13 @@ export async function clearPlayerSession(guildId: string): Promise<void> {
         pendingSaveTimers.delete(guildId)
     }
     pendingPlayers.delete(guildId)
-    // Shutdown flush and mid-restore cleanup own row lifetime; playerDestroy must not race them.
-    if (persistenceShuttingDown || isRestoreInProgress(guildId)) return
+    // Shutdown flush, mid-restore cleanup, and ephemeral web teardown own row lifetime.
+    if (
+        persistenceShuttingDown ||
+        isRestoreInProgress(guildId) ||
+        suppressSessionClearGuilds.delete(guildId)
+    ) {
+        return
+    }
     await deletePlayerSession(guildId)
 }

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -13,7 +13,19 @@ const SAVE_DEBOUNCE_MS = 2000
 const pendingSaveTimers = new Map<string, ReturnType<typeof setTimeout>>()
 const pendingPlayers = new Map<string, Player>()
 const restoreInProgressGuilds = new Set<string>()
+/** Bumped on intentional clear so in-flight debounced writes cannot resurrect deleted rows. */
+const sessionClearEpochByGuild = new Map<string, number>()
 let persistenceShuttingDown = false
+
+function getSessionClearEpoch(guildId: string): number {
+    return sessionClearEpochByGuild.get(guildId) ?? 0
+}
+
+function bumpSessionClearEpoch(guildId: string): number {
+    const next = getSessionClearEpoch(guildId) + 1
+    sessionClearEpochByGuild.set(guildId, next)
+    return next
+}
 
 /** Set during SIGINT/SIGTERM so playerDestroy does not wipe flushed session rows. */
 export function markPlayerSessionPersistenceShuttingDown(): void {
@@ -63,7 +75,9 @@ function isRestoreInProgress(guildId: string): boolean {
     return restoreInProgressGuilds.has(guildId)
 }
 
-async function writePlayerSession(player: Player): Promise<void> {
+async function writePlayerSession(player: Player, saveEpoch: number): Promise<void> {
+    if (getSessionClearEpoch(player.guildId) !== saveEpoch) return
+
     const snapshot = snapshotFromPlayer(player)
     const voiceChannelId = player.voiceChannelId
     if (!voiceChannelId) return
@@ -78,6 +92,11 @@ async function writePlayerSession(player: Player): Promise<void> {
         player.textChannelId ?? null,
         snapshot
     )
+
+    // clearPlayerSession may run while the upsert is in flight — undo a stale resurrection.
+    if (getSessionClearEpoch(player.guildId) !== saveEpoch) {
+        await deletePlayerSession(player.guildId).catch(() => undefined)
+    }
 }
 
 /** Debounced upsert of the player session snapshot (~2s per guild). */
@@ -85,6 +104,7 @@ export function schedulePlayerSessionSave(player: Player): void {
     if (persistenceShuttingDown || isRestoreInProgress(player.guildId)) return
 
     const guildId = player.guildId
+    const saveEpoch = getSessionClearEpoch(guildId)
     pendingPlayers.set(guildId, player)
     const existing = pendingSaveTimers.get(guildId)
     if (existing) clearTimeout(existing)
@@ -93,8 +113,8 @@ export function schedulePlayerSessionSave(player: Player): void {
         pendingSaveTimers.delete(guildId)
         const latest = pendingPlayers.get(guildId)
         pendingPlayers.delete(guildId)
-        if (!latest) return
-        void writePlayerSession(latest).catch((err: unknown) => {
+        if (!latest || getSessionClearEpoch(guildId) !== saveEpoch) return
+        void writePlayerSession(latest, saveEpoch).catch((err: unknown) => {
             const client = tryGetBotClient()
             const msg = err instanceof Error ? err.message : String(err)
             if (client) {
@@ -119,7 +139,7 @@ export async function flushPlayerSessionSave(guildId: string): Promise<void> {
     const player = pendingPlayers.get(guildId)
     pendingPlayers.delete(guildId)
     if (player) {
-        await writePlayerSession(player)
+        await writePlayerSession(player, getSessionClearEpoch(guildId))
     }
 }
 
@@ -135,7 +155,7 @@ export async function flushAllPlayerSessionSaves(): Promise<void> {
     for (const player of client.lavalink.players.values()) {
         if (isRestoreInProgress(player.guildId)) continue
         try {
-            await writePlayerSession(player)
+            await writePlayerSession(player, getSessionClearEpoch(player.guildId))
         } catch (err: unknown) {
             const msg = err instanceof Error ? err.message : String(err)
             client.error(
@@ -147,6 +167,7 @@ export async function flushAllPlayerSessionSaves(): Promise<void> {
 
 /** Removes a persisted session row (intentional destroy or stale cleanup). */
 export async function clearPlayerSession(guildId: string): Promise<void> {
+    bumpSessionClearEpoch(guildId)
     const timer = pendingSaveTimers.get(guildId)
     if (timer) {
         clearTimeout(timer)

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -122,8 +122,8 @@ export type PlayerSessionClearSuppressLease = {
 
 /**
  * Acquires an operation-scoped suppress lease for ephemeral player teardown.
- * Call `lease.release()` only when destroyPlayer rejects — a successful destroy is consumed
- * inside clearPlayerSession (playerDestroy is not awaited by destroyPlayer).
+ * A successful session clear (via playerDestroy → clearPlayerSession) consumes the lease;
+ * callers should invoke `release()` only when the associated destroyPlayer call fails.
  */
 export function acquirePlayerSessionClearSuppressLease(
     guildId: string

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -7,6 +7,7 @@ import {
 import { isRRQActive } from "./rrqDisconnect.js"
 import { persistedTrackFromLavalink } from "./playerSessionTracks.js"
 import { tryGetBotClient } from "../lib/botClientRegistry.js"
+import { createGuildAsyncChain } from "./guildAsyncChain.js"
 
 const SAVE_DEBOUNCE_MS = 2000
 
@@ -29,20 +30,7 @@ let nextSuppressLeaseId = 1
 let persistenceShuttingDown = false
 
 /** Per-guild FIFO so DB upsert/delete completion order matches generation claim order. */
-const persistenceChainByGuild = new Map<string, Promise<unknown>>()
-
-async function withGuildPersistenceLock<T>(guildId: string, work: () => Promise<T>): Promise<T> {
-    const prior = persistenceChainByGuild.get(guildId) ?? Promise.resolve()
-    const result = prior.then(() => work())
-    persistenceChainByGuild.set(
-        guildId,
-        result.then(
-            () => undefined,
-            () => undefined
-        )
-    )
-    return result
-}
+const withGuildPersistenceLock = createGuildAsyncChain()
 
 /** Injectable DB ops so regression tests can defer upsert/delete completion. */
 type PlayerSessionPersistenceDb = {
@@ -357,6 +345,11 @@ export async function clearPlayerSession(guildId: string): Promise<void> {
         return
     }
 
+    // Bump before awaiting the persistence lock so immediately following saves capture the new epoch.
+    bumpSessionClearEpoch(guildId)
+    // Invalidate in-flight write undos so they cannot delete a row rewritten after this clear.
+    bumpSessionPersistGeneration(guildId)
+
     const timer = pendingSaveTimers.get(guildId)
     if (timer) {
         clearTimeout(timer)
@@ -365,9 +358,6 @@ export async function clearPlayerSession(guildId: string): Promise<void> {
     pendingPlayers.delete(guildId)
 
     await withGuildPersistenceLock(guildId, async () => {
-        bumpSessionClearEpoch(guildId)
-        // Invalidate in-flight write undos so they cannot delete a row rewritten after this clear.
-        bumpSessionPersistGeneration(guildId)
         await persistenceDb.deletePlayerSession(guildId)
     })
 }

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -82,6 +82,27 @@ function isRestoreInProgress(guildId: string): boolean {
     return restoreInProgressGuilds.has(guildId)
 }
 
+/**
+ * Pure guard used by clearPlayerSession: shutdown flush, mid-restore, and one-shot suppress.
+ * Exported for regression tests.
+ */
+export function shouldSkipPlayerSessionClearForState(
+    shuttingDown: boolean,
+    restoreInProgress: boolean,
+    suppressNextClear = false
+): boolean {
+    return shuttingDown || restoreInProgress || suppressNextClear
+}
+
+/** True when clearPlayerSession must not delete the DB row for this guild. */
+export function shouldSkipPlayerSessionClear(guildId: string): boolean {
+    return shouldSkipPlayerSessionClearForState(
+        persistenceShuttingDown,
+        isRestoreInProgress(guildId),
+        suppressSessionClearGuilds.has(guildId)
+    )
+}
+
 async function writePlayerSession(player: Player, saveEpoch: number): Promise<void> {
     if (getSessionClearEpoch(player.guildId) !== saveEpoch) return
 
@@ -182,10 +203,13 @@ export async function clearPlayerSession(guildId: string): Promise<void> {
     }
     pendingPlayers.delete(guildId)
     // Shutdown flush, mid-restore cleanup, and ephemeral web teardown own row lifetime.
+    const suppressNextClear = suppressSessionClearGuilds.delete(guildId)
     if (
-        persistenceShuttingDown ||
-        isRestoreInProgress(guildId) ||
-        suppressSessionClearGuilds.delete(guildId)
+        shouldSkipPlayerSessionClearForState(
+            persistenceShuttingDown,
+            isRestoreInProgress(guildId),
+            suppressNextClear
+        )
     ) {
         return
     }

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -28,6 +28,53 @@ const suppressLeaseCountByGuild = new Map<string, number>()
 let nextSuppressLeaseId = 1
 let persistenceShuttingDown = false
 
+/** Per-guild FIFO so DB upsert/delete completion order matches generation claim order. */
+const persistenceChainByGuild = new Map<string, Promise<unknown>>()
+
+async function withGuildPersistenceLock<T>(guildId: string, work: () => Promise<T>): Promise<T> {
+    const prior = persistenceChainByGuild.get(guildId) ?? Promise.resolve()
+    const result = prior.then(() => work())
+    persistenceChainByGuild.set(
+        guildId,
+        result.then(
+            () => undefined,
+            () => undefined
+        )
+    )
+    return result
+}
+
+/** Injectable DB ops so regression tests can defer upsert/delete completion. */
+type PlayerSessionPersistenceDb = {
+    upsertPlayerSession: typeof upsertPlayerSession
+    deletePlayerSession: typeof deletePlayerSession
+}
+
+let persistenceDb: PlayerSessionPersistenceDb = {
+    upsertPlayerSession,
+    deletePlayerSession,
+}
+
+/** Test-only: replace upsert/delete (pass `null` to restore defaults). */
+export function setPlayerSessionPersistenceDbForTests(
+    next: Partial<PlayerSessionPersistenceDb> | null
+): void {
+    persistenceDb = next
+        ? {
+              upsertPlayerSession: next.upsertPlayerSession ?? persistenceDb.upsertPlayerSession,
+              deletePlayerSession: next.deletePlayerSession ?? persistenceDb.deletePlayerSession,
+          }
+        : { upsertPlayerSession, deletePlayerSession }
+}
+
+/** Test-only: enqueue work on the same per-guild persistence chain as writes/clears. */
+export function enqueueGuildPersistenceTaskForTests<T>(
+    guildId: string,
+    work: () => Promise<T>
+): Promise<T> {
+    return withGuildPersistenceLock(guildId, work)
+}
+
 function getSessionClearEpoch(guildId: string): number {
     return sessionClearEpochByGuild.get(guildId) ?? 0
 }
@@ -187,28 +234,43 @@ async function writePlayerSession(player: Player, saveEpoch: number): Promise<vo
     // good snapshot — only clearPlayerSession removes rows on intentional playerDestroy.
     if (!snapshot) return
 
-    // Claim a persist generation before awaiting so a newer write/clear can outrank this undo.
-    const writeGeneration = bumpSessionPersistGeneration(player.guildId)
+    const guildId = player.guildId
+    await withGuildPersistenceLock(guildId, async () => {
+        // Re-check under the lock: a clear may have landed while we waited for the chain.
+        if (getSessionClearEpoch(guildId) !== saveEpoch) return
 
-    await upsertPlayerSession(
-        player.guildId,
-        voiceChannelId,
-        player.textChannelId ?? null,
-        snapshot
-    )
+        // Claim a persist generation before awaiting so a newer write/clear can outrank this undo.
+        const writeGeneration = bumpSessionPersistGeneration(guildId)
 
-    // clearPlayerSession may run while the upsert is in flight — undo only if this write is
-    // still the latest persist generation (a newer save must not be deleted).
-    if (
-        shouldUndoStaleSessionUpsert(
-            getSessionClearEpoch(player.guildId),
-            saveEpoch,
-            getSessionPersistGeneration(player.guildId),
-            writeGeneration
+        await persistenceDb.upsertPlayerSession(
+            guildId,
+            voiceChannelId,
+            player.textChannelId ?? null,
+            snapshot
         )
-    ) {
-        await deletePlayerSession(player.guildId).catch(() => undefined)
-    }
+
+        // clearPlayerSession may invalidate this write — undo only if still the latest generation.
+        if (
+            shouldUndoStaleSessionUpsert(
+                getSessionClearEpoch(guildId),
+                saveEpoch,
+                getSessionPersistGeneration(guildId),
+                writeGeneration
+            )
+        ) {
+            await persistenceDb.deletePlayerSession(guildId).catch(() => undefined)
+        }
+    })
+}
+
+/** Test-only: run a write through the serialized persist path. */
+export async function writePlayerSessionForTests(player: Player, saveEpoch: number): Promise<void> {
+    await writePlayerSession(player, saveEpoch)
+}
+
+/** Test-only: current clear epoch for a guild (for scheduling writes in race tests). */
+export function getSessionClearEpochForTests(guildId: string): number {
+    return getSessionClearEpoch(guildId)
 }
 
 /** Debounced upsert of the player session snapshot (~2s per guild). */
@@ -295,14 +357,17 @@ export async function clearPlayerSession(guildId: string): Promise<void> {
         return
     }
 
-    bumpSessionClearEpoch(guildId)
-    // Invalidate in-flight write undos so they cannot delete a row rewritten after this clear.
-    bumpSessionPersistGeneration(guildId)
     const timer = pendingSaveTimers.get(guildId)
     if (timer) {
         clearTimeout(timer)
         pendingSaveTimers.delete(guildId)
     }
     pendingPlayers.delete(guildId)
-    await deletePlayerSession(guildId)
+
+    await withGuildPersistenceLock(guildId, async () => {
+        bumpSessionClearEpoch(guildId)
+        // Invalidate in-flight write undos so they cannot delete a row rewritten after this clear.
+        bumpSessionPersistGeneration(guildId)
+        await persistenceDb.deletePlayerSession(guildId)
+    })
 }

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -15,8 +15,17 @@ const pendingPlayers = new Map<string, Player>()
 const restoreInProgressGuilds = new Set<string>()
 /** Bumped on intentional clear so in-flight debounced writes cannot resurrect deleted rows. */
 const sessionClearEpochByGuild = new Map<string, number>()
-/** Skips the next clearPlayerSession DB delete (failed ephemeral web player teardown). */
-const suppressSessionClearGuilds = new Set<string>()
+/**
+ * Bumped on intentional clear and each write claim. Stale post-upsert undo deletes only when
+ * this still matches the write's claimed generation — so a newer persist survives.
+ */
+const sessionPersistGenerationByGuild = new Map<string, number>()
+/**
+ * Operation-scoped suppress leases (refcounted per guild).
+ * Successful destroy: clearPlayerSession consumes one; failed destroy: that lease.release().
+ */
+const suppressLeaseCountByGuild = new Map<string, number>()
+let nextSuppressLeaseId = 1
 let persistenceShuttingDown = false
 
 function getSessionClearEpoch(guildId: string): number {
@@ -29,14 +38,73 @@ function bumpSessionClearEpoch(guildId: string): number {
     return next
 }
 
-/** Prevents playerDestroy from deleting a persisted snapshot after ephemeral player cleanup. */
-export function suppressNextPlayerSessionClear(guildId: string): void {
-    suppressSessionClearGuilds.add(guildId)
+function getSessionPersistGeneration(guildId: string): number {
+    return sessionPersistGenerationByGuild.get(guildId) ?? 0
 }
 
-/** Clears a pending suppress marker when destroyPlayer fails before playerDestroy runs. */
-export function clearSuppressNextPlayerSessionClear(guildId: string): void {
-    suppressSessionClearGuilds.delete(guildId)
+function bumpSessionPersistGeneration(guildId: string): number {
+    const next = getSessionPersistGeneration(guildId) + 1
+    sessionPersistGenerationByGuild.set(guildId, next)
+    return next
+}
+
+/**
+ * True when an in-flight upsert should delete its row after a clear invalidated it.
+ * False when a newer persist already claimed a higher generation (newer snapshot must survive).
+ */
+export function shouldUndoStaleSessionUpsert(
+    currentClearEpoch: number,
+    saveEpoch: number,
+    currentPersistGeneration: number,
+    writeGeneration: number
+): boolean {
+    return currentClearEpoch !== saveEpoch && currentPersistGeneration === writeGeneration
+}
+
+function getSuppressLeaseCount(guildId: string): number {
+    return suppressLeaseCountByGuild.get(guildId) ?? 0
+}
+
+function hasActiveSuppressLease(guildId: string): boolean {
+    return getSuppressLeaseCount(guildId) > 0
+}
+
+/** Decrements one suppress lease for this guild (no-op when none remain). */
+function releaseOneSuppressLease(guildId: string): void {
+    const count = getSuppressLeaseCount(guildId)
+    if (count <= 0) return
+    if (count === 1) suppressLeaseCountByGuild.delete(guildId)
+    else suppressLeaseCountByGuild.set(guildId, count - 1)
+}
+
+/** Lease that skips clearPlayerSession DB delete for one ephemeral destroy attempt. */
+export type PlayerSessionClearSuppressLease = {
+    readonly guildId: string
+    readonly id: number
+    /** Releases only this lease; safe to call more than once. */
+    release(): void
+}
+
+/**
+ * Acquires an operation-scoped suppress lease for ephemeral player teardown.
+ * Call `lease.release()` only when destroyPlayer rejects — a successful destroy is consumed
+ * inside clearPlayerSession (playerDestroy is not awaited by destroyPlayer).
+ */
+export function acquirePlayerSessionClearSuppressLease(
+    guildId: string
+): PlayerSessionClearSuppressLease {
+    const id = nextSuppressLeaseId++
+    suppressLeaseCountByGuild.set(guildId, getSuppressLeaseCount(guildId) + 1)
+    let released = false
+    return {
+        guildId,
+        id,
+        release() {
+            if (released) return
+            released = true
+            releaseOneSuppressLease(guildId)
+        },
+    }
 }
 
 /** Set during SIGINT/SIGTERM so playerDestroy does not wipe flushed session rows. */
@@ -88,7 +156,7 @@ function isRestoreInProgress(guildId: string): boolean {
 }
 
 /**
- * Pure guard used by clearPlayerSession: shutdown flush, mid-restore, and one-shot suppress.
+ * Pure guard used by clearPlayerSession: shutdown flush, mid-restore, and suppress leases.
  * Exported for regression tests.
  */
 export function shouldSkipPlayerSessionClearForState(
@@ -104,7 +172,7 @@ export function shouldSkipPlayerSessionClear(guildId: string): boolean {
     return shouldSkipPlayerSessionClearForState(
         persistenceShuttingDown,
         isRestoreInProgress(guildId),
-        suppressSessionClearGuilds.has(guildId)
+        hasActiveSuppressLease(guildId)
     )
 }
 
@@ -119,6 +187,9 @@ async function writePlayerSession(player: Player, saveEpoch: number): Promise<vo
     // good snapshot — only clearPlayerSession removes rows on intentional playerDestroy.
     if (!snapshot) return
 
+    // Claim a persist generation before awaiting so a newer write/clear can outrank this undo.
+    const writeGeneration = bumpSessionPersistGeneration(player.guildId)
+
     await upsertPlayerSession(
         player.guildId,
         voiceChannelId,
@@ -126,8 +197,16 @@ async function writePlayerSession(player: Player, saveEpoch: number): Promise<vo
         snapshot
     )
 
-    // clearPlayerSession may run while the upsert is in flight — undo a stale resurrection.
-    if (getSessionClearEpoch(player.guildId) !== saveEpoch) {
+    // clearPlayerSession may run while the upsert is in flight — undo only if this write is
+    // still the latest persist generation (a newer save must not be deleted).
+    if (
+        shouldUndoStaleSessionUpsert(
+            getSessionClearEpoch(player.guildId),
+            saveEpoch,
+            getSessionPersistGeneration(player.guildId),
+            writeGeneration
+        )
+    ) {
         await deletePlayerSession(player.guildId).catch(() => undefined)
     }
 }
@@ -203,19 +282,22 @@ export async function clearPlayerSession(guildId: string): Promise<void> {
     // Evaluate preserve/skip before bumping the clear epoch or cancelling pending saves.
     // Skipped clears (shutdown, restore, ephemeral suppress) must not invalidate in-flight
     // writes — the stale-resurrection undo in writePlayerSession would delete protected rows.
-    const suppressNextClear = suppressSessionClearGuilds.has(guildId)
+    const hasSuppressLease = hasActiveSuppressLease(guildId)
     if (
         shouldSkipPlayerSessionClearForState(
             persistenceShuttingDown,
             isRestoreInProgress(guildId),
-            suppressNextClear
+            hasSuppressLease
         )
     ) {
-        suppressSessionClearGuilds.delete(guildId)
+        // Successful ephemeral destroy: consume one lease (handlers release only on reject).
+        if (hasSuppressLease) releaseOneSuppressLease(guildId)
         return
     }
 
     bumpSessionClearEpoch(guildId)
+    // Invalidate in-flight write undos so they cannot delete a row rewritten after this clear.
+    bumpSessionPersistGeneration(guildId)
     const timer = pendingSaveTimers.get(guildId)
     if (timer) {
         clearTimeout(timer)

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -34,6 +34,11 @@ export function suppressNextPlayerSessionClear(guildId: string): void {
     suppressSessionClearGuilds.add(guildId)
 }
 
+/** Clears a pending suppress marker when destroyPlayer fails before playerDestroy runs. */
+export function clearSuppressNextPlayerSessionClear(guildId: string): void {
+    suppressSessionClearGuilds.delete(guildId)
+}
+
 /** Set during SIGINT/SIGTERM so playerDestroy does not wipe flushed session rows. */
 export function markPlayerSessionPersistenceShuttingDown(): void {
     persistenceShuttingDown = true
@@ -195,15 +200,10 @@ export async function flushAllPlayerSessionSaves(): Promise<void> {
 
 /** Removes a persisted session row (intentional destroy or stale cleanup). */
 export async function clearPlayerSession(guildId: string): Promise<void> {
-    bumpSessionClearEpoch(guildId)
-    const timer = pendingSaveTimers.get(guildId)
-    if (timer) {
-        clearTimeout(timer)
-        pendingSaveTimers.delete(guildId)
-    }
-    pendingPlayers.delete(guildId)
-    // Shutdown flush, mid-restore cleanup, and ephemeral web teardown own row lifetime.
-    const suppressNextClear = suppressSessionClearGuilds.delete(guildId)
+    // Evaluate preserve/skip before bumping the clear epoch or cancelling pending saves.
+    // Skipped clears (shutdown, restore, ephemeral suppress) must not invalidate in-flight
+    // writes — the stale-resurrection undo in writePlayerSession would delete protected rows.
+    const suppressNextClear = suppressSessionClearGuilds.has(guildId)
     if (
         shouldSkipPlayerSessionClearForState(
             persistenceShuttingDown,
@@ -211,7 +211,16 @@ export async function clearPlayerSession(guildId: string): Promise<void> {
             suppressNextClear
         )
     ) {
+        suppressSessionClearGuilds.delete(guildId)
         return
     }
+
+    bumpSessionClearEpoch(guildId)
+    const timer = pendingSaveTimers.get(guildId)
+    if (timer) {
+        clearTimeout(timer)
+        pendingSaveTimers.delete(guildId)
+    }
+    pendingPlayers.delete(guildId)
     await deletePlayerSession(guildId)
 }

--- a/src/util/playerSessionSnapshotParse.test.ts
+++ b/src/util/playerSessionSnapshotParse.test.ts
@@ -102,13 +102,13 @@ describe("parsePlayerSessionSnapshot", () => {
         assert.equal(parsePlayerSessionSnapshot(validSnapshot({ paused: "no" })), null)
         assert.equal(parsePlayerSessionSnapshot(validSnapshot({ queue: null })), null)
         assert.equal(
-            parsePlayerSessionSnapshot(
-                validSnapshot({ queue: [{ ...validTrack, author: "" }] })
-            ),
+            parsePlayerSessionSnapshot(validSnapshot({ queue: [{ ...validTrack, author: "" }] })),
             null
         )
         assert.equal(
-            parsePlayerSessionSnapshot(validSnapshot({ current: { ...validTrack, duration: NaN } })),
+            parsePlayerSessionSnapshot(
+                validSnapshot({ current: { ...validTrack, duration: NaN } })
+            ),
             null
         )
     })

--- a/src/util/playerSessionSnapshotParse.test.ts
+++ b/src/util/playerSessionSnapshotParse.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    parsePersistedQueueTrack,
+    parsePlayerSessionSnapshot,
+} from "./playerSessionSnapshotParse.js"
+
+const validTrack = {
+    title: "Song",
+    author: "Artist",
+    uri: "https://example.com/track",
+    duration: 180000,
+    encoded: null,
+    requesterId: "123",
+    thumbnailUrl: null,
+    isStream: false,
+}
+
+function validSnapshot(overrides: Record<string, unknown> = {}) {
+    return {
+        version: 1,
+        volume: 100,
+        repeatMode: "off",
+        paused: false,
+        playing: true,
+        autoplay: false,
+        rrqEnabled: false,
+        current: validTrack,
+        queue: [],
+        ...overrides,
+    }
+}
+
+describe("parsePersistedQueueTrack", () => {
+    it("accepts a well-formed track and trims string fields", () => {
+        const parsed = parsePersistedQueueTrack({
+            ...validTrack,
+            title: "  Song  ",
+            author: "  Artist ",
+            uri: " https://example.com/track ",
+        })
+        assert.deepEqual(parsed, {
+            ...validTrack,
+            title: "Song",
+            author: "Artist",
+            uri: "https://example.com/track",
+        })
+    })
+
+    it("rejects blank author (author validation regression)", () => {
+        assert.equal(parsePersistedQueueTrack({ ...validTrack, author: "   " }), null)
+        assert.equal(parsePersistedQueueTrack({ ...validTrack, author: "" }), null)
+        assert.equal(parsePersistedQueueTrack({ ...validTrack, author: 42 }), null)
+    })
+
+    it("rejects non-finite duration", () => {
+        assert.equal(parsePersistedQueueTrack({ ...validTrack, duration: Number.NaN }), null)
+        assert.equal(
+            parsePersistedQueueTrack({ ...validTrack, duration: Number.POSITIVE_INFINITY }),
+            null
+        )
+        assert.equal(
+            parsePersistedQueueTrack({ ...validTrack, duration: Number.NEGATIVE_INFINITY }),
+            null
+        )
+    })
+
+    it("rejects missing required fields and wrong optional types", () => {
+        assert.equal(parsePersistedQueueTrack(null), null)
+        assert.equal(parsePersistedQueueTrack([]), null)
+        assert.equal(parsePersistedQueueTrack({ ...validTrack, title: "" }), null)
+        assert.equal(parsePersistedQueueTrack({ ...validTrack, uri: " " }), null)
+        assert.equal(parsePersistedQueueTrack({ ...validTrack, isStream: "no" }), null)
+        assert.equal(parsePersistedQueueTrack({ ...validTrack, encoded: 1 }), null)
+        assert.equal(parsePersistedQueueTrack({ ...validTrack, requesterId: 9 }), null)
+        assert.equal(parsePersistedQueueTrack({ ...validTrack, thumbnailUrl: false }), null)
+    })
+})
+
+describe("parsePlayerSessionSnapshot", () => {
+    it("accepts a valid v1 snapshot", () => {
+        const parsed = parsePlayerSessionSnapshot(validSnapshot())
+        assert.ok(parsed)
+        assert.equal(parsed.version, 1)
+        assert.equal(parsed.volume, 100)
+        assert.equal(parsed.current?.title, "Song")
+        assert.deepEqual(parsed.queue, [])
+    })
+
+    it("rejects non-finite volume (volume validation regression)", () => {
+        assert.equal(parsePlayerSessionSnapshot(validSnapshot({ volume: Number.NaN })), null)
+        assert.equal(
+            parsePlayerSessionSnapshot(validSnapshot({ volume: Number.POSITIVE_INFINITY })),
+            null
+        )
+        assert.equal(parsePlayerSessionSnapshot(validSnapshot({ volume: "100" })), null)
+    })
+
+    it("rejects bad version, repeatMode, flags, or corrupt queue entries", () => {
+        assert.equal(parsePlayerSessionSnapshot(validSnapshot({ version: 2 })), null)
+        assert.equal(parsePlayerSessionSnapshot(validSnapshot({ repeatMode: "loop" })), null)
+        assert.equal(parsePlayerSessionSnapshot(validSnapshot({ paused: "no" })), null)
+        assert.equal(parsePlayerSessionSnapshot(validSnapshot({ queue: null })), null)
+        assert.equal(
+            parsePlayerSessionSnapshot(
+                validSnapshot({ queue: [{ ...validTrack, author: "" }] })
+            ),
+            null
+        )
+        assert.equal(
+            parsePlayerSessionSnapshot(validSnapshot({ current: { ...validTrack, duration: NaN } })),
+            null
+        )
+    })
+
+    it("allows null current with a non-empty queue", () => {
+        const parsed = parsePlayerSessionSnapshot(
+            validSnapshot({ current: null, queue: [validTrack] })
+        )
+        assert.ok(parsed)
+        assert.equal(parsed.current, null)
+        assert.equal(parsed.queue.length, 1)
+    })
+})

--- a/src/util/playerSessionSnapshotParse.ts
+++ b/src/util/playerSessionSnapshotParse.ts
@@ -1,0 +1,78 @@
+import type { PersistedQueueTrack, PlayerSessionSnapshotV1 } from "../types/index.js"
+
+/** Parses one persisted queue track from JSON; null when required fields are missing or invalid. */
+export function parsePersistedQueueTrack(value: unknown): PersistedQueueTrack | null {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    const raw = value as Record<string, unknown>
+    if (typeof raw.title !== "string" || !raw.title.trim()) return null
+    if (typeof raw.author !== "string" || !raw.author.trim()) return null
+    if (typeof raw.uri !== "string" || !raw.uri.trim()) return null
+    if (typeof raw.duration !== "number" || !Number.isFinite(raw.duration)) return null
+    if (typeof raw.isStream !== "boolean") return null
+
+    let encoded: string | null = null
+    if (raw.encoded !== null && raw.encoded !== undefined) {
+        if (typeof raw.encoded !== "string") return null
+        encoded = raw.encoded
+    }
+    let requesterId: string | null = null
+    if (raw.requesterId !== null && raw.requesterId !== undefined) {
+        if (typeof raw.requesterId !== "string") return null
+        requesterId = raw.requesterId
+    }
+    let thumbnailUrl: string | null = null
+    if (raw.thumbnailUrl !== null && raw.thumbnailUrl !== undefined) {
+        if (typeof raw.thumbnailUrl !== "string") return null
+        thumbnailUrl = raw.thumbnailUrl
+    }
+
+    return {
+        title: raw.title.trim(),
+        author: raw.author.trim(),
+        uri: raw.uri.trim(),
+        duration: raw.duration,
+        encoded,
+        requesterId,
+        thumbnailUrl,
+        isStream: raw.isStream,
+    }
+}
+
+/** Parses a v1 player-session snapshot from JSON; null when the payload is corrupt or incomplete. */
+export function parsePlayerSessionSnapshot(value: unknown): PlayerSessionSnapshotV1 | null {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    const raw = value as Record<string, unknown>
+    if (raw.version !== 1) return null
+    if (typeof raw.volume !== "number" || !Number.isFinite(raw.volume)) return null
+    if (raw.repeatMode !== "off" && raw.repeatMode !== "track" && raw.repeatMode !== "queue") {
+        return null
+    }
+    if (typeof raw.paused !== "boolean" || typeof raw.playing !== "boolean") return null
+    if (typeof raw.autoplay !== "boolean" || typeof raw.rrqEnabled !== "boolean") return null
+    if (!Array.isArray(raw.queue)) return null
+
+    let current: PersistedQueueTrack | null = null
+    if (raw.current !== null) {
+        current = parsePersistedQueueTrack(raw.current)
+        if (!current) return null
+    }
+
+    const queue: PersistedQueueTrack[] = []
+    for (const item of raw.queue) {
+        const track = parsePersistedQueueTrack(item)
+        if (!track) return null
+        queue.push(track)
+    }
+
+    return {
+        version: 1,
+        volume: raw.volume,
+        repeatMode: raw.repeatMode,
+        paused: raw.paused,
+        playing: raw.playing,
+        autoplay: raw.autoplay,
+        rrqEnabled: raw.rrqEnabled,
+        current,
+        queue,
+    }
+}

--- a/src/util/playlistQueue.lock.test.ts
+++ b/src/util/playlistQueue.lock.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player, Track } from "lavalink-client"
+import { withGuildPlayerQueueLock } from "./guildPlayerQueueLock.js"
+import { playerHasQueueContent } from "./playlistQueue.js"
+
+function mockTrack(): Track {
+    return {
+        encoded: "enc",
+        info: {
+            title: "Song",
+            author: "Artist",
+            uri: "https://example.com/t",
+            duration: 1000,
+            isStream: false,
+            identifier: "id",
+            isSeekable: true,
+            sourceName: "http",
+            artworkUrl: null,
+            isrc: null,
+        },
+        requester: "user-1",
+    } as unknown as Track
+}
+
+function mockEmptyPlayer(guildId: string): Player {
+    return {
+        guildId,
+        queue: {
+            current: null,
+            tracks: [] as Track[],
+        },
+    } as unknown as Player
+}
+
+describe("playlist orphan cleanup vs enqueue lock", () => {
+    it("skips destroy when enqueue wins the guild queue lock first", async () => {
+        const guildId = "guild-playlist-race"
+        const player = mockEmptyPlayer(guildId)
+        let destroyed = false
+
+        await withGuildPlayerQueueLock(guildId, async () => {
+            player.queue.tracks.push(mockTrack())
+        })
+
+        await withGuildPlayerQueueLock(guildId, async () => {
+            if (playerHasQueueContent(player)) return
+            destroyed = true
+        })
+
+        assert.equal(playerHasQueueContent(player), true)
+        assert.equal(destroyed, false)
+    })
+
+    it("blocks enqueue until orphan cleanup finishes under the same lock", async () => {
+        const guildId = "guild-playlist-serialize"
+        const player = mockEmptyPlayer(guildId)
+        const events: string[] = []
+        let releaseCleanup!: () => void
+        const cleanupGate = new Promise<void>((resolve) => {
+            releaseCleanup = resolve
+        })
+        let destroyed = false
+
+        const cleanupP = withGuildPlayerQueueLock(guildId, async () => {
+            events.push("cleanup-start")
+            assert.equal(playerHasQueueContent(player), false)
+            await cleanupGate
+            if (playerHasQueueContent(player)) return
+            destroyed = true
+            events.push("cleanup-destroy")
+        })
+
+        const enqueueP = withGuildPlayerQueueLock(guildId, async () => {
+            player.queue.tracks.push(mockTrack())
+            events.push("enqueue")
+        })
+
+        await Promise.resolve()
+        assert.deepEqual(events, ["cleanup-start"])
+        assert.equal(playerHasQueueContent(player), false)
+        releaseCleanup()
+        await Promise.all([cleanupP, enqueueP])
+        assert.equal(destroyed, true)
+        assert.deepEqual(events, ["cleanup-start", "cleanup-destroy", "enqueue"])
+        assert.equal(playerHasQueueContent(player), true)
+    })
+})

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -8,6 +8,12 @@ import {
 } from "./rrqDisconnect.js"
 import { startPlaybackIfNeeded } from "./musicManager.js"
 import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
+import { withGuildPlayerQueueLock } from "./guildPlayerQueueLock.js"
+
+/** True when the player has a current track or upcoming queue entries. */
+export function playerHasQueueContent(player: Player): boolean {
+    return Boolean(player.queue.current) || player.queue.tracks.length > 0
+}
 
 export function shuffleArray<T>(items: T[]): T[] {
     const arr = [...items]
@@ -118,29 +124,31 @@ export async function enqueueResolvedPlaylistTracks(
     if (tracks.length === 0) {
         return { queued: 0, failed: 0, playbackStarted: false }
     }
-    const toQueue = shuffle ? shuffleArray(tracks) : tracks
-    stampRequesterUserIdOnTracks(toQueue, requesterId)
-    player.queue.add(toQueue)
-    if (isRRQActive(player)) {
-        await rebalancePlayerQueueRoundRobin(player)
-    }
-    let playbackStarted = false
-    let playbackError: string | undefined
-    if (!player.playing) {
-        try {
-            await startPlaybackIfNeeded(player)
-            playbackStarted = true
-        } catch (error: unknown) {
-            playbackError = error instanceof Error ? error.message : String(error)
+    return withGuildPlayerQueueLock(player.guildId, async () => {
+        const toQueue = shuffle ? shuffleArray(tracks) : tracks
+        stampRequesterUserIdOnTracks(toQueue, requesterId)
+        player.queue.add(toQueue)
+        if (isRRQActive(player)) {
+            await rebalancePlayerQueueRoundRobin(player)
         }
-    }
-    schedulePlayerSessionSave(player)
-    return {
-        queued: toQueue.length,
-        failed: 0,
-        playbackStarted,
-        playbackError,
-    }
+        let playbackStarted = false
+        let playbackError: string | undefined
+        if (!player.playing) {
+            try {
+                await startPlaybackIfNeeded(player)
+                playbackStarted = true
+            } catch (error: unknown) {
+                playbackError = error instanceof Error ? error.message : String(error)
+            }
+        }
+        schedulePlayerSessionSave(player)
+        return {
+            queued: toQueue.length,
+            failed: 0,
+            playbackStarted,
+            playbackError,
+        }
+    })
 }
 
 export type PlaylistTrackSearchHit = {

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -4,6 +4,7 @@ import type { PlayerSessionData } from "../types/index.js"
 import { deletePlayerSession, listPlayerSessions } from "../repositories/playerSessionRepository.js"
 import { updateControlMessage } from "../events/handlers/handleControlChannel.js"
 import { playerBroadcaster } from "../shared/websocket/PlayerBroadcaster.js"
+import { getDiscordErrorCode } from "./discordErrorDetails.js"
 import { getGuildSettings } from "./saveControlChannel.js"
 import { ensurePlayerConnected, startPlaybackIfNeeded } from "./musicManager.js"
 import {
@@ -15,35 +16,67 @@ import { resolvePersistedTracks } from "./playerSessionTracks.js"
 import { countHumanMembers } from "./voiceChannelMembers.js"
 
 let discordReady = false
-let restoreAttempted = false
+let restoreInFlight = false
+
+/** Discord API codes meaning the guild or voice channel no longer exists. */
+const STALE_SESSION_DISCORD_CODES = new Set([
+    10003, // Unknown Channel
+    10004, // Unknown Guild
+])
+
+function isStaleSessionDiscordError(error: unknown): boolean {
+    const code = getDiscordErrorCode(error)
+    return code !== undefined && STALE_SESSION_DISCORD_CODES.has(code)
+}
+
+type VoiceChannelFetchResult =
+    | { status: "found"; channel: VoiceBasedChannel }
+    | { status: "missing" }
+    | { status: "transient_error" }
 
 /** Called from `clientReady` so restore waits for Discord before touching guild channels. */
 export function markDiscordReadyForPlayerRestore(): void {
     discordReady = true
 }
 
-/** Attempts one-shot restore after Lavalink node connect (no-op if Discord is not ready yet). */
+/** Attempts restore after Lavalink node connect; re-runs on reconnect for guilds without live players. */
 export async function tryRestorePlayerSessionsOnLavalinkConnect(client: BotClient): Promise<void> {
-    if (!discordReady || restoreAttempted) return
-    const listed = await restorePlayerSessions(client)
-    if (listed) restoreAttempted = true
+    if (!discordReady || restoreInFlight) return
+    restoreInFlight = true
+    try {
+        await restorePlayerSessions(client)
+    } finally {
+        restoreInFlight = false
+    }
 }
 
 async function fetchVoiceChannel(
     client: BotClient,
     guildId: string,
     voiceChannelId: string
-): Promise<VoiceBasedChannel | null> {
-    const guild =
-        client.guilds.cache.get(guildId) ?? (await client.guilds.fetch(guildId).catch(() => null))
-    if (!guild) return null
+): Promise<VoiceChannelFetchResult> {
+    let guild = client.guilds.cache.get(guildId)
+    if (!guild) {
+        try {
+            guild = await client.guilds.fetch(guildId)
+        } catch (err: unknown) {
+            if (isStaleSessionDiscordError(err)) return { status: "missing" }
+            return { status: "transient_error" }
+        }
+    }
+    if (!guild) return { status: "missing" }
 
     const cached = guild.channels.cache.get(voiceChannelId)
-    if (cached?.isVoiceBased()) return cached
+    if (cached?.isVoiceBased()) return { status: "found", channel: cached }
 
-    const fetched = await guild.channels.fetch(voiceChannelId).catch(() => null)
-    if (fetched?.isVoiceBased()) return fetched
-    return null
+    try {
+        const fetched = await guild.channels.fetch(voiceChannelId)
+        if (fetched?.isVoiceBased()) return { status: "found", channel: fetched }
+        return { status: "missing" }
+    } catch (err: unknown) {
+        if (isStaleSessionDiscordError(err)) return { status: "missing" }
+        return { status: "transient_error" }
+    }
 }
 
 function resolveTextChannelId(session: PlayerSessionData): string | null {
@@ -60,14 +93,21 @@ async function restoreSingleSession(client: BotClient, session: PlayerSessionDat
         return
     }
 
-    const voiceChannel = await fetchVoiceChannel(client, guildId, voiceChannelId)
-    if (!voiceChannel) {
+    const voiceResult = await fetchVoiceChannel(client, guildId, voiceChannelId)
+    if (voiceResult.status === "transient_error") {
+        client.warn(
+            `[playerSession] restore deferred for ${guildId}: transient Discord error fetching voice channel ${voiceChannelId}`
+        )
+        return
+    }
+    if (voiceResult.status === "missing") {
         client.info(
             `[playerSession] stale session removed for ${guildId}: voice channel ${voiceChannelId} not found`
         )
         await deletePlayerSession(guildId)
         return
     }
+    const voiceChannel = voiceResult.channel
 
     const humans = countHumanMembers(voiceChannel)
     if (humans === 0) {

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -104,7 +104,12 @@ async function restoreSingleSession(client: BotClient, session: PlayerSessionDat
         client.info(
             `[playerSession] stale session removed for ${guildId}: voice channel ${voiceChannelId} not found`
         )
-        await deletePlayerSession(guildId)
+        try {
+            await deletePlayerSession(guildId)
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err)
+            client.info(`[playerSession] stale session delete failed for ${guildId}: ${msg}`)
+        }
         return
     }
     const voiceChannel = voiceResult.channel

--- a/src/util/rrqDisconnect.ts
+++ b/src/util/rrqDisconnect.ts
@@ -1,5 +1,6 @@
 import type { Player, Track, UnresolvedTrack } from "lavalink-client"
 import type { RRQDisconnectedUsersMap } from "../types/index.js"
+import { createGuildAsyncChain } from "./guildAsyncChain.js"
 
 const RRQ_DISCONNECTED_USERS_KEY = "rrqDisconnectedUsers"
 const RRQ_ENABLED_KEY = "rrqEnabled"
@@ -215,20 +216,7 @@ export async function removeUserTracksFromQueue(player: Player, userId: string):
     return removed
 }
 
-const rrqMutationChainByGuild = new Map<string, Promise<unknown>>()
-
-function enqueueRrqMutation<T>(guildId: string, work: () => Promise<T>): Promise<T> {
-    const prior = rrqMutationChainByGuild.get(guildId) ?? Promise.resolve()
-    const result = prior.then(() => work())
-    rrqMutationChainByGuild.set(
-        guildId,
-        result.then(
-            () => undefined,
-            () => undefined
-        )
-    )
-    return result
-}
+const enqueueRrqMutation = createGuildAsyncChain()
 
 export type RemoveAndRebalanceRrqHooks = {
     onRemoveError?: (err: unknown) => void

--- a/src/util/saveControlChannel.ts
+++ b/src/util/saveControlChannel.ts
@@ -6,6 +6,7 @@ import {
     getGuildSettingsStoreFromDatabase,
     replaceGuildSettingsStoreInDatabase,
 } from "../repositories/guildSettingsRepository.js"
+import { guildIdsEligibleForSettingsDelete } from "./guildSettingsDeleteFilter.js"
 import { loggerFromPartial } from "./loggerFromPartial.js"
 
 const __dirname = import.meta.dirname
@@ -204,10 +205,10 @@ export async function saveGuildSettings(
             }
             // Only delete rows that are empty after merge — stale callers may pass deleteGuildIds
             // based on a local snapshot that omitted fields another concurrent save just wrote.
-            const effectiveDeleteGuildIds = deleteGuildIds.filter((guildId) => {
-                const row = merged[guildId]
-                return row === undefined || Object.keys(row).length === 0
-            })
+            const effectiveDeleteGuildIds = guildIdsEligibleForSettingsDelete(
+                deleteGuildIds,
+                merged
+            )
             for (const guildId of effectiveDeleteGuildIds) {
                 delete merged[guildId]
             }

--- a/src/util/saveControlChannel.ts
+++ b/src/util/saveControlChannel.ts
@@ -6,7 +6,7 @@ import {
     getGuildSettingsStoreFromDatabase,
     replaceGuildSettingsStoreInDatabase,
 } from "../repositories/guildSettingsRepository.js"
-import { guildIdsEligibleForSettingsDelete } from "./guildSettingsDeleteFilter.js"
+import { resolveGuildSettingsDeleteIds } from "./guildSettingsDeleteIds.js"
 import { loggerFromPartial } from "./loggerFromPartial.js"
 
 const __dirname = import.meta.dirname
@@ -189,6 +189,8 @@ export async function saveGuildSettings(
             const guildIdsToApply = hasTouchedOption
                 ? touchedGuildIds
                 : Object.keys(settingsSnapshot)
+            /** Touched guilds whose merge cleared every field — must be deleted from the DB. */
+            const emptyAfterMergeGuildIds: string[] = []
             for (const guildId of guildIdsToApply) {
                 const cleared = (clearedGuildFields[guildId] ?? []).filter(
                     (key): key is keyof GuildSettings =>
@@ -199,14 +201,17 @@ export async function saveGuildSettings(
                 const nextRow = mergeGuildSettingsRow(merged[guildId], row, cleared)
                 if (Object.keys(nextRow).length === 0) {
                     delete merged[guildId]
+                    emptyAfterMergeGuildIds.push(guildId)
                 } else {
                     merged[guildId] = nextRow
                 }
             }
-            // Only delete rows that are empty after merge — stale callers may pass deleteGuildIds
-            // based on a local snapshot that omitted fields another concurrent save just wrote.
-            const effectiveDeleteGuildIds = guildIdsEligibleForSettingsDelete(
+            // Stale explicit deleteGuildIds must not wipe rows that still have fields after merge.
+            // Touched guilds emptied by clearedGuildFields must still be deleted even when callers
+            // omit deleteGuildIds (control-channel unset / download-limit clear after PR #109).
+            const effectiveDeleteGuildIds = resolveGuildSettingsDeleteIds(
                 deleteGuildIds,
+                emptyAfterMergeGuildIds,
                 merged
             )
             for (const guildId of effectiveDeleteGuildIds) {

--- a/src/util/voiceChannelMembers.ts
+++ b/src/util/voiceChannelMembers.ts
@@ -2,5 +2,10 @@ import type { VoiceBasedChannel } from "discord.js"
 
 /** Counts non-bot members in a voice channel (used for alone-in-VC cleanup and session restore). */
 export function countHumanMembers(voiceChannel: VoiceBasedChannel): number {
-    return voiceChannel.members.filter((m) => !m.user.bot).size
+    const guild = voiceChannel.guild
+    const botId = guild.client.user?.id
+    // Voice states are authoritative; voiceChannel.members only includes cached GuildMembers.
+    return guild.voiceStates.cache.filter(
+        (vs) => vs.channelId === voiceChannel.id && vs.id !== botId
+    ).size
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
         "noEmitOnError": true
     },
     "include": ["src/**/*", "lavaNodesConfig.d.ts"],
-    "exclude": ["src/web"]
+    "exclude": ["src/web", "src/**/*.test.ts"]
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false
+    },
+    "include": ["src/**/*.ts", "lavaNodesConfig.d.ts"],
+    "exclude": ["src/web"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -200,6 +200,136 @@
   dependencies:
     tslib "^2.4.0"
 
+"@esbuild/aix-ppc64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz#7a01a8d2ec2fbb2dac78adad09b0fa781e4082be"
+  integrity sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==
+
+"@esbuild/android-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz#b540a27d14e4afd058496a4dbec4d3f414db110a"
+  integrity sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==
+
+"@esbuild/android-arm@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.1.tgz#704bd297de6d762de54eabbeafbf55f6756abe2f"
+  integrity sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==
+
+"@esbuild/android-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.1.tgz#d1cb166d34b0fbf0fe8ab460a5594f24a378701e"
+  integrity sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==
+
+"@esbuild/darwin-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz#1034b26457fc886368fe61bbd09f653f6afa8e54"
+  integrity sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==
+
+"@esbuild/darwin-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz#65556a432a1e4d72032d8218c1932fcca1a49772"
+  integrity sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==
+
+"@esbuild/freebsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz#2e61e0592f9030d7e3dae18ee25ebc535918aef6"
+  integrity sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==
+
+"@esbuild/freebsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz#c95ec289959ef8079c4dca817a1e2c4be66b9bd3"
+  integrity sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==
+
+"@esbuild/linux-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz#40b22175dda06182f3ee8141186c5ff304c4a717"
+  integrity sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==
+
+"@esbuild/linux-arm@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz#c09a0f67917592ac0de892a9be4d3814debd2a6c"
+  integrity sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==
+
+"@esbuild/linux-ia32@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz#a580f9c676797833891e519fc7a1337c8afd8db3"
+  integrity sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==
+
+"@esbuild/linux-loong64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz#46452cf321dc7f9e91c2fa780a56bb56e79cd68b"
+  integrity sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==
+
+"@esbuild/linux-mips64el@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz#4211b3184dd6608f53dcb22e39f5d34ee08852c8"
+  integrity sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==
+
+"@esbuild/linux-ppc64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz#697857c2a61cb9b0b6bb6652e40c1dc5e1ca8e5d"
+  integrity sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==
+
+"@esbuild/linux-riscv64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz#d192943eb146a40ac4c6497d0cf7be35b986bf08"
+  integrity sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==
+
+"@esbuild/linux-s390x@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz#acea0356da0e0ebc08f97cf7b9c2e401e1e648dc"
+  integrity sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==
+
+"@esbuild/linux-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz#6f0c3ce0cb64c534b70c4c45ecb2c16d34e35dfd"
+  integrity sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==
+
+"@esbuild/netbsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz#8bcd77077a0dce3378b574fedb26d2a253b73d36"
+  integrity sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==
+
+"@esbuild/netbsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz#e7fb2a01e99c830c94e6623cd9fefb4c8fb58347"
+  integrity sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==
+
+"@esbuild/openbsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz#c52909372db8b86e2c55e05a8940033b5660a3b2"
+  integrity sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==
+
+"@esbuild/openbsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz#c427b9be5a64c262ff9a7eb70b5fbbaadf446c6c"
+  integrity sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==
+
+"@esbuild/openharmony-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz#dc9b147baca2e6c4b3c85571741ef4860a489097"
+  integrity sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==
+
+"@esbuild/sunos-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz#ce866d12df13c15e4c99f073a3d466f6e0649b3a"
+  integrity sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==
+
+"@esbuild/win32-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz#7468e3692d01d629d5941e5d83817bb80f9e39b4"
+  integrity sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==
+
+"@esbuild/win32-ia32@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz#a5bc0063fb2bcab6d0ed63f2a1537958bc269ec6"
+  integrity sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==
+
+"@esbuild/win32-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz#10064ee44f4347b90c9a02b446bbf80a91632b12"
+  integrity sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==
+
 "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz"
@@ -1392,6 +1522,38 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   dependencies:
     es-errors "^1.3.0"
 
+esbuild@~0.28.0:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.1.tgz#ef45b4634c9c9d97a296aea4114a5f9840f95578"
+  integrity sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.1"
+    "@esbuild/android-arm" "0.28.1"
+    "@esbuild/android-arm64" "0.28.1"
+    "@esbuild/android-x64" "0.28.1"
+    "@esbuild/darwin-arm64" "0.28.1"
+    "@esbuild/darwin-x64" "0.28.1"
+    "@esbuild/freebsd-arm64" "0.28.1"
+    "@esbuild/freebsd-x64" "0.28.1"
+    "@esbuild/linux-arm" "0.28.1"
+    "@esbuild/linux-arm64" "0.28.1"
+    "@esbuild/linux-ia32" "0.28.1"
+    "@esbuild/linux-loong64" "0.28.1"
+    "@esbuild/linux-mips64el" "0.28.1"
+    "@esbuild/linux-ppc64" "0.28.1"
+    "@esbuild/linux-riscv64" "0.28.1"
+    "@esbuild/linux-s390x" "0.28.1"
+    "@esbuild/linux-x64" "0.28.1"
+    "@esbuild/netbsd-arm64" "0.28.1"
+    "@esbuild/netbsd-x64" "0.28.1"
+    "@esbuild/openbsd-arm64" "0.28.1"
+    "@esbuild/openbsd-x64" "0.28.1"
+    "@esbuild/openharmony-arm64" "0.28.1"
+    "@esbuild/sunos-x64" "0.28.1"
+    "@esbuild/win32-arm64" "0.28.1"
+    "@esbuild/win32-ia32" "0.28.1"
+    "@esbuild/win32-x64" "0.28.1"
+
 escalade@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
@@ -1675,7 +1837,7 @@ fresh@^2.0.0:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
   integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
-fsevents@~2.3.2:
+fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -2791,6 +2953,15 @@ tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.6.3, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tsx@^4.20.5:
+  version "4.23.1"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.23.1.tgz#1703da002ee4432b9a053917431f91462fca235b"
+  integrity sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==
+  dependencies:
+    esbuild "~0.28.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Summary
- Consolidates open PRs #128–#131 into one reviewable change set against current `main`.
- Hardens player-session persistence: clear-epoch guards against post-destroy resurrect, transient Discord fetch handling + Lavalink reconnect restore, suppress clear on ephemeral web teardown, voiceStates-based human count.
- Fixes empty guild-settings rows not being deleted after control-channel unset / download-limit clear (PR #109 regression), with a unified `resolveGuildSettingsDeleteIds` helper.
- Adds the first `yarn test` suite (node:test via tsx) for session parse/guards, settings deletes, WS connect tokens, and bot API private-peer checks.

## Supersedes
Closes / replaces:
- #128 — session destroy/restore races
- #129 — ephemeral web teardown + voice member count
- #130 — regression test coverage + pure helper extraction
- #131 — empty guild-settings delete after cleared fields

## Test plan
- [x] `yarn test` (33 passed)
- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] Smoke: `/control-channel unset` when that is the only guild setting removes the DB row
- [ ] Smoke: failed web search/play does not wipe a persisted crash-recovery session
- [ ] Smoke: Lavalink restart while bot stays up re-restores guilds without live players