### PR TITLE
chore: consolidate Cursor fixes and regression tests (Jul 2026)

### DIFF
--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -16,7 +16,10 @@ import {
     restoreUpcomingQueue,
     snapshotUpcomingQueue,
 } from "../../util/playlistQueue.js"
-import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
+import {
+    acquireGuildPlayerLifecycleReservation,
+    tryDestroyOrphanGuildPlayer,
+} from "../../util/guildPlayerQueueLock.js"
 import { acquirePlayerSessionClearSuppressLease } from "../../util/playerSessionPersistence.js"
 
 export async function playerPlaylistPlayPOST(
@@ -138,77 +141,87 @@ export async function playerPlaylistPlayPOST(
         }
 
         const player = voiceSetup.player
-        const { resolved, failed } = await resolveStoredPlaylistTracks(
-            player,
-            playlist.tracks,
-            requesterPayload
-        )
+        // Cover resolve → enqueue/cleanup so queueEnd idle destroy and concurrent orphan
+        // teardown cannot kill the player while playlist tracks are still resolving.
+        const lifecycleReservation = await acquireGuildPlayerLifecycleReservation(guildId)
+        try {
+            const { resolved, failed } = await resolveStoredPlaylistTracks(
+                player,
+                playlist.tracks,
+                requesterPayload
+            )
 
-        if (resolved.length === 0) {
-            // Serialize emptiness check + destroy with enqueue so a concurrent queue add cannot
-            // land between the check and teardown.
-            await withGuildPlayerQueueLock(guildId, async () => {
-                if (playerHasQueueContent(player)) return
-                const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
-                await client.lavalink.destroyPlayer(guildId).catch(() => {
-                    // Release only this attempt's lease; clearPlayerSession consumes on success.
-                    suppressLease.release()
+            if (resolved.length === 0) {
+                await tryDestroyOrphanGuildPlayer(guildId, {
+                    hasQueueContent: () => {
+                        const live = client.lavalink.getPlayer(guildId) ?? player
+                        return playerHasQueueContent(live)
+                    },
+                    destroyPlayer: async () => {
+                        const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
+                        await client.lavalink.destroyPlayer(guildId).catch(() => {
+                            // Release only this attempt's lease; clearPlayerSession consumes on success.
+                            suppressLease.release()
+                        })
+                    },
                 })
-            })
+                return {
+                    status: 404,
+                    body: {
+                        ok: false,
+                        error: {
+                            error: "No matches found.",
+                            details: "Could not resolve any tracks from this playlist.",
+                        },
+                    },
+                }
+            }
+
+            const savedUpcoming = snapshotUpcomingQueue(player)
+            let enqueue: EnqueuePlaylistResult
+            try {
+                await clearUpcomingQueue(player)
+                enqueue = await enqueueResolvedPlaylistTracks(
+                    player,
+                    resolved,
+                    requester.requesterId,
+                    shuffle
+                )
+            } catch (enqueueErr: unknown) {
+                try {
+                    await restoreUpcomingQueue(player, savedUpcoming)
+                } catch (restoreErr: unknown) {
+                    const restoreMessage =
+                        restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
+                    console.error(
+                        "[playerPlaylistPlayPOST] failed to restore queue after enqueue error",
+                        {
+                            guildId,
+                            restoreMessage,
+                        }
+                    )
+                }
+                throw enqueueErr
+            }
+
+            const state = await toPlayerStateResponse(guildId, requester.requesterId, player)
+
             return {
-                status: 404,
+                status: 200,
                 body: {
-                    ok: false,
-                    error: {
-                        error: "No matches found.",
-                        details: "Could not resolve any tracks from this playlist.",
+                    ok: true,
+                    data: {
+                        state,
+                        playlistId: playlist.id,
+                        playlistName: playlist.name,
+                        queued: enqueue.queued,
+                        failed,
+                        shuffle,
                     },
                 },
             }
-        }
-
-        const savedUpcoming = snapshotUpcomingQueue(player)
-        let enqueue: EnqueuePlaylistResult
-        try {
-            await clearUpcomingQueue(player)
-            enqueue = await enqueueResolvedPlaylistTracks(
-                player,
-                resolved,
-                requester.requesterId,
-                shuffle
-            )
-        } catch (enqueueErr: unknown) {
-            try {
-                await restoreUpcomingQueue(player, savedUpcoming)
-            } catch (restoreErr: unknown) {
-                const restoreMessage =
-                    restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
-                console.error(
-                    "[playerPlaylistPlayPOST] failed to restore queue after enqueue error",
-                    {
-                        guildId,
-                        restoreMessage,
-                    }
-                )
-            }
-            throw enqueueErr
-        }
-
-        const state = await toPlayerStateResponse(guildId, requester.requesterId, player)
-
-        return {
-            status: 200,
-            body: {
-                ok: true,
-                data: {
-                    state,
-                    playlistId: playlist.id,
-                    playlistName: playlist.name,
-                    queued: enqueue.queued,
-                    failed,
-                    shuffle,
-                },
-            },
+        } finally {
+            lifecycleReservation.release()
         }
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -8,13 +8,10 @@ import { toPlayerStateResponse } from "../../shared/player-state.js"
 import { getPlaylistById } from "../../repositories/playlistRepository.js"
 import { searchAndEnqueue } from "./searchAndEnqueue.js"
 import {
-    clearUpcomingQueue,
-    enqueueResolvedPlaylistTracks,
     type EnqueuePlaylistResult,
     playerHasQueueContent,
+    replaceUpcomingWithResolvedPlaylistTracks,
     resolveStoredPlaylistTracks,
-    restoreUpcomingQueue,
-    snapshotUpcomingQueue,
 } from "../../util/playlistQueue.js"
 import {
     acquireGuildPlayerLifecycleReservation,
@@ -177,32 +174,14 @@ export async function playerPlaylistPlayPOST(
                 }
             }
 
-            const savedUpcoming = snapshotUpcomingQueue(player)
-            let enqueue: EnqueuePlaylistResult
-            try {
-                await clearUpcomingQueue(player)
-                enqueue = await enqueueResolvedPlaylistTracks(
-                    player,
-                    resolved,
-                    requester.requesterId,
-                    shuffle
-                )
-            } catch (enqueueErr: unknown) {
-                try {
-                    await restoreUpcomingQueue(player, savedUpcoming)
-                } catch (restoreErr: unknown) {
-                    const restoreMessage =
-                        restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
-                    console.error(
-                        "[playerPlaylistPlayPOST] failed to restore queue after enqueue error",
-                        {
-                            guildId,
-                            restoreMessage,
-                        }
-                    )
-                }
-                throw enqueueErr
-            }
+            // Clear + enqueue must share one guild lock so a concurrent queue POST cannot
+            // succeed then be wiped by clearUpcoming between unlocked clear and locked add.
+            const enqueue: EnqueuePlaylistResult = await replaceUpcomingWithResolvedPlaylistTracks(
+                player,
+                resolved,
+                requester.requesterId,
+                shuffle
+            )
 
             const state = await toPlayerStateResponse(guildId, requester.requesterId, player)
 

--- a/src/botApi/handlers/queue.ts
+++ b/src/botApi/handlers/queue.ts
@@ -8,6 +8,7 @@ import { toQueueResponse } from "../../shared/player-state.js"
 import { playerBroadcaster } from "../../shared/websocket/PlayerBroadcaster.js"
 import { searchAndEnqueue } from "./searchAndEnqueue.js"
 import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
 
 const MAX_QUEUE_PAGE_LIMIT = 100
 
@@ -124,8 +125,15 @@ export async function queueDELETE(
     const player = getBotClient().lavalink.getPlayer(guildId)
     try {
         if (player) {
-            await player.queue.splice(0, player.queue.tracks.length)
-            schedulePlayerSessionSave(player)
+            // Serialize with searchAndEnqueue / playlist replace / reorder so clear cannot
+            // interleave with a remove+insert reorder (resurrecting a cleared track).
+            await withGuildPlayerQueueLock(guildId, async () => {
+                const size = player.queue.tracks.length
+                if (size > 0) {
+                    await player.queue.splice(0, size)
+                }
+                schedulePlayerSessionSave(player)
+            })
             playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
         }
         return {

--- a/src/botApi/handlers/queueIndex.ts
+++ b/src/botApi/handlers/queueIndex.ts
@@ -6,6 +6,7 @@ import { getBotClient, tryGetBotClient } from "../../lib/botClientRegistry.js"
 import { toQueueResponse } from "../../shared/player-state.js"
 import { playerBroadcaster } from "../../shared/websocket/PlayerBroadcaster.js"
 import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
 
 function parseIndex(value: string): number | null {
     const index = Number(value)
@@ -41,15 +42,28 @@ export async function queueIndexDELETE(
         }
 
         const player = getBotClient().lavalink.getPlayer(guildId)
-        if (!player || queueIndex >= player.queue.tracks.length) {
+        if (!player) {
+            return {
+                status: 404,
+                body: { ok: false, error: { error: "No active player for this guild." } },
+            }
+        }
+
+        const removeResult = await withGuildPlayerQueueLock(guildId, async () => {
+            if (queueIndex >= player.queue.tracks.length) {
+                return { ok: false as const }
+            }
+            await player.queue.splice(queueIndex, 1)
+            schedulePlayerSessionSave(player)
+            return { ok: true as const }
+        })
+        if (!removeResult.ok) {
             return {
                 status: 404,
                 body: { ok: false, error: { error: "Queue index out of range." } },
             }
         }
 
-        await player.queue.splice(queueIndex, 1)
-        schedulePlayerSessionSave(player)
         playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
         return {
             status: 200,
@@ -118,53 +132,64 @@ export async function queueIndexPATCH(
             }
         }
 
-        const trackCount = player.queue.tracks.length
-        if (sourceIndex >= trackCount || destinationIndex >= trackCount) {
+        const reorderResult = await withGuildPlayerQueueLock(guildId, async () => {
+            const trackCount = player.queue.tracks.length
+            if (sourceIndex >= trackCount || destinationIndex >= trackCount) {
+                return { ok: false as const, error: "Queue index out of range." }
+            }
+
+            const [track] = await player.queue.splice(sourceIndex, 1)
+            if (!track) {
+                return { ok: false as const, error: "Queue index out of range." }
+            }
+            const insertIndexRaw = destinationIndex
+            const lenAfterRemove = player.queue.tracks.length
+            const insertIndex = Math.min(Math.max(insertIndexRaw, 0), lenAfterRemove)
+            try {
+                await player.queue.splice(insertIndex, 0, track)
+            } catch (insertErr: unknown) {
+                try {
+                    await player.queue.splice(sourceIndex, 0, track)
+                } catch (restoreErr: unknown) {
+                    const restoreMessage =
+                        restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
+                    const client = tryGetBotClient()
+                    if (client) {
+                        client.error(
+                            "[queueIndexPATCH] failed to restore track after reorder error",
+                            {
+                                guildId,
+                                sourceIndex,
+                                restoreMessage,
+                                insertErr,
+                            }
+                        )
+                    } else {
+                        console.error(
+                            "[queueIndexPATCH] failed to restore track after reorder error",
+                            {
+                                guildId,
+                                sourceIndex,
+                                restoreMessage,
+                                insertErr,
+                            }
+                        )
+                    }
+                }
+                throw insertErr
+            }
+            schedulePlayerSessionSave(player)
+            return { ok: true as const }
+        })
+
+        if (!reorderResult.ok) {
             return {
                 status: 404,
-                body: { ok: false, error: { error: "Queue index out of range." } },
+                body: { ok: false, error: { error: reorderResult.error } },
             }
         }
 
-        const [track] = await player.queue.splice(sourceIndex, 1)
-        if (!track) {
-            return {
-                status: 404,
-                body: { ok: false, error: { error: "Queue index out of range." } },
-            }
-        }
-        const insertIndexRaw = destinationIndex
-        const lenAfterRemove = player.queue.tracks.length
-        const insertIndex = Math.min(Math.max(insertIndexRaw, 0), lenAfterRemove)
-        try {
-            await player.queue.splice(insertIndex, 0, track)
-        } catch (insertErr: unknown) {
-            try {
-                await player.queue.splice(sourceIndex, 0, track)
-            } catch (restoreErr: unknown) {
-                const restoreMessage =
-                    restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
-                const client = tryGetBotClient()
-                if (client) {
-                    client.error("[queueIndexPATCH] failed to restore track after reorder error", {
-                        guildId,
-                        sourceIndex,
-                        restoreMessage,
-                        insertErr,
-                    })
-                } else {
-                    console.error("[queueIndexPATCH] failed to restore track after reorder error", {
-                        guildId,
-                        sourceIndex,
-                        restoreMessage,
-                        insertErr,
-                    })
-                }
-            }
-            throw insertErr
-        }
         playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
-        schedulePlayerSessionSave(player)
 
         return {
             status: 200,

--- a/src/commands/admin/Discord-Logs.ts
+++ b/src/commands/admin/Discord-Logs.ts
@@ -134,7 +134,9 @@ function formatConfig(cfg: GuildDiscordLogSettings): string {
 export default {
     data: new SlashCommandBuilder()
         .setName("discord-logs")
-        .setDescription("Configure Discord channels for bot log forwarding in this server.")
+        .setDescription(
+            "Configure Discord channels for guild-scoped bot log forwarding in this server."
+        )
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
         .setDMPermission(false)
         .addSubcommand((sub) =>

--- a/src/commands/admin/Discord-Logs.ts
+++ b/src/commands/admin/Discord-Logs.ts
@@ -82,10 +82,7 @@ function storeWithGuildRow(
 }
 
 /** Guild keys removed from the store map (explicit DB deletes — not inferred from stale snapshots). */
-function guildIdsRemovedFromStore(
-    before: GuildSettingsStore,
-    after: GuildSettingsStore
-): string[] {
+function guildIdsRemovedFromStore(before: GuildSettingsStore, after: GuildSettingsStore): string[] {
     return Object.keys(before).filter((id) => !(id in after))
 }
 

--- a/src/commands/music/ClearQueue.ts
+++ b/src/commands/music/ClearQueue.ts
@@ -2,6 +2,8 @@ import { SlashCommandBuilder } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
+import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -80,14 +82,25 @@ export default {
         }
 
         try {
-            const queueSize = player.queue.tracks.length
-            client.debug(
-                `[ClearQueue] Clearing queue for guild ${guild.id}. Current size: ${queueSize}`
-            )
+            const cleared = await withGuildPlayerQueueLock(guild.id, async () => {
+                const queueSize = player.queue.tracks.length
+                if (queueSize === 0) return 0
+                client.debug(
+                    `[ClearQueue] Clearing queue for guild ${guild.id}. Current size: ${queueSize}`
+                )
+                await player.queue.splice(0, queueSize)
+                schedulePlayerSessionSave(player)
+                return queueSize
+            })
 
-            await player.queue.splice(0, queueSize)
+            if (cleared === 0) {
+                return interaction.reply({
+                    content: "The queue is already empty.",
+                    ephemeral: true,
+                })
+            }
 
-            await interaction.reply({ content: `Cleared ${queueSize} tracks from the queue.` })
+            await interaction.reply({ content: `Cleared ${cleared} tracks from the queue.` })
             client.debug(`[ClearQueue] Successfully cleared queue for guild ${guild.id}`)
         } catch (error) {
             client.error("[ClearQueue] Error clearing the queue:", error)

--- a/src/commands/music/Leave.ts
+++ b/src/commands/music/Leave.ts
@@ -2,6 +2,7 @@ import { SlashCommandBuilder, type Message } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import { memberMayControlPlayerVoice } from "../../util/sameVoiceChannel.js"
 
 const DELETE_REPLY_DELAY_MS = 1000 * 10
 const DELETE_REPLY_RETRY_MS = 2000
@@ -43,13 +44,13 @@ export default {
         const voiceChannel = member.voice.channel
         if (!voiceChannel) {
             client.debug("Leave command failed: User not in a voice channel")
-            return interaction.reply({ content: "Join a voice channel first!" })
+            return interaction.reply({
+                content: "Join a voice channel first!",
+                ephemeral: true,
+            })
         }
 
         client.debug(`User ${interaction.user.tag} is in voice channel ${voiceChannel.id}`)
-
-        await interaction.deferReply()
-        client.debug("Leave command deferred reply")
 
         const player = client.lavalink.players.get(guild.id)
 
@@ -61,6 +62,13 @@ export default {
             // Optional: Check if the bot *thinks* it's in a channel anyway (e.g., after a crash)
             const botVoiceState = guild.members.me?.voice
             if (botVoiceState?.channel) {
+                if (!memberMayControlPlayerVoice(botVoiceState.channel.id, voiceChannel.id)) {
+                    return interaction.reply({
+                        content: "You need to be in the same voice channel as the bot!",
+                        ephemeral: true,
+                    })
+                }
+                await interaction.deferReply()
                 client.debug(
                     `Bot is in voice channel ${botVoiceState.channel.id}. Attempting to leave.`
                 )
@@ -81,10 +89,23 @@ export default {
                 }
             } else {
                 client.debug("Bot is not in a voice channel. Replying 'nothing to leave'.")
-                await interaction.editReply("I'm not in a voice channel!")
+                await interaction.reply({
+                    content: "I'm not in a voice channel!",
+                    ephemeral: true,
+                })
             }
             return
         }
+
+        if (!memberMayControlPlayerVoice(player.voiceChannelId, voiceChannel.id)) {
+            return interaction.reply({
+                content: "You need to be in the same voice channel as the bot!",
+                ephemeral: true,
+            })
+        }
+
+        await interaction.deferReply()
+        client.debug("Leave command deferred reply")
 
         client.debug(
             `Found player for guild ${guild.id}. Connected: ${player.connected}, Playing: ${player.playing}`

--- a/src/commands/music/PlayNext.ts
+++ b/src/commands/music/PlayNext.ts
@@ -4,9 +4,11 @@ import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
 import {
     isRRQActive,
-    rebalancePlayerQueueRoundRobin,
+    rebalancePlayerQueueRoundRobinAssumingLock,
     stampRequesterUserIdOnTracks,
 } from "../../util/rrqDisconnect.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
+import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -70,10 +72,13 @@ export default {
 
         const track = res.tracks[0]
         stampRequesterUserIdOnTracks([track], interaction.user.id)
-        player.queue.add(track, 0)
-        if (isRRQActive(player)) {
-            await rebalancePlayerQueueRoundRobin(player)
-        }
+        await withGuildPlayerQueueLock(guild.id, async () => {
+            player.queue.add(track, 0)
+            if (isRRQActive(player)) {
+                await rebalancePlayerQueueRoundRobinAssumingLock(player)
+            }
+            schedulePlayerSessionSave(player)
+        })
         return interaction.editReply(
             `Added [${track.info.title}](${track.info.uri}) to the top of the queue.`
         )

--- a/src/commands/music/Seek.ts
+++ b/src/commands/music/Seek.ts
@@ -43,6 +43,13 @@ export default {
             return interaction.reply({ content: "Nothing is playing.", ephemeral: true })
         }
 
+        if (player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
+            return interaction.reply({
+                content: "You need to be in the same voice channel as the bot!",
+                ephemeral: true,
+            })
+        }
+
         const current = player.queue.current
 
         const durationMs = current.info.duration ?? 0

--- a/src/commands/music/Shuffle.ts
+++ b/src/commands/music/Shuffle.ts
@@ -2,6 +2,8 @@ import { SlashCommandBuilder } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
+import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
 
 export default {
     data: new SlashCommandBuilder().setName("shuffle").setDescription("Shuffle the current queue"),
@@ -47,7 +49,11 @@ export default {
             })
         }
 
-        await player.queue.shuffle()
+        await withGuildPlayerQueueLock(guild.id, async () => {
+            if (player.queue.tracks.length < 2) return
+            await player.queue.shuffle()
+            schedulePlayerSessionSave(player)
+        })
         await interaction.reply("Queue shuffled.")
     },
 }

--- a/src/commands/music/Stop.ts
+++ b/src/commands/music/Stop.ts
@@ -2,7 +2,9 @@ import { SlashCommandBuilder } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction, Message } from "discord.js"
 import { discordDeleteErrorDetails } from "../../util/discordErrorDetails.js"
+import { guildMemberFromInteraction } from "../../util/guildMember.js"
 import { stopLocalPlayer, getLocalPlayerState } from "../../util/localPlayer.js"
+import { memberMayControlPlayerVoice } from "../../util/sameVoiceChannel.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -14,6 +16,34 @@ export default {
         if (!guild) {
             return interaction.reply({
                 content: "Use this command in a server.",
+                ephemeral: true,
+            })
+        }
+
+        const member = guildMemberFromInteraction(interaction)
+        if (!member) {
+            return interaction.reply({
+                content: "Could not resolve your member profile. Try again.",
+                ephemeral: true,
+            })
+        }
+
+        const voiceChannel = member.voice.channel
+        if (!voiceChannel) {
+            return interaction.reply({
+                content: "Join a voice channel first!",
+                ephemeral: true,
+            })
+        }
+
+        // Require same VC so remote /stop cannot wipe another channel's player session.
+        const lavalinkPlayer = client.lavalink.players.get(guild.id)
+        if (
+            lavalinkPlayer &&
+            !memberMayControlPlayerVoice(lavalinkPlayer.voiceChannelId, voiceChannel.id)
+        ) {
+            return interaction.reply({
+                content: "You need to be in the same voice channel as the bot!",
                 ephemeral: true,
             })
         }
@@ -32,8 +62,6 @@ export default {
             }
         }
 
-        // Attempt to stop Lavalink player
-        const lavalinkPlayer = client.lavalink.players.get(guild.id)
         if (lavalinkPlayer) {
             // Check if it was actually doing something or had a queue
             if (

--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -25,6 +25,15 @@ const MAX_FILE_AGE_DAYS = 7
 // Maximum total size of downloads directory in MB (default fallback)
 const DEFAULT_MAX_DIR_SIZE_MB = 1000
 
+/** Wall-clock limit for a single yt-dlp run (live / very long media). */
+const DOWNLOAD_PROCESS_TIMEOUT_MS = 10 * 60 * 1000
+
+/**
+ * Rough upper bound on WAV output (~10 MiB/min for 16-bit 44.1kHz stereo).
+ * Used only for yt-dlp duration filtering before download starts.
+ */
+const APPROX_WAV_MIB_PER_MINUTE = 10
+
 /**
  * Resolves the configured downloads size limit for a guild.
  * @param {import('../../lib/BotClient.js').default} client The bot client instance.
@@ -38,6 +47,23 @@ function getMaxDirSizeMb(client: BotClient, guildId: string) {
     const parsed = Number.parseFloat(String(configured ?? ""))
     if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_MAX_DIR_SIZE_MB
     return parsed
+}
+
+/** Max accepted on-disk size for one download (guild quota, in bytes). */
+function getMaxDownloadBytes(maxDirSizeMb: number): number {
+    return Math.max(1, maxDirSizeMb) * 1024 * 1024
+}
+
+/**
+ * yt-dlp match-filter: reject live streams and media whose estimated WAV size
+ * would exceed the guild downloads quota.
+ */
+function buildYtDlpMatchFilter(maxDirSizeMb: number): string {
+    const maxDurationSec = Math.max(
+        60,
+        Math.floor((maxDirSizeMb / APPROX_WAV_MIB_PER_MINUTE) * 60)
+    )
+    return `!is_live & duration <= ${maxDurationSec}`
 }
 
 /**
@@ -368,6 +394,8 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
 
         // Download the video
         await updateReply("Downloading audio... This can take a moment.", true)
+        const maxDownloadBytes = getMaxDownloadBytes(maxDirSizeMb)
+        const matchFilter = buildYtDlpMatchFilter(maxDirSizeMb)
         let downloadProcess: ReturnType<typeof spawn>
         try {
             downloadProcess = spawn("yt-dlp", [
@@ -382,6 +410,11 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                 "--newline",
                 "--print",
                 "after_move:filepath",
+                // Source media size cap (WAV output can still be larger; post-check below).
+                "--max-filesize",
+                `${maxDirSizeMb}M`,
+                "--match-filter",
+                matchFilter,
                 "-o",
                 `${downloadsDir}/${downloadFilePrefix}%(title)s.%(ext)s`,
             ])
@@ -400,6 +433,21 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
             )
             return
         }
+
+        let timedOut = false
+        const killTimer = setTimeout(() => {
+            timedOut = true
+            client.error(
+                `[Download] yt-dlp exceeded ${DOWNLOAD_PROCESS_TIMEOUT_MS}ms; killing process`
+            )
+            try {
+                downloadProcess.kill("SIGKILL")
+            } catch (killErr: unknown) {
+                client.error("[Download] Failed to kill timed-out yt-dlp:", killErr)
+            }
+        }, DOWNLOAD_PROCESS_TIMEOUT_MS)
+        downloadProcess.on("close", () => clearTimeout(killTimer))
+        downloadProcess.on("error", () => clearTimeout(killTimer))
 
         downloadProcess.on("error", (err: Error) => {
             client.error("[Download] Failed to start yt-dlp", err)
@@ -461,10 +509,24 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
 
         downloadProcess.on("close", async (code: number | null) => {
             try {
+                if (timedOut) {
+                    await interaction
+                        .editReply({
+                            content:
+                                "Download timed out. Try a shorter video, or contact an admin if this keeps happening.",
+                        })
+                        .catch((e: unknown) =>
+                            client.error("Failed to edit reply on download timeout", e)
+                        )
+                    return
+                }
                 if (code !== 0) {
                     client.error(`[Download] yt-dlp process exited with code ${code}`)
                     await interaction
-                        .editReply({ content: "Error downloading video. Please try again later." })
+                        .editReply({
+                            content:
+                                "Error downloading video. It may be too long, live, or otherwise rejected by size limits. Try a shorter YouTube URL.",
+                        })
                         .catch((e: unknown) =>
                             client.error("Failed to edit reply on download error", e)
                         )
@@ -522,6 +584,43 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                         )
                         .catch((e: unknown) =>
                             client.error("Failed to edit reply on file not found", e)
+                        )
+                    return
+                }
+
+                // Refuse to retain a single file larger than the guild quota. Previously the new
+                // file was "protected" during size cleanup, so an oversized WAV wiped other guild
+                // downloads while remaining on disk above the configured limit.
+                let downloadedStats: fs.Stats
+                try {
+                    downloadedStats = fs.statSync(filePath)
+                } catch (statErr: unknown) {
+                    client.error("[Download] Failed to stat downloaded file:", statErr)
+                    await interaction
+                        .editReply({
+                            content:
+                                "Download finished but the file could not be verified. Please try again.",
+                        })
+                        .catch((e: unknown) =>
+                            client.error("Failed to edit reply on download stat failure", e)
+                        )
+                    return
+                }
+                if (downloadedStats.size > maxDownloadBytes) {
+                    client.error(
+                        `[Download] Rejecting oversized file ${downloadedFile} (${downloadedStats.size} bytes > ${maxDownloadBytes} byte guild limit)`
+                    )
+                    try {
+                        fs.unlinkSync(filePath)
+                    } catch (unlinkErr: unknown) {
+                        client.error("[Download] Failed to unlink oversized download:", unlinkErr)
+                    }
+                    await interaction
+                        .editReply({
+                            content: `Download rejected: the resulting file exceeds this server's download limit (${maxDirSizeMb}MB). Try a shorter video.`,
+                        })
+                        .catch((e: unknown) =>
+                            client.error("Failed to edit reply on oversized download", e)
                         )
                     return
                 }

--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -664,6 +664,24 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                     )
                 }
 
+                const savedBaseName = downloadedFile.replace(/\.wav$/i, "")
+
+                // Auto-play only from the bot's current voice channel. Otherwise Play Local /
+                // ensurePlayerConnected would destroy the active session and move the bot.
+                const existingPlayer = client.lavalink.getPlayer(guildId)
+                const botVoiceChannelId = guild.members.me?.voice.channel?.id ?? null
+                const playerVoiceChannelId = existingPlayer?.voiceChannelId ?? null
+                const occupiedVoiceChannelId = playerVoiceChannelId || botVoiceChannelId
+                if (occupiedVoiceChannelId && occupiedVoiceChannelId !== voiceChannel.id) {
+                    await interaction.editReply({
+                        content:
+                            `Saved as **${savedBaseName}**.\n` +
+                            `You need to be in the same voice channel as the bot to auto-play.\n` +
+                            `Use \`/play ${savedBaseName}\` from that channel when ready.`,
+                    })
+                    return
+                }
+
                 // Auto-play logic using handleQueryAndPlay
                 try {
                     await updateReply("Attempting to play the downloaded track...", true)
@@ -687,6 +705,17 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                     if (!player) {
                         await interaction.editReply({
                             content: "Could not start the music player.",
+                        })
+                        return
+                    }
+
+                    // Re-check after createPlayer: refuse to move an already-bound player.
+                    if (player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
+                        await interaction.editReply({
+                            content:
+                                `Saved as **${savedBaseName}**.\n` +
+                                `You need to be in the same voice channel as the bot to auto-play.\n` +
+                                `Use \`/play ${savedBaseName}\` from that channel when ready.`,
                         })
                         return
                     }

--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -59,10 +59,7 @@ function getMaxDownloadBytes(maxDirSizeMb: number): number {
  * would exceed the guild downloads quota.
  */
 function buildYtDlpMatchFilter(maxDirSizeMb: number): string {
-    const maxDurationSec = Math.max(
-        60,
-        Math.floor((maxDirSizeMb / APPROX_WAV_MIB_PER_MINUTE) * 60)
-    )
+    const maxDurationSec = Math.max(60, Math.floor((maxDirSizeMb / APPROX_WAV_MIB_PER_MINUTE) * 60))
     return `!is_live & duration <= ${maxDurationSec}`
 }
 

--- a/src/commands/user/downloads.ts
+++ b/src/commands/user/downloads.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder } from "discord.js"
+import { PermissionFlagsBits, SlashCommandBuilder } from "discord.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import fs from "fs"
 import { promises as fsp } from "fs"
@@ -71,7 +71,7 @@ const data = new SlashCommandBuilder()
     .addSubcommand((subcommand) =>
         subcommand
             .setName("cleanup")
-            .setDescription("Remove old downloaded files")
+            .setDescription("Remove old downloaded files (requires Manage Server)")
             .addIntegerOption((option) =>
                 option
                     .setName("days")
@@ -229,6 +229,15 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
         }
 
         if (subcommand === "cleanup") {
+            // Runtime check: DefaultMemberPermissions cannot be set per-subcommand, and list stays
+            // available to members. Cleanup deletes guild download files and must require Manage Guild.
+            if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+                return interaction.reply({
+                    ephemeral: true,
+                    content:
+                        "You need the **Manage Server** permission to clean up downloaded files.",
+                })
+            }
             const removeAll = interaction.options.getBoolean("all") || false
             const daysOpt = interaction.options.getInteger("days")
             const days = daysOpt === null ? 7 : daysOpt

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -36,7 +36,9 @@ import {
 } from "../util/rrqDisconnect.js"
 import { playerBroadcaster } from "../shared/websocket/PlayerBroadcaster.js"
 import { clearPlayerSession, schedulePlayerSessionSave } from "../util/playerSessionPersistence.js"
+import { tryDestroyOrphanGuildPlayer } from "../util/guildPlayerQueueLock.js"
 import { countHumanMembers } from "../util/voiceChannelMembers.js"
+import { playerHasQueueContent } from "../util/playlistQueue.js"
 
 /** Rate-limit `queueUpdate` websocket fan-out on Lavalink position ticks (pause/resume still immediate). */
 const lastQueueUpdateBroadcastAtMs = new Map<string, number>()
@@ -383,25 +385,42 @@ export default async (client: BotClient) => {
                     )
             }
 
-            // Standard player destroy timeout
+            // Standard player destroy timeout — reservation-aware so in-flight search/enqueue
+            // (web dashboard) is not torn down mid-request when the queue just ended.
             client.debug(
                 `[LavaMgrEvents] Setting standard timeout to destroy player ${player.guildId} after queue end.`
             )
+            const queueEndGuildId = player.guildId
             setTimeout(() => {
                 void (async () => {
                     client.debug(
-                        `[LavaMgrEvents] Executing standard queue end timeout check for player ${player.guildId}.`
+                        `[LavaMgrEvents] Executing standard queue end timeout check for player ${queueEndGuildId}.`
                     )
-                    if (player && player.queue.tracks.length === 0 && !player.queue.current) {
-                        client.debug(
-                            `[LavaMgrEvents] Player ${player.guildId} is idle, destroying after queue end timeout.`
-                        )
-                        await player.destroy()
-                    } else {
-                        client.debug(
-                            `[LavaMgrEvents] Player ${player.guildId} has new tracks or state changed, not destroying after standard timeout. Player: ${!!player}, Queue Size: ${player?.queue.tracks.length}, Current: ${!!player?.queue.current}`
-                        )
-                    }
+                    await tryDestroyOrphanGuildPlayer(
+                        queueEndGuildId,
+                        {
+                            hasQueueContent: () => {
+                                const live = client.lavalink.getPlayer(queueEndGuildId)
+                                // Already gone — treat as "has content" so we do not re-destroy.
+                                if (!live) return true
+                                return playerHasQueueContent(live)
+                            },
+                            destroyPlayer: async () => {
+                                const live = client.lavalink.getPlayer(queueEndGuildId)
+                                if (!live || playerHasQueueContent(live)) {
+                                    client.debug(
+                                        `[LavaMgrEvents] Player ${queueEndGuildId} has new tracks or state changed, not destroying after standard timeout.`
+                                    )
+                                    return
+                                }
+                                client.debug(
+                                    `[LavaMgrEvents] Player ${queueEndGuildId} is idle, destroying after queue end timeout.`
+                                )
+                                await live.destroy()
+                            },
+                        },
+                        0
+                    )
                 })()
             }, 5000)
         })

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -35,7 +35,11 @@ import {
     userHasQueuedTracks,
 } from "../util/rrqDisconnect.js"
 import { playerBroadcaster } from "../shared/websocket/PlayerBroadcaster.js"
-import { clearPlayerSession, schedulePlayerSessionSave } from "../util/playerSessionPersistence.js"
+import {
+    clearPlayerSession,
+    schedulePlayerSessionSave,
+    shouldClearPlayerSessionOnDestroy,
+} from "../util/playerSessionPersistence.js"
 import { tryDestroyOrphanGuildPlayer } from "../util/guildPlayerQueueLock.js"
 import { countHumanMembers } from "../util/voiceChannelMembers.js"
 import { playerHasQueueContent } from "../util/playlistQueue.js"
@@ -118,12 +122,18 @@ export default async (client: BotClient) => {
             )
             lastQueueUpdateBroadcastAtMs.delete(player.guildId)
             player.set(DASHBOARD_REQUESTER_KEY, undefined)
-            void clearPlayerSession(player.guildId).catch((err: unknown) => {
-                const msg = err instanceof Error ? err.message : String(err)
-                client.error(
-                    `[LavaMgrEvents] clearPlayerSession failed (guildId=${player.guildId}): ${msg}`
+            if (shouldClearPlayerSessionOnDestroy(reason)) {
+                void clearPlayerSession(player.guildId).catch((err: unknown) => {
+                    const msg = err instanceof Error ? err.message : String(err)
+                    client.error(
+                        `[LavaMgrEvents] clearPlayerSession failed (guildId=${player.guildId}): ${msg}`
+                    )
+                })
+            } else {
+                client.debug(
+                    `[LavaMgrEvents] Preserving player session for guild ${player.guildId} after destroy reason: ${String(reason)}`
                 )
-            })
+            }
             scheduleControlMessageUpdate(client, player.guildId, "playerDestroy")
             playerBroadcaster.broadcastPlayerEvent(player.guildId, null, "playerDestroy")
         })

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -43,6 +43,7 @@ import {
 import { tryDestroyOrphanGuildPlayer } from "../util/guildPlayerQueueLock.js"
 import { countHumanMembers } from "../util/voiceChannelMembers.js"
 import { playerHasQueueContent } from "../util/playlistQueue.js"
+import { skipCurrentTrack } from "../util/skipCurrentTrack.js"
 
 /** Rate-limit `queueUpdate` websocket fan-out on Lavalink position ticks (pause/resume still immediate). */
 const lastQueueUpdateBroadcastAtMs = new Map<string, number>()
@@ -275,7 +276,15 @@ export default async (client: BotClient) => {
             client.debug(
                 `[LavaMgrEvents] Attempting to skip stuck track in guild ${player.guildId}.`
             )
-            await player.skip()
+            try {
+                // Default skip() throws when upcoming queue is empty (e.g. last/autoplay track).
+                await skipCurrentTrack(player)
+            } catch (e: unknown) {
+                client.error(
+                    `[LavaMgrEvents] Failed to skip stuck track in guild ${player.guildId}:`,
+                    e
+                )
+            }
         })
         .on(
             "trackError",

--- a/src/lib/LavalinkManager.ts
+++ b/src/lib/LavalinkManager.ts
@@ -408,6 +408,19 @@ export default function createLavalinkManager(client: BotClient): LavalinkManage
             fallbackSearchEngine: "youtube",
         },
         playerOptions: {
+            // Default destroyPlayer:true wipes persisted sessions on Discord voice drops
+            // (admin Disconnect, voice-server blips). Reconnect instead; failed reconnect
+            // still destroys with PlayerReconnectFail, which we preserve in playerDestroy.
+            onDisconnect: {
+                destroyPlayer: false,
+                autoReconnect: true,
+            },
+            // Default (3 errors / 35s) destroys the whole player before our trackError
+            // handler can skip — clearing the queue and session. threshold 0 disables.
+            maxErrorsPerTime: {
+                threshold: 0,
+                maxAmount: 0,
+            },
             onEmptyQueue: {
                 autoPlayFunction: async (player: Player, endedTrack: Track | undefined) => {
                     try {

--- a/src/shared/discord-user-id.test.ts
+++ b/src/shared/discord-user-id.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { isDiscordSnowflake } from "./discord-user-id.js"
+
+describe("isDiscordSnowflake", () => {
+    it("accepts typical Discord snowflakes after trim", () => {
+        assert.equal(isDiscordSnowflake("12345678901234567"), true) // 17
+        assert.equal(isDiscordSnowflake("123456789012345678"), true) // 18
+        assert.equal(isDiscordSnowflake("1234567890123456789"), true) // 19
+        assert.equal(isDiscordSnowflake("1234567890123456789012"), true) // 22
+        assert.equal(isDiscordSnowflake("  123456789012345678  "), true)
+    })
+
+    it("rejects too-short, too-long, non-digit, and empty values", () => {
+        assert.equal(isDiscordSnowflake("1234567890123456"), false) // 16
+        assert.equal(isDiscordSnowflake("12345678901234567890123"), false) // 23
+        assert.equal(isDiscordSnowflake("12345678901234567a"), false)
+        assert.equal(isDiscordSnowflake("not-a-snowflake"), false)
+        assert.equal(isDiscordSnowflake(""), false)
+        assert.equal(isDiscordSnowflake("   "), false)
+    })
+})

--- a/src/shared/permissions.test.ts
+++ b/src/shared/permissions.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict"
+import { afterEach, describe, it } from "node:test"
+import {
+    WebPermission,
+    hasRequiredPermissions,
+    invalidatePermissionCache,
+    resolveOauthGuildPermissionFallback,
+    resolveUserPermissions,
+} from "./permissions.js"
+
+type MockVoiceState = { channelId?: string | null; member?: unknown }
+
+/** Minimal Lavalink player shape accepted by `isPlayer` / voice summary. */
+function mockLavalinkPlayer(voiceChannelId: string | null, guildId = "guild-1") {
+    return {
+        guildId,
+        voiceChannelId,
+        playing: false,
+        queue: { tracks: [] as unknown[] },
+        get: () => undefined,
+    }
+}
+
+function mockPermissionClient(opts: {
+    guildId: string
+    ownerId?: string
+    voiceStates?: Map<string, MockVoiceState>
+    /** When set (including null), returned from lavalink.getPlayer as an isPlayer-shaped object. */
+    playerVoiceChannelId?: string | null
+    meVoiceChannelId?: string | null
+    memberFetch?: (userId: string) => Promise<unknown>
+}) {
+    const voiceStates = opts.voiceStates ?? new Map<string, MockVoiceState>()
+    return {
+        guilds: {
+            cache: new Map([
+                [
+                    opts.guildId,
+                    {
+                        ownerId: opts.ownerId ?? "owner-1",
+                        voiceStates: { cache: voiceStates },
+                        members: {
+                            me:
+                                opts.meVoiceChannelId !== undefined
+                                    ? { voice: { channelId: opts.meVoiceChannelId } }
+                                    : undefined,
+                            fetch:
+                                opts.memberFetch ??
+                                (async () => {
+                                    return null
+                                }),
+                        },
+                    },
+                ],
+            ]),
+        },
+        lavalink: {
+            getPlayer: (guildId: string) => {
+                if (guildId !== opts.guildId) return null
+                if (opts.playerVoiceChannelId === undefined) return null
+                return mockLavalinkPlayer(opts.playerVoiceChannelId, opts.guildId)
+            },
+        },
+    }
+}
+
+afterEach(() => {
+    invalidatePermissionCache()
+})
+
+describe("hasRequiredPermissions", () => {
+    it("allows empty required lists and rejects missing capabilities", () => {
+        assert.equal(hasRequiredPermissions([], []), true)
+        assert.equal(hasRequiredPermissions([WebPermission.VIEW_PLAYER], []), true)
+        assert.equal(
+            hasRequiredPermissions(
+                [WebPermission.VIEW_PLAYER, WebPermission.MANAGE_QUEUE],
+                [WebPermission.VIEW_PLAYER]
+            ),
+            true
+        )
+        assert.equal(
+            hasRequiredPermissions([WebPermission.VIEW_PLAYER], [WebPermission.CONTROL_PLAYBACK]),
+            false
+        )
+        assert.equal(
+            hasRequiredPermissions(
+                [WebPermission.VIEW_PLAYER],
+                [WebPermission.VIEW_PLAYER, WebPermission.MANAGE_QUEUE]
+            ),
+            false
+        )
+    })
+})
+
+describe("resolveOauthGuildPermissionFallback", () => {
+    const guildId = "guild-1"
+    const userId = "user-1"
+
+    it("grants VIEW_PLAYER only when client or guild is missing", () => {
+        assert.deepEqual(resolveOauthGuildPermissionFallback(null, guildId, userId), {
+            permissions: [WebPermission.VIEW_PLAYER],
+            inVoiceWithBot: false,
+        })
+
+        const client = mockPermissionClient({ guildId: "other-guild" })
+        assert.deepEqual(resolveOauthGuildPermissionFallback(client, guildId, userId), {
+            permissions: [WebPermission.VIEW_PLAYER],
+            inVoiceWithBot: false,
+        })
+    })
+
+    it("keeps queue ability when user is in voice and bot is not", () => {
+        const client = mockPermissionClient({
+            guildId,
+            voiceStates: new Map([[userId, { channelId: "vc-user" }]]),
+            playerVoiceChannelId: null,
+        })
+        const result = resolveOauthGuildPermissionFallback(client, guildId, userId)
+        assert.equal(result.inVoiceWithBot, false)
+        assert.deepEqual(result.permissions, [
+            WebPermission.VIEW_PLAYER,
+            WebPermission.MANAGE_QUEUE,
+        ])
+        assert.equal(result.permissions.includes(WebPermission.CONTROL_PLAYBACK), false)
+        assert.equal(result.permissions.includes(WebPermission.MANAGE_GUILD_SETTINGS), false)
+    })
+
+    it("grants playback and queue when user shares the bot voice channel", () => {
+        const client = mockPermissionClient({
+            guildId,
+            voiceStates: new Map([[userId, { channelId: "vc-1" }]]),
+            playerVoiceChannelId: "vc-1",
+        })
+        const result = resolveOauthGuildPermissionFallback(client, guildId, userId)
+        assert.equal(result.inVoiceWithBot, true)
+        assert.deepEqual(result.permissions, [
+            WebPermission.VIEW_PLAYER,
+            WebPermission.CONTROL_PLAYBACK,
+            WebPermission.MANAGE_QUEUE,
+        ])
+    })
+
+    it("strips voice-gated perms when user is in a different voice channel", () => {
+        const client = mockPermissionClient({
+            guildId,
+            voiceStates: new Map([[userId, { channelId: "vc-other" }]]),
+            playerVoiceChannelId: "vc-1",
+        })
+        const result = resolveOauthGuildPermissionFallback(client, guildId, userId)
+        assert.equal(result.inVoiceWithBot, false)
+        assert.deepEqual(result.permissions, [WebPermission.VIEW_PLAYER])
+    })
+
+    it("strips voice-gated perms when user is not in voice", () => {
+        const client = mockPermissionClient({
+            guildId,
+            voiceStates: new Map(),
+            playerVoiceChannelId: "vc-1",
+        })
+        const result = resolveOauthGuildPermissionFallback(client, guildId, userId)
+        assert.equal(result.inVoiceWithBot, false)
+        assert.deepEqual(result.permissions, [WebPermission.VIEW_PLAYER])
+    })
+})
+
+describe("resolveUserPermissions", () => {
+    const guildId = "guild-1"
+    const ownerId = "owner-1"
+
+    it("returns empty permissions when the guild is not cached", async () => {
+        const client = mockPermissionClient({ guildId: "other" })
+        const result = await resolveUserPermissions(client, guildId, ownerId)
+        assert.deepEqual(result, { permissions: [], inVoiceWithBot: false })
+    })
+
+    it("grants guild-owner capabilities without member fetch", async () => {
+        const client = mockPermissionClient({
+            guildId,
+            ownerId,
+            voiceStates: new Map([[ownerId, { channelId: "vc-1" }]]),
+            playerVoiceChannelId: "vc-1",
+        })
+        const result = await resolveUserPermissions(client, guildId, ownerId)
+        assert.equal(result.inVoiceWithBot, true)
+        assert.deepEqual(result.permissions, [
+            WebPermission.VIEW_PLAYER,
+            WebPermission.CONTROL_PLAYBACK,
+            WebPermission.MANAGE_QUEUE,
+            WebPermission.MANAGE_GUILD_SETTINGS,
+            WebPermission.MANAGE_MESSAGES,
+        ])
+        assert.equal(result.permissions.includes(WebPermission.DEVELOPER_ACCESS), false)
+    })
+
+    it("skips voice gating for dashboard entitlement reads", async () => {
+        const client = mockPermissionClient({
+            guildId,
+            ownerId,
+            voiceStates: new Map(),
+            playerVoiceChannelId: "vc-1",
+        })
+        const result = await resolveUserPermissions(client, guildId, ownerId, {
+            applyVoiceGating: false,
+        })
+        assert.equal(result.inVoiceWithBot, false)
+        assert.deepEqual(result.permissions, [
+            WebPermission.VIEW_PLAYER,
+            WebPermission.CONTROL_PLAYBACK,
+            WebPermission.MANAGE_QUEUE,
+            WebPermission.MANAGE_GUILD_SETTINGS,
+            WebPermission.MANAGE_MESSAGES,
+        ])
+    })
+
+    it("returns empty when non-owner member cannot be resolved", async () => {
+        const client = mockPermissionClient({
+            guildId,
+            ownerId,
+            memberFetch: async () => null,
+        })
+        const result = await resolveUserPermissions(client, guildId, "member-2")
+        assert.deepEqual(result, { permissions: [], inVoiceWithBot: false })
+    })
+})
+
+describe("invalidatePermissionCache", () => {
+    it("clears cached voice-gated resolutions so later reads recompute", async () => {
+        const guildId = "guild-cache"
+        const ownerId = "owner-cache"
+        const voiceStates = new Map<string, MockVoiceState>([
+            [ownerId, { channelId: "vc-1" }],
+        ])
+        const client = mockPermissionClient({
+            guildId,
+            ownerId,
+            voiceStates,
+            playerVoiceChannelId: "vc-1",
+        })
+
+        const first = await resolveUserPermissions(client, guildId, ownerId)
+        assert.equal(first.inVoiceWithBot, true)
+        assert.equal(first.permissions.includes(WebPermission.CONTROL_PLAYBACK), true)
+
+        voiceStates.set(ownerId, { channelId: "vc-other" })
+        const stale = await resolveUserPermissions(client, guildId, ownerId)
+        assert.equal(stale.inVoiceWithBot, true, "TTL cache should still serve pre-move voice state")
+
+        invalidatePermissionCache(guildId)
+        const refreshed = await resolveUserPermissions(client, guildId, ownerId)
+        assert.equal(refreshed.inVoiceWithBot, false)
+        assert.equal(refreshed.permissions.includes(WebPermission.CONTROL_PLAYBACK), false)
+    })
+})

--- a/src/shared/permissions.test.ts
+++ b/src/shared/permissions.test.ts
@@ -231,9 +231,7 @@ describe("invalidatePermissionCache", () => {
     it("clears cached voice-gated resolutions so later reads recompute", async () => {
         const guildId = "guild-cache"
         const ownerId = "owner-cache"
-        const voiceStates = new Map<string, MockVoiceState>([
-            [ownerId, { channelId: "vc-1" }],
-        ])
+        const voiceStates = new Map<string, MockVoiceState>([[ownerId, { channelId: "vc-1" }]])
         const client = mockPermissionClient({
             guildId,
             ownerId,
@@ -247,7 +245,11 @@ describe("invalidatePermissionCache", () => {
 
         voiceStates.set(ownerId, { channelId: "vc-other" })
         const stale = await resolveUserPermissions(client, guildId, ownerId)
-        assert.equal(stale.inVoiceWithBot, true, "TTL cache should still serve pre-move voice state")
+        assert.equal(
+            stale.inVoiceWithBot,
+            true,
+            "TTL cache should still serve pre-move voice state"
+        )
 
         invalidatePermissionCache(guildId)
         const refreshed = await resolveUserPermissions(client, guildId, ownerId)

--- a/src/shared/permissions.test.ts
+++ b/src/shared/permissions.test.ts
@@ -21,6 +21,9 @@ function mockLavalinkPlayer(voiceChannelId: string | null, guildId = "guild-1") 
     }
 }
 
+/** Duck-typed client accepted by permission helpers (avoids full discord.js GuildMemberManager). */
+type MockPermissionClient = NonNullable<Parameters<typeof resolveOauthGuildPermissionFallback>[0]>
+
 function mockPermissionClient(opts: {
     guildId: string
     ownerId?: string
@@ -29,7 +32,7 @@ function mockPermissionClient(opts: {
     playerVoiceChannelId?: string | null
     meVoiceChannelId?: string | null
     memberFetch?: (userId: string) => Promise<unknown>
-}) {
+}): MockPermissionClient {
     const voiceStates = opts.voiceStates ?? new Map<string, MockVoiceState>()
     return {
         guilds: {
@@ -61,7 +64,7 @@ function mockPermissionClient(opts: {
                 return mockLavalinkPlayer(opts.playerVoiceChannelId, opts.guildId)
             },
         },
-    }
+    } as unknown as MockPermissionClient
 }
 
 afterEach(() => {

--- a/src/shared/player-state.test.ts
+++ b/src/shared/player-state.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    isPlayer,
+    resolveBotVoiceChannelId,
+    snapshotGuildListPlayer,
+    summarizeVoiceForWeb,
+} from "./player-state.js"
+
+function mockPlayer(opts: {
+    guildId?: string
+    voiceChannelId?: string | null
+    playing?: boolean
+    paused?: boolean
+    tracks?: unknown[]
+    current?: { info?: { title?: string; author?: string } } | null
+}) {
+    return {
+        get: () => undefined,
+        guildId: opts.guildId ?? "guild-1",
+        voiceChannelId: opts.voiceChannelId === undefined ? "vc-bot" : opts.voiceChannelId,
+        playing: opts.playing ?? false,
+        paused: opts.paused ?? false,
+        queue: {
+            tracks: opts.tracks ?? [],
+            current: opts.current ?? null,
+        },
+    }
+}
+
+function mockClient(opts: {
+    guildId?: string
+    botChannelId?: string | null
+    userId?: string
+    userChannelId?: string | null
+}) {
+    const guildId = opts.guildId ?? "guild-1"
+    const voiceStates = new Map<string, { channelId?: string | null }>()
+    if (opts.userId) {
+        voiceStates.set(opts.userId, { channelId: opts.userChannelId ?? null })
+    }
+    const guild = {
+        members: {
+            me: { voice: { channelId: opts.botChannelId ?? null } },
+        },
+        voiceStates: { cache: voiceStates },
+    }
+    return {
+        guilds: {
+            cache: new Map([[guildId, guild]]),
+        },
+    }
+}
+
+describe("isPlayer", () => {
+    it("accepts a minimal Lavalink-shaped player", () => {
+        assert.equal(isPlayer(mockPlayer({})), true)
+    })
+
+    it("rejects missing get, queue.tracks, playing, or guildId", () => {
+        assert.equal(isPlayer(null), false)
+        assert.equal(isPlayer({ queue: { tracks: [] }, playing: false, guildId: "g" }), false)
+        assert.equal(
+            isPlayer({ get: () => undefined, queue: {}, playing: false, guildId: "g" }),
+            false
+        )
+        assert.equal(
+            isPlayer({
+                get: () => undefined,
+                queue: { tracks: [] },
+                playing: "yes",
+                guildId: "g",
+            }),
+            false
+        )
+        assert.equal(
+            isPlayer({
+                get: () => undefined,
+                queue: { tracks: [] },
+                playing: false,
+                guildId: 1,
+            }),
+            false
+        )
+        assert.equal(
+            isPlayer({
+                get: () => undefined,
+                queue: { tracks: [] },
+                playing: false,
+                guildId: "g",
+                node: null,
+            }),
+            false
+        )
+    })
+})
+
+describe("resolveBotVoiceChannelId", () => {
+    it("prefers Lavalink player.voiceChannelId when set", () => {
+        const client = mockClient({ botChannelId: "vc-discord" })
+        assert.equal(
+            resolveBotVoiceChannelId(
+                "guild-1",
+                mockPlayer({ voiceChannelId: "vc-lava" }) as never,
+                client
+            ),
+            "vc-lava"
+        )
+    })
+
+    it("falls back to Discord members.me.voice when player VC is empty", () => {
+        const client = mockClient({ botChannelId: "vc-discord" })
+        assert.equal(
+            resolveBotVoiceChannelId(
+                "guild-1",
+                mockPlayer({ voiceChannelId: null }) as never,
+                client
+            ),
+            "vc-discord"
+        )
+        assert.equal(resolveBotVoiceChannelId("guild-1", null, client), "vc-discord")
+    })
+
+    it("returns null when neither player nor Discord has a bot VC", () => {
+        const client = mockClient({ botChannelId: null })
+        assert.equal(resolveBotVoiceChannelId("guild-1", null, client), null)
+        assert.equal(resolveBotVoiceChannelId("missing-guild", null, client), null)
+    })
+})
+
+describe("summarizeVoiceForWeb", () => {
+    it("marks inVoiceWithBot only when user and bot share the same VC", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-same",
+            botChannelId: "vc-other",
+        })
+        const player = mockPlayer({ voiceChannelId: "vc-same" })
+        assert.deepEqual(summarizeVoiceForWeb("guild-1", "user-1", player, client), {
+            inVoiceWithBot: true,
+            botInVoiceChannel: true,
+            canQueueTracks: true,
+        })
+    })
+
+    it("allows canQueueTracks when user is in voice and bot is not", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-user",
+            botChannelId: null,
+        })
+        assert.deepEqual(summarizeVoiceForWeb("guild-1", "user-1", null, client), {
+            inVoiceWithBot: false,
+            botInVoiceChannel: false,
+            canQueueTracks: true,
+        })
+    })
+
+    it("blocks canQueueTracks when user is in a different VC than the bot", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-user",
+            botChannelId: "vc-bot",
+        })
+        const player = mockPlayer({ voiceChannelId: "vc-bot" })
+        assert.deepEqual(summarizeVoiceForWeb("guild-1", "user-1", player, client), {
+            inVoiceWithBot: false,
+            botInVoiceChannel: true,
+            canQueueTracks: false,
+        })
+    })
+
+    it("blocks queueing when the user is not in any voice channel", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: null,
+            botChannelId: "vc-bot",
+        })
+        const player = mockPlayer({ voiceChannelId: "vc-bot" })
+        assert.deepEqual(summarizeVoiceForWeb("guild-1", "user-1", player, client), {
+            inVoiceWithBot: false,
+            botInVoiceChannel: true,
+            canQueueTracks: false,
+        })
+    })
+
+    it("ignores non-player shapes for bot VC and falls back to Discord", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-discord",
+            botChannelId: "vc-discord",
+        })
+        assert.deepEqual(
+            summarizeVoiceForWeb("guild-1", "user-1", { voiceChannelId: "vc-ignored" }, client),
+            {
+                inVoiceWithBot: true,
+                botInVoiceChannel: true,
+                canQueueTracks: true,
+            }
+        )
+    })
+})
+
+describe("snapshotGuildListPlayer", () => {
+    it("returns null when there is no player and the bot is not in voice", () => {
+        const client = mockClient({ botChannelId: null })
+        assert.equal(snapshotGuildListPlayer("guild-1", "user-1", null, client), null)
+    })
+
+    it("reports idle bot-in-voice without a player, and clears inVoiceWithBot without discordUserId", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-bot",
+            botChannelId: "vc-bot",
+        })
+        assert.deepEqual(snapshotGuildListPlayer("guild-1", undefined, null, client), {
+            status: "idle",
+            botInVoiceChannel: true,
+            inVoiceWithBot: false,
+            currentTrackTitle: null,
+            currentTrackAuthor: null,
+            queueCount: 0,
+        })
+    })
+
+    it("surfaces playing status and current track fields from a valid player", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-bot",
+            botChannelId: "vc-bot",
+        })
+        const player = mockPlayer({
+            voiceChannelId: "vc-bot",
+            playing: true,
+            tracks: [{}, {}],
+            current: { info: { title: "Song", author: "Artist" } },
+        })
+        assert.deepEqual(snapshotGuildListPlayer("guild-1", "user-1", player, client), {
+            status: "playing",
+            botInVoiceChannel: true,
+            inVoiceWithBot: true,
+            currentTrackTitle: "Song",
+            currentTrackAuthor: "Artist",
+            queueCount: 2,
+        })
+    })
+})

--- a/src/util/autoplayHistory.test.ts
+++ b/src/util/autoplayHistory.test.ts
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player, Track, TrackInfo } from "lavalink-client"
+import {
+    AUTOPLAY_RECENT_SONG_CAP,
+    autoplaySameComposition,
+    autoplayTrackFingerprint,
+    clearAutoplayRecent,
+    isAutoplayRecentlyPlayed,
+    isDuplicateAutoplayCandidate,
+    isPlausibleAutoplayMusicTrack,
+    isSamePrimaryArtist,
+    orderLavalinkTracksForAutoplay,
+    orderSimilarByArtistVariety,
+    primaryArtistKey,
+    rememberAutoplayPlayed,
+    songIdentityKey,
+    youtubeVideoIdFromUri,
+    canonicalSongCore,
+    coreTrackTitle,
+} from "./autoplayHistory.js"
+
+function info(overrides: Partial<TrackInfo> = {}): TrackInfo {
+    return {
+        title: "Song Title",
+        author: "Artist",
+        uri: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        duration: 180_000,
+        isStream: false,
+        identifier: "dQw4w9WgXcQ",
+        isSeekable: true,
+        sourceName: "youtube",
+        artworkUrl: null,
+        isrc: null,
+        ...overrides,
+    } as TrackInfo
+}
+
+function mockPlayer(): Player {
+    const store = new Map<string, unknown>()
+    return {
+        get: (key: string) => store.get(key),
+        set: (key: string, value: unknown) => {
+            store.set(key, value)
+        },
+        queue: { current: null, tracks: [], previous: [] },
+    } as unknown as Player
+}
+
+function trackFromInfo(trackInfo: TrackInfo): Track {
+    return { info: trackInfo, encoded: "enc", requester: null } as unknown as Track
+}
+
+describe("youtubeVideoIdFromUri", () => {
+    it("parses watch, short, embed, shorts, and live URLs", () => {
+        assert.equal(
+            youtubeVideoIdFromUri("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+            "dQw4w9WgXcQ"
+        )
+        assert.equal(youtubeVideoIdFromUri("https://youtu.be/dQw4w9WgXcQ"), "dQw4w9WgXcQ")
+        assert.equal(
+            youtubeVideoIdFromUri("https://www.youtube.com/embed/dQw4w9WgXcQ"),
+            "dQw4w9WgXcQ"
+        )
+        assert.equal(
+            youtubeVideoIdFromUri("https://www.youtube.com/shorts/dQw4w9WgXcQ"),
+            "dQw4w9WgXcQ"
+        )
+        assert.equal(
+            youtubeVideoIdFromUri("https://music.youtube.com/watch?v=abc123XYZ01"),
+            "abc123XYZ01"
+        )
+    })
+
+    it("returns null for missing, non-YouTube, or malformed URIs", () => {
+        assert.equal(youtubeVideoIdFromUri(undefined), null)
+        assert.equal(youtubeVideoIdFromUri("https://open.spotify.com/track/x"), null)
+        assert.equal(youtubeVideoIdFromUri("not a url"), null)
+    })
+})
+
+describe("title and artist normalization", () => {
+    it("strips promo trailers and feat. tails for comparable cores", () => {
+        assert.equal(coreTrackTitle("Hello (Official Music Video)"), "hello")
+        assert.equal(primaryArtistKey("Adele feat. Someone"), "adele")
+        assert.equal(canonicalSongCore("Adele", "Adele - Hello (Lyrics)"), "hello")
+        assert.equal(isSamePrimaryArtist("Adele ft. X", "Adele"), true)
+        assert.equal(isSamePrimaryArtist("Adele", "Beyonce"), false)
+    })
+})
+
+describe("isPlausibleAutoplayMusicTrack", () => {
+    it("rejects reaction/interview junk and very short non-stream clips", () => {
+        assert.equal(
+            isPlausibleAutoplayMusicTrack(info({ title: "Producer Reacts to New Song" })),
+            false
+        )
+        assert.equal(
+            isPlausibleAutoplayMusicTrack(info({ title: "Exclusive Interview with the Band" })),
+            false
+        )
+        assert.equal(
+            isPlausibleAutoplayMusicTrack(info({ title: "Real Song", duration: 15_000 })),
+            false
+        )
+        assert.equal(isPlausibleAutoplayMusicTrack(info({ title: "Real Song" })), true)
+        assert.equal(isPlausibleAutoplayMusicTrack(undefined), false)
+    })
+})
+
+describe("autoplaySameComposition / duplicates", () => {
+    it("matches covers and lyric uploads of the same work", () => {
+        assert.equal(
+            autoplaySameComposition("Radiohead", "Creep", "Radiohead", "Creep Lyrics"),
+            true
+        )
+        assert.equal(
+            autoplaySameComposition(
+                "Radiohead",
+                "Creep",
+                "Some Cover Channel",
+                "Radiohead - Creep (Cover)"
+            ),
+            false
+        )
+    })
+
+    it("does not treat unrelated short titles as the same song across artists", () => {
+        assert.equal(autoplaySameComposition("Artist A", "Run", "Artist B", "Run"), false)
+        assert.equal(autoplaySameComposition("Artist A", "Run", "Artist A", "Run"), true)
+    })
+
+    it("detects duplicates by URI, YouTube id, and composition", () => {
+        const ended = info({
+            uri: "https://www.youtube.com/watch?v=abc123XYZ01",
+            identifier: "abc123XYZ01",
+            author: "Adele",
+            title: "Hello",
+        })
+        assert.equal(
+            isDuplicateAutoplayCandidate(
+                info({
+                    uri: "https://youtu.be/abc123XYZ01",
+                    identifier: "other",
+                    author: "Adele",
+                    title: "Hello Official Video",
+                }),
+                ended
+            ),
+            true
+        )
+        assert.equal(
+            isDuplicateAutoplayCandidate(
+                info({
+                    uri: "https://www.youtube.com/watch?v=zzzzzzzzzzz",
+                    identifier: "zzzzzzzzzzz",
+                    author: "Other",
+                    title: "Totally Different Song Name Here",
+                }),
+                ended
+            ),
+            false
+        )
+    })
+})
+
+describe("fingerprints and recent history", () => {
+    it("prefers YouTube id fingerprints and falls back to song identity", () => {
+        assert.equal(
+            autoplayTrackFingerprint(info({ uri: "https://youtu.be/dQw4w9WgXcQ" })),
+            "yt:dQw4w9WgXcQ"
+        )
+        assert.equal(
+            autoplayTrackFingerprint(
+                info({
+                    uri: "https://open.spotify.com/track/x",
+                    identifier: "",
+                    author: "Adele",
+                    title: "Hello",
+                })
+            ),
+            songIdentityKey("Adele", "Hello")
+        )
+    })
+
+    it("remembers distinct songs, caps history, and matches fuzzy recent plays", () => {
+        const player = mockPlayer()
+        rememberAutoplayPlayed(player, info({ author: "Adele", title: "Hello" }))
+        rememberAutoplayPlayed(player, info({ author: "Adele", title: "Hello (Lyrics)" }))
+        assert.equal(
+            isAutoplayRecentlyPlayed(player, info({ author: "Adele", title: "Hello Official Audio" })),
+            true
+        )
+        assert.equal(
+            isAutoplayRecentlyPlayed(player, info({ author: "Beyonce", title: "Halo" })),
+            false
+        )
+
+        for (let i = 0; i < AUTOPLAY_RECENT_SONG_CAP + 5; i++) {
+            rememberAutoplayPlayed(player, info({ author: `Artist${i}`, title: `Song ${i}` }))
+        }
+        const recent = player.get("autoplayRecentSongs") as string[]
+        assert.equal(recent.length, AUTOPLAY_RECENT_SONG_CAP)
+        assert.equal(isAutoplayRecentlyPlayed(player, info({ author: "Adele", title: "Hello" })), false)
+
+        clearAutoplayRecent(player)
+        assert.equal(
+            isAutoplayRecentlyPlayed(player, info({ author: `Artist${AUTOPLAY_RECENT_SONG_CAP + 4}`, title: `Song ${AUTOPLAY_RECENT_SONG_CAP + 4}` })),
+            false
+        )
+    })
+})
+
+describe("ordering helpers", () => {
+    it("orders similar recommendations with other artists first", () => {
+        const ordered = orderSimilarByArtistVariety(
+            [
+                { artist: "Adele", title: "Someone Like You" },
+                { artist: "Sam Smith", title: "Stay With Me" },
+                { artist: "Adele ft. X", title: "Rumour Has It" },
+            ],
+            "Adele"
+        )
+        assert.deepEqual(
+            ordered.map((s) => s.artist),
+            ["Sam Smith", "Adele", "Adele ft. X"]
+        )
+    })
+
+    it("filters junk, duplicates, and recent plays when ordering Lavalink hits", () => {
+        const player = mockPlayer()
+        const ended = info({
+            author: "Seed",
+            title: "Ended Track",
+            identifier: "ended1",
+            uri: "https://www.youtube.com/watch?v=endedTrack01",
+        })
+        rememberAutoplayPlayed(
+            player,
+            info({
+                author: "Recent",
+                title: "Already Heard",
+                identifier: "recent1",
+                uri: "https://www.youtube.com/watch?v=recentHeard01",
+            })
+        )
+
+        const tracks = [
+            trackFromInfo(
+                info({
+                    author: "Other Band",
+                    title: "Fresh Cut",
+                    identifier: "a1",
+                    uri: "https://www.youtube.com/watch?v=freshCutAAAA",
+                })
+            ),
+            trackFromInfo(
+                info({
+                    author: "Seed",
+                    title: "Ended Track",
+                    identifier: "ended1",
+                    uri: ended.uri,
+                })
+            ),
+            trackFromInfo(
+                info({
+                    author: "Recent",
+                    title: "Already Heard",
+                    identifier: "r1",
+                    uri: "https://www.youtube.com/watch?v=recentHeard02",
+                })
+            ),
+            trackFromInfo(
+                info({
+                    author: "Clip Channel",
+                    title: "Producer Reacts to Hit",
+                    identifier: "j1",
+                    uri: "https://www.youtube.com/watch?v=junkReact0001",
+                })
+            ),
+            trackFromInfo(
+                info({
+                    author: "Seed",
+                    title: "Same Artist B-Side",
+                    identifier: "s1",
+                    uri: "https://www.youtube.com/watch?v=sameArtistB01",
+                })
+            ),
+        ]
+
+        const ordered = orderLavalinkTracksForAutoplay(tracks, "Seed", ended, player)
+        assert.deepEqual(
+            ordered.map((t) => t.info?.identifier),
+            ["a1", "s1"]
+        )
+    })
+})

--- a/src/util/autoplayHistory.test.ts
+++ b/src/util/autoplayHistory.test.ts
@@ -188,7 +188,10 @@ describe("fingerprints and recent history", () => {
         rememberAutoplayPlayed(player, info({ author: "Adele", title: "Hello" }))
         rememberAutoplayPlayed(player, info({ author: "Adele", title: "Hello (Lyrics)" }))
         assert.equal(
-            isAutoplayRecentlyPlayed(player, info({ author: "Adele", title: "Hello Official Audio" })),
+            isAutoplayRecentlyPlayed(
+                player,
+                info({ author: "Adele", title: "Hello Official Audio" })
+            ),
             true
         )
         assert.equal(
@@ -201,11 +204,20 @@ describe("fingerprints and recent history", () => {
         }
         const recent = player.get("autoplayRecentSongs") as string[]
         assert.equal(recent.length, AUTOPLAY_RECENT_SONG_CAP)
-        assert.equal(isAutoplayRecentlyPlayed(player, info({ author: "Adele", title: "Hello" })), false)
+        assert.equal(
+            isAutoplayRecentlyPlayed(player, info({ author: "Adele", title: "Hello" })),
+            false
+        )
 
         clearAutoplayRecent(player)
         assert.equal(
-            isAutoplayRecentlyPlayed(player, info({ author: `Artist${AUTOPLAY_RECENT_SONG_CAP + 4}`, title: `Song ${AUTOPLAY_RECENT_SONG_CAP + 4}` })),
+            isAutoplayRecentlyPlayed(
+                player,
+                info({
+                    author: `Artist${AUTOPLAY_RECENT_SONG_CAP + 4}`,
+                    title: `Song ${AUTOPLAY_RECENT_SONG_CAP + 4}`,
+                })
+            ),
             false
         )
     })

--- a/src/util/countdownUpdater.test.ts
+++ b/src/util/countdownUpdater.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { isUnrecoverableCountdownDiscordError } from "./countdownUpdater.js"
+
+describe("isUnrecoverableCountdownDiscordError", () => {
+    it("deletes countdowns only for unknown channel/message", () => {
+        assert.equal(isUnrecoverableCountdownDiscordError({ code: 10003 }), true)
+        assert.equal(isUnrecoverableCountdownDiscordError({ code: 10008 }), true)
+    })
+
+    it("retries permission and non-numeric failures instead of wiping countdown rows", () => {
+        assert.equal(isUnrecoverableCountdownDiscordError({ code: 50001 }), false)
+        assert.equal(isUnrecoverableCountdownDiscordError({ code: 50013 }), false)
+        assert.equal(isUnrecoverableCountdownDiscordError({ code: "10003" }), false)
+        assert.equal(isUnrecoverableCountdownDiscordError(new Error("timeout")), false)
+        assert.equal(isUnrecoverableCountdownDiscordError(null), false)
+    })
+})

--- a/src/util/countdownUpdater.ts
+++ b/src/util/countdownUpdater.ts
@@ -14,7 +14,11 @@ const UNRECOVERABLE_CODES = new Set([
     10008, // Unknown Message
 ])
 
-function isUnrecoverableError(error: unknown): boolean {
+/**
+ * True when a Discord fetch/edit failure should delete the countdown row.
+ * Permission and transient errors must return false so the next interval can retry.
+ */
+export function isUnrecoverableCountdownDiscordError(error: unknown): boolean {
     if (typeof error === "object" && error !== null && "code" in error) {
         const code = (error as { code: unknown }).code
         return typeof code === "number" && UNRECOVERABLE_CODES.has(code)
@@ -74,7 +78,7 @@ export async function updateAllCountdowns(client: BotClient): Promise<void> {
                 }
                 channel = fetched
             } catch (error: unknown) {
-                if (isUnrecoverableError(error)) {
+                if (isUnrecoverableCountdownDiscordError(error)) {
                     await removeCountdown(entry.id)
                 } else {
                     client.warn(
@@ -89,7 +93,7 @@ export async function updateAllCountdowns(client: BotClient): Promise<void> {
             try {
                 message = await channel.messages.fetch(entry.messageId)
             } catch (error: unknown) {
-                if (isUnrecoverableError(error)) {
+                if (isUnrecoverableCountdownDiscordError(error)) {
                     await removeCountdown(entry.id)
                 } else {
                     client.warn(
@@ -114,7 +118,7 @@ export async function updateAllCountdowns(client: BotClient): Promise<void> {
                 }
             }
         } catch (error: unknown) {
-            if (isUnrecoverableError(error)) {
+            if (isUnrecoverableCountdownDiscordError(error)) {
                 await removeCountdown(entry.id).catch((removeErr: unknown) =>
                     client.warn(
                         `[countdown] Failed to remove unrecoverable countdown #${entry.id}:`,

--- a/src/util/dashboardRequesterSnapshot.test.ts
+++ b/src/util/dashboardRequesterSnapshot.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { snapshotFromRequester } from "./dashboardRequesterSnapshot.js"
+
+describe("snapshotFromRequester", () => {
+    it("returns null for missing or unusable requesters", () => {
+        assert.equal(snapshotFromRequester(null), null)
+        assert.equal(snapshotFromRequester(undefined), null)
+        assert.equal(snapshotFromRequester({}), null)
+        assert.equal(snapshotFromRequester({ username: "no-id" }), null)
+        assert.equal(snapshotFromRequester(42), null)
+    })
+
+    it("accepts stamped string ids and numeric/bigint object ids", () => {
+        assert.deepEqual(snapshotFromRequester("123456789012345678"), {
+            id: "123456789012345678",
+        })
+        assert.deepEqual(snapshotFromRequester({ id: 42 }), { id: "42" })
+        assert.deepEqual(snapshotFromRequester({ id: 99n }), { id: "99" })
+    })
+
+    it("prefers globalName, then username, then displayName (trimmed)", () => {
+        assert.deepEqual(
+            snapshotFromRequester({
+                id: "1",
+                globalName: "  Display  ",
+                username: "login",
+                displayName: "nick",
+            }),
+            { id: "1", username: "Display" }
+        )
+        assert.deepEqual(
+            snapshotFromRequester({ id: "2", globalName: "   ", username: " login ", displayName: "nick" }),
+            { id: "2", username: "login" }
+        )
+        assert.deepEqual(
+            snapshotFromRequester({ id: "3", username: "", displayName: "  Nick  " }),
+            { id: "3", username: "Nick" }
+        )
+        assert.deepEqual(
+            snapshotFromRequester({ id: "4", globalName: "", username: "  ", displayName: "  " }),
+            { id: "4" }
+        )
+    })
+})

--- a/src/util/dashboardRequesterSnapshot.test.ts
+++ b/src/util/dashboardRequesterSnapshot.test.ts
@@ -30,7 +30,12 @@ describe("snapshotFromRequester", () => {
             { id: "1", username: "Display" }
         )
         assert.deepEqual(
-            snapshotFromRequester({ id: "2", globalName: "   ", username: " login ", displayName: "nick" }),
+            snapshotFromRequester({
+                id: "2",
+                globalName: "   ",
+                username: " login ",
+                displayName: "nick",
+            }),
             { id: "2", username: "login" }
         )
         assert.deepEqual(

--- a/src/util/discordErrorDetails.test.ts
+++ b/src/util/discordErrorDetails.test.ts
@@ -19,7 +19,7 @@ describe("getDiscordErrorCode", () => {
         assert.equal(getDiscordErrorCode({}), undefined)
         assert.equal(getDiscordErrorCode({ code: "EAI_AGAIN" }), undefined)
         assert.equal(getDiscordErrorCode({ code: Number.NaN }), undefined)
-        assert.equal(getDiscordErrorCode({ code: 12.5 }), undefined)
+        assert.equal(getDiscordErrorCode({ code: Number.POSITIVE_INFINITY }), undefined)
     })
 })
 

--- a/src/util/discordErrorDetails.test.ts
+++ b/src/util/discordErrorDetails.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { discordDeleteErrorDetails, getDiscordErrorCode } from "./discordErrorDetails.js"
+
+describe("getDiscordErrorCode", () => {
+    it("reads finite numeric codes from thrown Discord-like errors", () => {
+        assert.equal(getDiscordErrorCode({ code: 10003 }), 10003)
+        assert.equal(getDiscordErrorCode({ code: 0 }), 0)
+    })
+
+    it("parses digit-only string codes used by some discord.js surfaces", () => {
+        assert.equal(getDiscordErrorCode({ code: "10004" }), 10004)
+    })
+
+    it("rejects non-codes so callers do not misclassify network failures as Discord API errors", () => {
+        assert.equal(getDiscordErrorCode(null), undefined)
+        assert.equal(getDiscordErrorCode(undefined), undefined)
+        assert.equal(getDiscordErrorCode("boom"), undefined)
+        assert.equal(getDiscordErrorCode({}), undefined)
+        assert.equal(getDiscordErrorCode({ code: "EAI_AGAIN" }), undefined)
+        assert.equal(getDiscordErrorCode({ code: Number.NaN }), undefined)
+        assert.equal(getDiscordErrorCode({ code: 12.5 }), undefined)
+    })
+})
+
+describe("discordDeleteErrorDetails", () => {
+    it("normalizes Error and non-Error throws for logging", () => {
+        assert.deepEqual(discordDeleteErrorDetails(new Error("gone")), {
+            code: undefined,
+            message: "gone",
+        })
+        assert.deepEqual(discordDeleteErrorDetails({ code: "EAI_AGAIN", message: "dns" }), {
+            code: "EAI_AGAIN",
+            message: "[object Object]",
+        })
+        assert.deepEqual(discordDeleteErrorDetails({ code: 500 }), {
+            code: "500",
+            message: "[object Object]",
+        })
+    })
+})

--- a/src/util/discordLogForward.test.ts
+++ b/src/util/discordLogForward.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { GuildDiscordLogSettings } from "../types/index.js"
+import { discordLogLevelAllowed, resolveDiscordLogChannelId } from "./discordLogForward.js"
+
+describe("resolveDiscordLogChannelId", () => {
+    it("prefers per-level overrides over allChannelId", () => {
+        const cfg: GuildDiscordLogSettings = {
+            allChannelId: "all-chan",
+            byLevel: { error: "error-chan", warn: "warn-chan" },
+        }
+        assert.equal(resolveDiscordLogChannelId(cfg, "error"), "error-chan")
+        assert.equal(resolveDiscordLogChannelId(cfg, "warn"), "warn-chan")
+        assert.equal(resolveDiscordLogChannelId(cfg, "info"), "all-chan")
+        assert.equal(resolveDiscordLogChannelId(cfg, "debug"), "all-chan")
+    })
+
+    it("returns null when neither per-level nor allChannelId is set", () => {
+        assert.equal(resolveDiscordLogChannelId({}, "error"), null)
+        assert.equal(resolveDiscordLogChannelId({ byLevel: {} }, "info"), null)
+    })
+})
+
+describe("discordLogLevelAllowed", () => {
+    it("defaults minLevel to debug (all levels allowed)", () => {
+        const cfg: GuildDiscordLogSettings = {}
+        assert.equal(discordLogLevelAllowed(cfg, "debug"), true)
+        assert.equal(discordLogLevelAllowed(cfg, "error"), true)
+    })
+
+    it("filters below the configured threshold and allows equal/higher", () => {
+        const cfg: GuildDiscordLogSettings = { minLevel: "warn" }
+        assert.equal(discordLogLevelAllowed(cfg, "debug"), false)
+        assert.equal(discordLogLevelAllowed(cfg, "info"), false)
+        assert.equal(discordLogLevelAllowed(cfg, "warn"), true)
+        assert.equal(discordLogLevelAllowed(cfg, "error"), true)
+    })
+
+    it("allows only error when minLevel is error", () => {
+        const cfg: GuildDiscordLogSettings = { minLevel: "error" }
+        assert.equal(discordLogLevelAllowed(cfg, "warn"), false)
+        assert.equal(discordLogLevelAllowed(cfg, "error"), true)
+    })
+})

--- a/src/util/discordLogForward.test.ts
+++ b/src/util/discordLogForward.test.ts
@@ -47,7 +47,10 @@ describe("logMessageBelongsToGuild", () => {
     })
 
     it("rejects process-wide logs with no guild id (prevents cross-tenant fan-out)", () => {
-        assert.equal(logMessageBelongsToGuild("[Database] Database connection verified.", guildA), false)
+        assert.equal(
+            logMessageBelongsToGuild("[Database] Database connection verified.", guildA),
+            false
+        )
         assert.equal(logMessageBelongsToGuild("Lavalink Node main CONNECTED", guildA), false)
     })
 

--- a/src/util/discordLogForward.test.ts
+++ b/src/util/discordLogForward.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 import type { GuildDiscordLogSettings } from "../types/index.js"
-import { discordLogLevelAllowed, resolveDiscordLogChannelId } from "./discordLogForward.js"
+import {
+    discordLogLevelAllowed,
+    logMessageBelongsToGuild,
+    resolveDiscordLogChannelId,
+} from "./discordLogForward.js"
 
 describe("resolveDiscordLogChannelId", () => {
     it("prefers per-level overrides over allChannelId", () => {
@@ -18,6 +22,39 @@ describe("resolveDiscordLogChannelId", () => {
     it("returns null when neither per-level nor allChannelId is set", () => {
         assert.equal(resolveDiscordLogChannelId({}, "error"), null)
         assert.equal(resolveDiscordLogChannelId({ byLevel: {} }, "info"), null)
+    })
+})
+
+describe("logMessageBelongsToGuild", () => {
+    const guildA = "123456789012345678"
+    const guildB = "987654321098765432"
+
+    it("requires the guild snowflake to appear as its own digit run", () => {
+        assert.equal(
+            logMessageBelongsToGuild(
+                `[MusicManager] handleQueryAndPlay called for guild ${guildA}. Query: "song"`,
+                guildA
+            ),
+            true
+        )
+        assert.equal(
+            logMessageBelongsToGuild(
+                `[MusicManager] handleQueryAndPlay called for guild ${guildA}. Query: "song"`,
+                guildB
+            ),
+            false
+        )
+    })
+
+    it("rejects process-wide logs with no guild id (prevents cross-tenant fan-out)", () => {
+        assert.equal(logMessageBelongsToGuild("[Database] Database connection verified.", guildA), false)
+        assert.equal(logMessageBelongsToGuild("Lavalink Node main CONNECTED", guildA), false)
+    })
+
+    it("rejects invalid guild ids and substring digit matches", () => {
+        assert.equal(logMessageBelongsToGuild(`guild ${guildA}`, ""), false)
+        assert.equal(logMessageBelongsToGuild(`guild ${guildA}`, "not-a-snowflake"), false)
+        assert.equal(logMessageBelongsToGuild(`id ${guildA}9`, guildA), false)
     })
 })
 

--- a/src/util/discordLogForward.ts
+++ b/src/util/discordLogForward.ts
@@ -21,6 +21,9 @@ const MAX_EMBED_DESC = 3900
 
 const TRUNCATE_SUFFIX = "\n… (truncated)"
 
+/** Discord snowflake shape used to scope forwarded log lines to a guild. */
+const DISCORD_SNOWFLAKE_RE = /^\d{17,19}$/
+
 /** Max queued Discord forwards; oldest entries are dropped when full. */
 const DISCORD_LOG_FORWARD_QUEUE_CAP = 200
 
@@ -105,8 +108,23 @@ function truncateForDiscord(text: string): string {
 }
 
 /**
+ * Whether a process log line should be forwarded to a guild's Discord log channel.
+ * Requires an explicit guild snowflake in the message so one server cannot receive
+ * other tenants' operational logs (queries, URLs, paths, user tags, error stacks).
+ */
+export function logMessageBelongsToGuild(message: string, guildId: string): boolean {
+    if (!guildId || !DISCORD_SNOWFLAKE_RE.test(guildId)) {
+        return false
+    }
+    // Word-ish boundary: snowflakes are digits; avoid matching a longer digit run.
+    const re = new RegExp(`(?<!\\d)${guildId}(?!\\d)`)
+    return re.test(message)
+}
+
+/**
  * Sends a log line to every guild that configured Discord logging for this level.
  * Skips guilds where the channel is missing or the bot lacks permission.
+ * Only forwards lines that reference that guild's id (cross-tenant isolation).
  */
 export async function forwardLogToDiscordChannels(
     client: BotClient,
@@ -119,6 +137,9 @@ export async function forwardLogToDiscordChannels(
     for (const [guildId, guildSettings] of Object.entries(settings)) {
         const cfg = guildSettings.discordLog
         if (!cfg) {
+            continue
+        }
+        if (!logMessageBelongsToGuild(message, guildId)) {
             continue
         }
         if (!discordLogLevelAllowed(cfg, level)) {

--- a/src/util/downloadMetadataKeys.test.ts
+++ b/src/util/downloadMetadataKeys.test.ts
@@ -96,6 +96,9 @@ describe("downloadMetadataFileBelongsToGuild / entryMatchesGuild / keysForFile",
             composite,
             fileName,
         ])
-        assert.deepEqual(downloadMetadataKeysForFile({ [fileName]: { guildId: "x" } }, fileName, guildId), [])
+        assert.deepEqual(
+            downloadMetadataKeysForFile({ [fileName]: { guildId: "x" } }, fileName, guildId),
+            []
+        )
     })
 })

--- a/src/util/downloadMetadataKeys.test.ts
+++ b/src/util/downloadMetadataKeys.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    DOWNLOAD_METADATA_KEY_SEP,
+    DOWNLOAD_METADATA_UNKNOWN_GUILD_ID,
+    downloadMetadataEntryMatchesGuild,
+    downloadMetadataFileBelongsToGuild,
+    downloadMetadataKeysForFile,
+    downloadMetadataStoreKey,
+    effectiveDownloadMetadataGuildId,
+    parseDownloadMetadataStoreKey,
+} from "./downloadMetadataKeys.js"
+
+describe("downloadMetadataStoreKey / parseDownloadMetadataStoreKey", () => {
+    it("round-trips composite guild+file keys", () => {
+        const key = downloadMetadataStoreKey("guild-a", "track.wav")
+        assert.equal(key, `guild-a${DOWNLOAD_METADATA_KEY_SEP}track.wav`)
+        assert.deepEqual(parseDownloadMetadataStoreKey(key), {
+            guildId: "guild-a",
+            fileName: "track.wav",
+        })
+    })
+
+    it("treats legacy plain file names as guild-less keys", () => {
+        assert.deepEqual(parseDownloadMetadataStoreKey("legacy.wav"), {
+            guildId: null,
+            fileName: "legacy.wav",
+        })
+    })
+})
+
+describe("effectiveDownloadMetadataGuildId", () => {
+    it("prefers composite key guild id and ignores UNKNOWN sentinel", () => {
+        const composite = downloadMetadataStoreKey("guild-a", "a.wav")
+        assert.equal(effectiveDownloadMetadataGuildId(composite, { guildId: "other" }), "guild-a")
+        assert.equal(
+            effectiveDownloadMetadataGuildId(
+                downloadMetadataStoreKey(DOWNLOAD_METADATA_UNKNOWN_GUILD_ID, "a.wav"),
+                undefined
+            ),
+            null
+        )
+        assert.equal(
+            effectiveDownloadMetadataGuildId("legacy.wav", {
+                guildId: DOWNLOAD_METADATA_UNKNOWN_GUILD_ID,
+            }),
+            null
+        )
+        assert.equal(
+            effectiveDownloadMetadataGuildId("legacy.wav", { guildId: " guild-b " }),
+            "guild-b"
+        )
+    })
+})
+
+describe("downloadMetadataFileBelongsToGuild / entryMatchesGuild / keysForFile", () => {
+    it("matches composite keys strictly and legacy keys by guildId rules", () => {
+        const guildId = "guild-1"
+        const fileName = "song.wav"
+        const composite = downloadMetadataStoreKey(guildId, fileName)
+        const metadata = {
+            [composite]: { guildId },
+            "other.wav": { guildId: "guild-2" },
+            "orphan.wav": { guildId: "" },
+        }
+
+        assert.equal(downloadMetadataFileBelongsToGuild(metadata, fileName, guildId), true)
+        assert.equal(downloadMetadataFileBelongsToGuild(metadata, "other.wav", guildId), false)
+        assert.equal(downloadMetadataFileBelongsToGuild(metadata, "orphan.wav", guildId), true)
+        assert.equal(downloadMetadataFileBelongsToGuild(metadata, "missing.wav", guildId), false)
+
+        assert.equal(
+            downloadMetadataEntryMatchesGuild(composite, metadata[composite], guildId),
+            true
+        )
+        assert.equal(
+            downloadMetadataEntryMatchesGuild("other.wav", metadata["other.wav"], guildId),
+            false
+        )
+        assert.equal(
+            downloadMetadataEntryMatchesGuild("orphan.wav", metadata["orphan.wav"], guildId),
+            true
+        )
+    })
+
+    it("collects composite and matching legacy keys for cleanup", () => {
+        const guildId = "guild-1"
+        const fileName = "song.wav"
+        const composite = downloadMetadataStoreKey(guildId, fileName)
+        const metadata = {
+            [composite]: { guildId },
+            [fileName]: { guildId },
+            "song.wav-other": { guildId: "guild-2" },
+        }
+        assert.deepEqual(downloadMetadataKeysForFile(metadata, fileName, guildId), [
+            composite,
+            fileName,
+        ])
+        assert.deepEqual(downloadMetadataKeysForFile({ [fileName]: { guildId: "x" } }, fileName, guildId), [])
+    })
+})

--- a/src/util/formatCountdownDuration.test.ts
+++ b/src/util/formatCountdownDuration.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { formatCountdownDuration } from "./formatCountdownDuration.js"
+
+describe("formatCountdownDuration", () => {
+    it("returns Event started! for non-positive or non-finite input", () => {
+        assert.equal(formatCountdownDuration(0), "Event started!")
+        assert.equal(formatCountdownDuration(-1), "Event started!")
+        assert.equal(formatCountdownDuration(Number.NaN), "Event started!")
+        assert.equal(formatCountdownDuration(Number.POSITIVE_INFINITY), "Event started!")
+    })
+
+    it("uses Less than a minute for sub-minute remainders", () => {
+        assert.equal(formatCountdownDuration(1), "Less than a minute")
+        assert.equal(formatCountdownDuration(59_999), "Less than a minute")
+    })
+
+    it("formats days, hours, and minutes without zero units or seconds", () => {
+        assert.equal(formatCountdownDuration(60_000), "1 minute")
+        assert.equal(formatCountdownDuration(2 * 60_000), "2 minutes")
+        assert.equal(formatCountdownDuration(60 * 60_000), "1 hour")
+        assert.equal(formatCountdownDuration(2 * 60 * 60_000 + 3 * 60_000), "2 hours, 3 minutes")
+        assert.equal(
+            formatCountdownDuration(3 * 24 * 60 * 60_000 + 4 * 60 * 60_000 + 20 * 60_000),
+            "3 days, 4 hours, 20 minutes"
+        )
+        assert.equal(formatCountdownDuration(24 * 60 * 60_000), "1 day")
+        // Sub-minute remainder after whole minutes is dropped (no seconds).
+        assert.equal(formatCountdownDuration(90_000), "1 minute")
+    })
+})

--- a/src/util/guildPlayerLifecycle.test.ts
+++ b/src/util/guildPlayerLifecycle.test.ts
@@ -118,4 +118,30 @@ describe("deferred orphan player cleanup", () => {
         holder.release()
         await waitForPendingOrphanDestroyForTests(guildId)
     })
+
+    it("defers idle destroy when reservedByCaller is 0 and a reservation is held", async () => {
+        const guildId = "guild-orphan-idle-timer"
+        let destroyed = false
+
+        const inFlight = await acquireGuildPlayerLifecycleReservation(guildId)
+
+        // queueEnd-style idle teardown does not itself hold a reservation.
+        await tryDestroyOrphanGuildPlayer(
+            guildId,
+            {
+                hasQueueContent: () => false,
+                destroyPlayer: async () => {
+                    destroyed = true
+                },
+            },
+            0
+        )
+        assert.equal(destroyed, false)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), true)
+
+        inFlight.release()
+        await waitForPendingOrphanDestroyForTests(guildId)
+        assert.equal(destroyed, true)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), false)
+    })
 })

--- a/src/util/guildPlayerQueueLock.ts
+++ b/src/util/guildPlayerQueueLock.ts
@@ -65,21 +65,26 @@ export function getGuildPlayerLifecycleReservationCount(guildId: string): number
 }
 
 /**
- * Destroys an empty orphan player when safe. If other lifecycle reservations are held,
+ * Destroys an empty orphan player when safe. If conflicting lifecycle reservations are held,
  * records a pending cleanup and retries under the queue lock when the count reaches zero.
  * Destroy runs under the same lock as reservation grants, so acquire waits until it finishes.
+ *
+ * @param reservedByCaller How many of the current reservation count belong to this caller
+ *   (1 for search/enqueue cleanup that still holds a lease; 0 for idle timers / non-reserved paths).
  */
 export async function tryDestroyOrphanGuildPlayer(
     guildId: string,
-    hooks: PendingOrphanDestroy
+    hooks: PendingOrphanDestroy,
+    reservedByCaller = 1
 ): Promise<void> {
+    const selfReservations = reservedByCaller > 0 ? reservedByCaller : 0
     await withGuildPlayerQueueLock(guildId, async () => {
         if (hooks.hasQueueContent()) {
             pendingOrphanDestroyByGuild.delete(guildId)
             return
         }
-        // Count includes the caller; >1 means another in-flight request still needs the player.
-        if (getGuildPlayerLifecycleReservationCount(guildId) > 1) {
+        // Defer while other in-flight requests still need this player.
+        if (getGuildPlayerLifecycleReservationCount(guildId) > selfReservations) {
             pendingOrphanDestroyByGuild.set(guildId, hooks)
             return
         }

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -121,6 +121,44 @@ describe("snapshotFromPlayer", () => {
     })
 })
 
+describe("shouldClearPlayerSessionOnDestroy", () => {
+    it("clears for intentional app destroys (undefined / empty reason)", () => {
+        assert.equal(shouldClearPlayerSessionOnDestroy(undefined), true)
+        assert.equal(shouldClearPlayerSessionOnDestroy(null), true)
+        assert.equal(shouldClearPlayerSessionOnDestroy(""), true)
+        assert.equal(shouldClearPlayerSessionOnDestroy("custom leave"), true)
+    })
+
+    it("preserves sessions for Discord disconnect and reconnect failure", () => {
+        assert.equal(shouldClearPlayerSessionOnDestroy("Disconnected"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("PlayerReconnectFail"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("LavalinkNoVoice"), false)
+    })
+
+    it("preserves sessions for node / infra teardown reasons", () => {
+        assert.equal(shouldClearPlayerSessionOnDestroy("NodeDestroy"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("NodeDeleted"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("NodeReconnectFail"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("DisconnectAllNodes"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("ReconnectAllNodes"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("PlayerChangeNodeFail"), false)
+        assert.equal(
+            shouldClearPlayerSessionOnDestroy("PlayerChangeNodeFailNoEligibleNode"),
+            false
+        )
+    })
+
+    it("preserves sessions for library max-errors auto-destroy", () => {
+        assert.equal(shouldClearPlayerSessionOnDestroy("TrackErrorMaxTracksErroredPerTime"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("TrackStuckMaxTracksErroredPerTime"), false)
+    })
+
+    it("still clears when the voice channel itself is deleted", () => {
+        assert.equal(shouldClearPlayerSessionOnDestroy("ChannelDeleted"), true)
+        assert.equal(shouldClearPlayerSessionOnDestroy("QueueEmpty"), true)
+    })
+})
+
 describe("shouldSkipPlayerSessionClear", () => {
     afterEach(() => {
         clearPlayerSessionRestoreInProgress("guild-restore")

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -10,6 +10,7 @@ import {
     setPlayerSessionPersistenceDbForTests,
     shouldSkipPlayerSessionClear,
     shouldSkipPlayerSessionClearForState,
+    shouldClearPlayerSessionOnDestroy,
     shouldUndoStaleSessionUpsert,
     snapshotFromPlayer,
     writePlayerSessionForTests,

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -160,6 +160,37 @@ describe("shouldSkipPlayerSessionClear", () => {
     })
 })
 
+describe("clearPlayerSession suppress lease consumption", () => {
+    afterEach(() => {
+        setPlayerSessionPersistenceDbForTests(null)
+    })
+
+    it("consumes one suppress lease without deleting or bumping the clear epoch", async () => {
+        const guildId = "guild-suppress-consume"
+        const events: string[] = []
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => {
+                events.push("upsert")
+            },
+            deletePlayerSession: async () => {
+                events.push("delete")
+            },
+        })
+
+        const epochBefore = getSessionClearEpochForTests(guildId)
+        acquirePlayerSessionClearSuppressLease(guildId)
+        await clearPlayerSession(guildId)
+
+        assert.deepEqual(events, [])
+        assert.equal(getSessionClearEpochForTests(guildId), epochBefore)
+        assert.equal(shouldSkipPlayerSessionClear(guildId), false)
+
+        await clearPlayerSession(guildId)
+        assert.deepEqual(events, ["delete"])
+        assert.equal(getSessionClearEpochForTests(guildId), epochBefore + 1)
+    })
+})
+
 describe("shouldUndoStaleSessionUpsert", () => {
     it("undoes when clear invalidated the write and no newer persist claimed generation", () => {
         // saveEpoch 1, clear bumped to 2, write still owns generation 5

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -142,10 +142,7 @@ describe("shouldClearPlayerSessionOnDestroy", () => {
         assert.equal(shouldClearPlayerSessionOnDestroy("DisconnectAllNodes"), false)
         assert.equal(shouldClearPlayerSessionOnDestroy("ReconnectAllNodes"), false)
         assert.equal(shouldClearPlayerSessionOnDestroy("PlayerChangeNodeFail"), false)
-        assert.equal(
-            shouldClearPlayerSessionOnDestroy("PlayerChangeNodeFailNoEligibleNode"),
-            false
-        )
+        assert.equal(shouldClearPlayerSessionOnDestroy("PlayerChangeNodeFailNoEligibleNode"), false)
     })
 
     it("preserves sessions for library max-errors auto-destroy", () => {

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -327,6 +327,35 @@ export async function flushAllPlayerSessionSaves(): Promise<void> {
     }
 }
 
+/**
+ * Library / infrastructure destroy reasons that must not wipe persisted sessions.
+ * Intentional app destroys (`player.destroy()` with no reason, alone-in-VC, /stop, etc.)
+ * still clear so queues do not resurrect after an explicit teardown.
+ */
+const PRESERVE_SESSION_DESTROY_REASONS = new Set([
+    "Disconnected",
+    "PlayerReconnectFail",
+    "LavalinkNoVoice",
+    "NodeDestroy",
+    "NodeDeleted",
+    "NodeReconnectFail",
+    "DisconnectAllNodes",
+    "ReconnectAllNodes",
+    "PlayerChangeNodeFail",
+    "PlayerChangeNodeFailNoEligibleNode",
+    "TrackErrorMaxTracksErroredPerTime",
+    "TrackStuckMaxTracksErroredPerTime",
+])
+
+/**
+ * Whether `playerDestroy` should delete the DB session for this destroy reason.
+ * Non-string reasons (typical app `player.destroy()`) clear; known infra reasons preserve.
+ */
+export function shouldClearPlayerSessionOnDestroy(reason: unknown): boolean {
+    if (typeof reason !== "string" || reason.length === 0) return true
+    return !PRESERVE_SESSION_DESTROY_REASONS.has(reason)
+}
+
 /** Removes a persisted session row (intentional destroy or stale cleanup). */
 export async function clearPlayerSession(guildId: string): Promise<void> {
     // Evaluate preserve/skip before bumping the clear epoch or cancelling pending saves.

--- a/src/util/playerSessionTracks.test.ts
+++ b/src/util/playerSessionTracks.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player } from "lavalink-client"
+import type { PersistedQueueTrack } from "../types/index.js"
+import { resolvePersistedTracks } from "./playerSessionTracks.js"
+
+function stored(overrides: Partial<PersistedQueueTrack> = {}): PersistedQueueTrack {
+    return {
+        title: "Song",
+        author: "Artist",
+        uri: "https://example.com/track",
+        duration: 1000,
+        encoded: null,
+        requesterId: "user-1",
+        thumbnailUrl: null,
+        isStream: false,
+        ...overrides,
+    }
+}
+
+function mockPlayer(hooks: {
+    search?: (uri: string) => Promise<{ tracks: unknown[] }>
+    decode?: (encoded: string) => Promise<unknown>
+}): Player {
+    return {
+        search: async (uri: string) => {
+            if (!hooks.search) throw new Error("search not stubbed")
+            return hooks.search(uri)
+        },
+        node: {
+            decode: {
+                singleTrack: async (encoded: string) => {
+                    if (!hooks.decode) throw new Error("decode not stubbed")
+                    return hooks.decode(encoded)
+                },
+            },
+        },
+    } as unknown as Player
+}
+
+describe("resolvePersistedTracks transient vs permanent failures", () => {
+    it("reports transientFailures when URI search throws", async () => {
+        const player = mockPlayer({
+            search: async () => {
+                throw new Error("lavalink down")
+            },
+        })
+        const result = await resolvePersistedTracks(player, [stored()])
+        assert.equal(result.resolved.length, 0)
+        assert.equal(result.failed, 1)
+        assert.equal(result.transientFailures, 1)
+    })
+
+    it("treats empty search results as permanent failures", async () => {
+        const player = mockPlayer({
+            search: async () => ({ tracks: [] }),
+        })
+        const result = await resolvePersistedTracks(player, [stored()])
+        assert.equal(result.resolved.length, 0)
+        assert.equal(result.failed, 1)
+        assert.equal(result.transientFailures, 0)
+    })
+
+    it("reports transientFailures when encoded-only decode throws", async () => {
+        const player = mockPlayer({
+            decode: async () => {
+                throw new Error("decode failed")
+            },
+        })
+        const result = await resolvePersistedTracks(player, [
+            stored({ uri: "", encoded: "encoded-track" }),
+        ])
+        assert.equal(result.resolved.length, 0)
+        assert.equal(result.failed, 1)
+        assert.equal(result.transientFailures, 1)
+    })
+})

--- a/src/util/playerSessionTracks.ts
+++ b/src/util/playerSessionTracks.ts
@@ -57,8 +57,9 @@ function trackMatchesStored(track: Track, stored: PersistedQueueTrack): boolean 
 async function resolvePersistedTrackAtIndex(
     player: Player,
     stored: PersistedQueueTrack
-): Promise<Track | null> {
+): Promise<{ track: Track | null; transientFailure: boolean }> {
     const requester = stored.requesterId ?? "session-restore"
+    let sawTransientFailure = false
 
     if (stored.encoded) {
         try {
@@ -67,9 +68,10 @@ async function resolvePersistedTrackAtIndex(
                 if (stored.requesterId) {
                     stampRequesterUserIdOnTracks([decoded], stored.requesterId)
                 }
-                return decoded
+                return { track: decoded, transientFailure: false }
             }
         } catch {
+            sawTransientFailure = true
             /* fall through to URI search */
         }
     }
@@ -82,32 +84,41 @@ async function resolvePersistedTrackAtIndex(
                 if (stored.requesterId) {
                     stampRequesterUserIdOnTracks([first], stored.requesterId)
                 }
-                return first
+                return { track: first, transientFailure: false }
             }
+            // Search completed but no usable match — permanent for this snapshot.
+            return { track: null, transientFailure: false }
         } catch {
-            /* unresolved */
+            return { track: null, transientFailure: true }
         }
     }
-    return null
+
+    // Encoded-only track whose decode threw, with no URI fallback.
+    return { track: null, transientFailure: sawTransientFailure }
 }
 
 /** Resolves persisted tracks via Lavalink (parallel, preserves order). */
 export async function resolvePersistedTracks(
     player: Player,
     storedTracks: PersistedQueueTrack[]
-): Promise<{ resolved: Track[]; failed: number }> {
+): Promise<{ resolved: Track[]; failed: number; transientFailures: number }> {
     if (storedTracks.length === 0) {
-        return { resolved: [], failed: 0 }
+        return { resolved: [], failed: 0, transientFailures: 0 }
     }
 
     const slots: (Track | null)[] = new Array(storedTracks.length).fill(null)
     let nextIndex = 0
+    let transientFailures = 0
 
     async function worker(): Promise<void> {
         while (true) {
             const i = nextIndex++
             if (i >= storedTracks.length) return
-            slots[i] = await resolvePersistedTrackAtIndex(player, storedTracks[i]!)
+            const outcome = await resolvePersistedTrackAtIndex(player, storedTracks[i]!)
+            slots[i] = outcome.track
+            if (!outcome.track && outcome.transientFailure) {
+                transientFailures += 1
+            }
         }
     }
 
@@ -118,5 +129,5 @@ export async function resolvePersistedTracks(
     for (const track of slots) {
         if (track) resolved.push(track)
     }
-    return { resolved, failed: storedTracks.length - resolved.length }
+    return { resolved, failed: storedTracks.length - resolved.length, transientFailures }
 }

--- a/src/util/playlistQueue.lock.test.ts
+++ b/src/util/playlistQueue.lock.test.ts
@@ -4,16 +4,16 @@ import type { Player, Track } from "lavalink-client"
 import { withGuildPlayerQueueLock } from "./guildPlayerQueueLock.js"
 import { playerHasQueueContent } from "./playlistQueue.js"
 
-function mockTrack(): Track {
+function mockTrack(id: string): Track {
     return {
-        encoded: "enc",
+        encoded: `enc-${id}`,
         info: {
-            title: "Song",
+            title: id,
             author: "Artist",
-            uri: "https://example.com/t",
+            uri: `https://example.com/${id}`,
             duration: 1000,
             isStream: false,
-            identifier: "id",
+            identifier: id,
             isSeekable: true,
             sourceName: "http",
             artworkUrl: null,
@@ -23,12 +23,24 @@ function mockTrack(): Track {
     } as unknown as Track
 }
 
-function mockEmptyPlayer(guildId: string): Player {
+function mockMutablePlayer(guildId: string, initial: Track[] = []): Player {
+    const tracks = [...initial]
     return {
         guildId,
+        playing: true,
         queue: {
             current: null,
-            tracks: [] as Track[],
+            tracks,
+            add(items: Track | Track[]) {
+                const list = Array.isArray(items) ? items : [items]
+                tracks.push(...list)
+            },
+            async splice(start: number, deleteCount: number, ...insert: Track[]) {
+                return tracks.splice(start, deleteCount, ...insert.flat())
+            },
+        },
+        get() {
+            return undefined
         },
     } as unknown as Player
 }
@@ -36,11 +48,11 @@ function mockEmptyPlayer(guildId: string): Player {
 describe("playlist orphan cleanup vs enqueue lock", () => {
     it("skips destroy when enqueue wins the guild queue lock first", async () => {
         const guildId = "guild-playlist-race"
-        const player = mockEmptyPlayer(guildId)
+        const player = mockMutablePlayer(guildId)
         let destroyed = false
 
         await withGuildPlayerQueueLock(guildId, async () => {
-            player.queue.tracks.push(mockTrack())
+            player.queue.add(mockTrack("queued"))
         })
 
         await withGuildPlayerQueueLock(guildId, async () => {
@@ -54,7 +66,7 @@ describe("playlist orphan cleanup vs enqueue lock", () => {
 
     it("blocks enqueue until orphan cleanup finishes under the same lock", async () => {
         const guildId = "guild-playlist-serialize"
-        const player = mockEmptyPlayer(guildId)
+        const player = mockMutablePlayer(guildId)
         const events: string[] = []
         let releaseCleanup!: () => void
         const cleanupGate = new Promise<void>((resolve) => {
@@ -72,7 +84,7 @@ describe("playlist orphan cleanup vs enqueue lock", () => {
         })
 
         const enqueueP = withGuildPlayerQueueLock(guildId, async () => {
-            player.queue.tracks.push(mockTrack())
+            player.queue.add(mockTrack("queued"))
             events.push("enqueue")
         })
 
@@ -84,5 +96,87 @@ describe("playlist orphan cleanup vs enqueue lock", () => {
         assert.equal(destroyed, true)
         assert.deepEqual(events, ["cleanup-start", "cleanup-destroy", "enqueue"])
         assert.equal(playerHasQueueContent(player), true)
+    })
+})
+
+describe("playlist replace clear+add must share one guild lock", () => {
+    it("keeps concurrent enqueue after clear+add (atomic replace contract)", async () => {
+        const guildId = "guild-playlist-replace-atomic"
+        const player = mockMutablePlayer(guildId, [mockTrack("old-upcoming")])
+        const events: string[] = []
+        let releaseReplace!: () => void
+        const replaceGate = new Promise<void>((resolve) => {
+            releaseReplace = resolve
+        })
+
+        // Mirrors replaceUpcomingWithResolvedPlaylistTracks: clear + add under one lock.
+        const replaceP = withGuildPlayerQueueLock(guildId, async () => {
+            const size = player.queue.tracks.length
+            if (size > 0) await player.queue.splice(0, size)
+            events.push("replace-cleared")
+            await replaceGate
+            player.queue.add([mockTrack("playlist-a"), mockTrack("playlist-b")])
+            events.push("replace-added")
+        })
+
+        // Ensure replace has entered the lock before scheduling concurrent enqueue.
+        await Promise.resolve()
+        await Promise.resolve()
+        assert.deepEqual(events, ["replace-cleared"])
+        assert.deepEqual(
+            player.queue.tracks.map((t) => t.info.title),
+            []
+        )
+
+        const enqueueP = withGuildPlayerQueueLock(guildId, async () => {
+            player.queue.add(mockTrack("concurrent-add"))
+            events.push("enqueue")
+        })
+
+        releaseReplace()
+        await Promise.all([replaceP, enqueueP])
+
+        assert.deepEqual(events, ["replace-cleared", "replace-added", "enqueue"])
+        assert.deepEqual(
+            player.queue.tracks.map((t) => t.info.title),
+            ["playlist-a", "playlist-b", "concurrent-add"]
+        )
+    })
+})
+
+describe("queue clear vs reorder under guild lock", () => {
+    it("prevents clear from interleaving between reorder remove and insert", async () => {
+        const guildId = "guild-reorder-clear-race"
+        const player = mockMutablePlayer(guildId, [
+            mockTrack("a"),
+            mockTrack("b"),
+            mockTrack("c"),
+        ])
+        const events: string[] = []
+        let releaseReorder!: () => void
+        const reorderGate = new Promise<void>((resolve) => {
+            releaseReorder = resolve
+        })
+
+        const reorderP = withGuildPlayerQueueLock(guildId, async () => {
+            events.push("reorder-remove")
+            const [track] = await player.queue.splice(0, 1)
+            await reorderGate
+            await player.queue.splice(player.queue.tracks.length, 0, track!)
+            events.push("reorder-insert")
+        })
+
+        const clearP = withGuildPlayerQueueLock(guildId, async () => {
+            const size = player.queue.tracks.length
+            if (size > 0) await player.queue.splice(0, size)
+            events.push("cleared")
+        })
+
+        await Promise.resolve()
+        assert.deepEqual(events, ["reorder-remove"])
+        releaseReorder()
+        await Promise.all([reorderP, clearP])
+        assert.deepEqual(events, ["reorder-remove", "reorder-insert", "cleared"])
+        assert.equal(player.queue.tracks.length, 0)
     })
 })

--- a/src/util/playlistQueue.lock.test.ts
+++ b/src/util/playlistQueue.lock.test.ts
@@ -147,11 +147,7 @@ describe("playlist replace clear+add must share one guild lock", () => {
 describe("queue clear vs reorder under guild lock", () => {
     it("prevents clear from interleaving between reorder remove and insert", async () => {
         const guildId = "guild-reorder-clear-race"
-        const player = mockMutablePlayer(guildId, [
-            mockTrack("a"),
-            mockTrack("b"),
-            mockTrack("c"),
-        ])
+        const player = mockMutablePlayer(guildId, [mockTrack("a"), mockTrack("b"), mockTrack("c")])
         const events: string[] = []
         let releaseReorder!: () => void
         const reorderGate = new Promise<void>((resolve) => {

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -114,6 +114,37 @@ export async function clearUpcomingQueue(player: Player): Promise<void> {
     }
 }
 
+async function enqueueTracksUnderLock(
+    player: Player,
+    tracks: Track[],
+    requesterId: string,
+    shuffle: boolean
+): Promise<EnqueuePlaylistResult> {
+    const toQueue = shuffle ? shuffleArray(tracks) : tracks
+    stampRequesterUserIdOnTracks(toQueue, requesterId)
+    player.queue.add(toQueue)
+    if (isRRQActive(player)) {
+        await rebalancePlayerQueueRoundRobin(player)
+    }
+    let playbackStarted = false
+    let playbackError: string | undefined
+    if (!player.playing) {
+        try {
+            await startPlaybackIfNeeded(player)
+            playbackStarted = true
+        } catch (error: unknown) {
+            playbackError = error instanceof Error ? error.message : String(error)
+        }
+    }
+    schedulePlayerSessionSave(player)
+    return {
+        queued: toQueue.length,
+        failed: 0,
+        playbackStarted,
+        playbackError,
+    }
+}
+
 /** Adds resolved tracks to the player queue and starts playback when idle. */
 export async function enqueueResolvedPlaylistTracks(
     player: Player,
@@ -124,29 +155,55 @@ export async function enqueueResolvedPlaylistTracks(
     if (tracks.length === 0) {
         return { queued: 0, failed: 0, playbackStarted: false }
     }
+    return withGuildPlayerQueueLock(player.guildId, () =>
+        enqueueTracksUnderLock(player, tracks, requesterId, shuffle)
+    )
+}
+
+/**
+ * Atomically replaces the upcoming queue with resolved playlist tracks.
+ * Snapshot + clear + enqueue run under one guild lock so a concurrent
+ * searchAndEnqueue cannot land between clear and add (silent track loss).
+ */
+export async function replaceUpcomingWithResolvedPlaylistTracks(
+    player: Player,
+    tracks: Track[],
+    requesterId: string,
+    shuffle: boolean
+): Promise<EnqueuePlaylistResult> {
+    if (tracks.length === 0) {
+        return { queued: 0, failed: 0, playbackStarted: false }
+    }
     return withGuildPlayerQueueLock(player.guildId, async () => {
-        const toQueue = shuffle ? shuffleArray(tracks) : tracks
-        stampRequesterUserIdOnTracks(toQueue, requesterId)
-        player.queue.add(toQueue)
-        if (isRRQActive(player)) {
-            await rebalancePlayerQueueRoundRobin(player)
-        }
-        let playbackStarted = false
-        let playbackError: string | undefined
-        if (!player.playing) {
-            try {
-                await startPlaybackIfNeeded(player)
-                playbackStarted = true
-            } catch (error: unknown) {
-                playbackError = error instanceof Error ? error.message : String(error)
+        const savedUpcoming = snapshotUpcomingQueue(player)
+        try {
+            const size = player.queue.tracks.length
+            if (size > 0) {
+                await player.queue.splice(0, size)
             }
-        }
-        schedulePlayerSessionSave(player)
-        return {
-            queued: toQueue.length,
-            failed: 0,
-            playbackStarted,
-            playbackError,
+            return await enqueueTracksUnderLock(player, tracks, requesterId, shuffle)
+        } catch (enqueueErr: unknown) {
+            try {
+                const size = player.queue.tracks.length
+                if (size > 0) {
+                    await player.queue.splice(0, size)
+                }
+                if (savedUpcoming.length > 0) {
+                    await player.queue.splice(0, 0, savedUpcoming)
+                }
+                schedulePlayerSessionSave(player)
+            } catch (restoreErr: unknown) {
+                const restoreMessage =
+                    restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
+                console.error(
+                    "[replaceUpcomingWithResolvedPlaylistTracks] failed to restore queue after enqueue error",
+                    {
+                        guildId: player.guildId,
+                        restoreMessage,
+                    }
+                )
+            }
+            throw enqueueErr
         }
     })
 }

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -3,7 +3,7 @@ import type { PlaylistTrackData } from "../types/index.js"
 import { thumbnailFromLavalinkTrack } from "./trackThumbnail.js"
 import {
     isRRQActive,
-    rebalancePlayerQueueRoundRobin,
+    rebalancePlayerQueueRoundRobinAssumingLock,
     stampRequesterUserIdOnTracks,
 } from "./rrqDisconnect.js"
 import { startPlaybackIfNeeded } from "./musicManager.js"
@@ -124,7 +124,8 @@ async function enqueueTracksUnderLock(
     stampRequesterUserIdOnTracks(toQueue, requesterId)
     player.queue.add(toQueue)
     if (isRRQActive(player)) {
-        await rebalancePlayerQueueRoundRobin(player)
+        // Already holding the guild queue lock -- do not re-enter via rebalancePlayerQueueRoundRobin.
+        await rebalancePlayerQueueRoundRobinAssumingLock(player)
     }
     let playbackStarted = false
     let playbackError: string | undefined

--- a/src/util/restorePlayerSessions.test.ts
+++ b/src/util/restorePlayerSessions.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { isStaleSessionDiscordError } from "./restorePlayerSessions.js"
+
+describe("isStaleSessionDiscordError", () => {
+    it("treats unknown channel/guild as permanently stale (safe to delete session)", () => {
+        assert.equal(isStaleSessionDiscordError({ code: 10003 }), true)
+        assert.equal(isStaleSessionDiscordError({ code: 10004 }), true)
+        assert.equal(isStaleSessionDiscordError({ code: "10003" }), true)
+    })
+
+    it("treats permission, rate-limit, and network-shaped failures as transient (keep session)", () => {
+        assert.equal(isStaleSessionDiscordError({ code: 50001 }), false) // Missing Access
+        assert.equal(isStaleSessionDiscordError({ code: 50013 }), false) // Missing Permissions
+        assert.equal(isStaleSessionDiscordError({ code: 429 }), false)
+        assert.equal(isStaleSessionDiscordError({ code: "EAI_AGAIN" }), false)
+        assert.equal(isStaleSessionDiscordError(new Error("fetch failed")), false)
+        assert.equal(isStaleSessionDiscordError(null), false)
+    })
+})

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -24,7 +24,12 @@ const STALE_SESSION_DISCORD_CODES = new Set([
     10004, // Unknown Guild
 ])
 
-function isStaleSessionDiscordError(error: unknown): boolean {
+/**
+ * True when a Discord API failure means the persisted voice channel/guild is gone
+ * (safe to delete the session). Transient/network errors must return false so restore
+ * can retry later without wiping the queue snapshot.
+ */
+export function isStaleSessionDiscordError(error: unknown): boolean {
     const code = getDiscordErrorCode(error)
     return code !== undefined && STALE_SESSION_DISCORD_CODES.has(code)
 }

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -148,17 +148,29 @@ async function restoreSingleSession(client: BotClient, session: PlayerSessionDat
 
         await ensurePlayerConnected(client, player, voiceChannel)
 
-        const { resolved, failed } = await resolvePersistedTracks(player, tracksToRestore)
+        const { resolved, failed, transientFailures } = await resolvePersistedTracks(
+            player,
+            tracksToRestore
+        )
         if (failed > 0) {
             client.warn(
-                `[playerSession] restore for ${guildId}: ${failed}/${tracksToRestore.length} tracks failed to resolve`
+                `[playerSession] restore for ${guildId}: ${failed}/${tracksToRestore.length} tracks failed to resolve` +
+                    (transientFailures > 0 ? ` (${transientFailures} transient)` : "")
             )
         }
         if (resolved.length === 0) {
+            await player.destroy()
+            // Lavalink/source blips that throw during decode/search must not wipe the snapshot.
+            // Deterministic no-match (search returned nothing usable) still deletes.
+            if (transientFailures > 0) {
+                client.warn(
+                    `[playerSession] restore for ${guildId}: no tracks resolved due to transient failures; preserving session`
+                )
+                return
+            }
             client.warn(
                 `[playerSession] restore for ${guildId}: no tracks resolved; destroying player`
             )
-            await player.destroy()
             await deletePlayerSession(guildId)
             return
         }

--- a/src/util/rrqDisconnect.test.ts
+++ b/src/util/rrqDisconnect.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player, Track } from "lavalink-client"
+import {
+    clearDisconnectedUser,
+    getDisconnectedUsers,
+    hasTrackedDisconnect,
+    isDisconnectTimeoutCurrent,
+    isRRQActive,
+    roundRobinReorderTracks,
+    stampRequesterUserIdOnTracks,
+    toggleRRQ,
+    trackDisconnectedUser,
+    userHasQueuedTracks,
+} from "./rrqDisconnect.js"
+
+function mockTrack(requester: unknown, title = "t"): Track {
+    return {
+        encoded: "enc",
+        info: {
+            title,
+            author: "a",
+            uri: `https://example.com/${title}`,
+            duration: 1000,
+            isStream: false,
+            identifier: title,
+            isSeekable: true,
+            sourceName: "http",
+            artworkUrl: null,
+            isrc: null,
+        },
+        requester,
+    } as unknown as Track
+}
+
+function mockPlayer(tracks: Track[] = []): Player {
+    const store = new Map<string, unknown>()
+    return {
+        guildId: "guild-rrq",
+        queue: {
+            current: null,
+            tracks,
+        },
+        get: (key: string) => store.get(key),
+        set: (key: string, value: unknown) => {
+            store.set(key, value)
+        },
+    } as unknown as Player
+}
+
+describe("roundRobinReorderTracks", () => {
+    it("returns a shallow copy for empty or single-track queues", () => {
+        const empty = roundRobinReorderTracks([], "__rrq_none__")
+        assert.deepEqual(empty, [])
+        assert.notEqual(empty, [])
+
+        const one = [mockTrack("a", "only")]
+        const reordered = roundRobinReorderTracks(one, "a")
+        assert.equal(reordered.length, 1)
+        assert.equal(reordered[0], one[0])
+        assert.notEqual(reordered, one)
+    })
+
+    it("avoids the previous requester when another user has tracks", () => {
+        const a1 = mockTrack("a", "a1")
+        const a2 = mockTrack("a", "a2")
+        const b1 = mockTrack("b", "b1")
+        const ordered = roundRobinReorderTracks([a1, a2, b1], "a")
+        assert.equal(ordered[0], b1)
+        assert.ok(ordered.slice(1).every((t) => t.requester === "a"))
+    })
+
+    it("prefers the heavier remaining requester among valid candidates", () => {
+        const a1 = mockTrack("a", "a1")
+        const b1 = mockTrack("b", "b1")
+        const b2 = mockTrack("b", "b2")
+        const b3 = mockTrack("b", "b3")
+        const c1 = mockTrack("c", "c1")
+        // Previous was c → candidates a (1) and b (3); pick b first.
+        const ordered = roundRobinReorderTracks([a1, b1, b2, b3, c1], "c")
+        assert.equal(ordered[0]?.requester, "b")
+        // Never place the same requester twice in a row while another user still has tracks.
+        for (let i = 1; i < ordered.length; i++) {
+            const prev = ordered[i - 1]?.requester
+            const cur = ordered[i]?.requester
+            if (prev === cur) {
+                const othersRemain = ordered.slice(i).some((t) => t.requester !== cur)
+                assert.equal(
+                    othersRemain,
+                    false,
+                    `unexpected back-to-back ${String(cur)} while others remain`
+                )
+            }
+        }
+    })
+
+    it("falls back to same requester when no alternate remains", () => {
+        const a1 = mockTrack("a", "a1")
+        const a2 = mockTrack("a", "a2")
+        const ordered = roundRobinReorderTracks([a1, a2], "a")
+        assert.deepEqual(
+            ordered.map((t) => t.info.title),
+            ["a1", "a2"]
+        )
+    })
+
+    it("treats missing requesters as a shared unknown bucket", () => {
+        const missing = mockTrack(null, "missing")
+        const other = mockTrack("u1", "other")
+        const ordered = roundRobinReorderTracks([missing, other], "__rrq_none__")
+        // Heavier-first among candidates from no previous: both length 1; first key wins reduce.
+        assert.equal(ordered.length, 2)
+        assert.ok(ordered.includes(missing))
+        assert.ok(ordered.includes(other))
+        // After placing one, the next should prefer the other bucket over repeating unknown/user.
+        assert.notEqual(ordered[0]?.requester ?? null, ordered[1]?.requester ?? null)
+    })
+
+    it("reads object-shaped requesters the same as string ids", () => {
+        const a = mockTrack({ id: "user-a" }, "a")
+        const b = mockTrack({ id: "user-b" }, "b")
+        const ordered = roundRobinReorderTracks([a, a, b], "user-a")
+        assert.equal(ordered[0], b)
+    })
+})
+
+describe("stampRequesterUserIdOnTracks", () => {
+    it("stamps a stable string requester on each track", () => {
+        const tracks = [mockTrack({ id: "old" }, "t1"), mockTrack("other", "t2")]
+        stampRequesterUserIdOnTracks(tracks, "discord-user")
+        assert.equal(tracks[0]?.requester, "discord-user")
+        assert.equal(tracks[1]?.requester, "discord-user")
+    })
+})
+
+describe("RRQ disconnect tracking", () => {
+    it("creates, replaces, and clears disconnect timers without leaving stale handles", () => {
+        const player = mockPlayer()
+        const first = setTimeout(() => {}, 60_000)
+        const second = setTimeout(() => {}, 60_000)
+        try {
+            trackDisconnectedUser(player, "u1", first)
+            assert.equal(hasTrackedDisconnect(player, "u1"), true)
+            assert.equal(isDisconnectTimeoutCurrent(player, "u1", first), true)
+
+            trackDisconnectedUser(player, "u1", second)
+            assert.equal(isDisconnectTimeoutCurrent(player, "u1", first), false)
+            assert.equal(isDisconnectTimeoutCurrent(player, "u1", second), true)
+
+            clearDisconnectedUser(player, "u1")
+            assert.equal(hasTrackedDisconnect(player, "u1"), false)
+            assert.equal(getDisconnectedUsers(player).size, 0)
+        } finally {
+            clearTimeout(first)
+            clearTimeout(second)
+        }
+    })
+
+    it("toggleRRQ clears pending disconnect timers when disabling", () => {
+        const player = mockPlayer()
+        const handle = setTimeout(() => {}, 60_000)
+        try {
+            assert.equal(isRRQActive(player), false)
+            assert.equal(toggleRRQ(player), true)
+            assert.equal(isRRQActive(player), true)
+
+            trackDisconnectedUser(player, "u1", handle)
+            assert.equal(hasTrackedDisconnect(player, "u1"), true)
+
+            assert.equal(toggleRRQ(player), false)
+            assert.equal(isRRQActive(player), false)
+            assert.equal(hasTrackedDisconnect(player, "u1"), false)
+        } finally {
+            clearTimeout(handle)
+        }
+    })
+
+    it("userHasQueuedTracks inspects upcoming tracks only", () => {
+        const player = mockPlayer([mockTrack("u1", "q1"), mockTrack("u2", "q2")])
+        assert.equal(userHasQueuedTracks(player, "u1"), true)
+        assert.equal(userHasQueuedTracks(player, "u3"), false)
+    })
+})

--- a/src/util/rrqDisconnect.ts
+++ b/src/util/rrqDisconnect.ts
@@ -1,6 +1,7 @@
 import type { Player, Track, UnresolvedTrack } from "lavalink-client"
 import type { RRQDisconnectedUsersMap } from "../types/index.js"
-import { createGuildAsyncChain } from "./guildAsyncChain.js"
+import { withGuildPlayerQueueLock } from "./guildPlayerQueueLock.js"
+import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
 
 const RRQ_DISCONNECTED_USERS_KEY = "rrqDisconnectedUsers"
 const RRQ_ENABLED_KEY = "rrqEnabled"
@@ -89,8 +90,11 @@ export function roundRobinReorderTracks(
     return result
 }
 
-/** Core reorder; must run inside enqueueRrqMutation (or call exported rebalancePlayerQueueRoundRobin). */
-async function rebalancePlayerQueueRoundRobinImpl(player: Player): Promise<void> {
+/**
+ * Core reorder. Callers must already hold {@link withGuildPlayerQueueLock} for this guild
+ * (or use {@link rebalancePlayerQueueRoundRobin}, which acquires it).
+ */
+export async function rebalancePlayerQueueRoundRobinAssumingLock(player: Player): Promise<void> {
     if (!isRRQActive(player)) return
     const tracks = player.queue.tracks
     const n = tracks.length
@@ -110,10 +114,13 @@ async function rebalancePlayerQueueRoundRobinImpl(player: Player): Promise<void>
 
 /**
  * Re-sorts `player.queue.tracks` for round-robin fairness when RRQ mode is on.
- * Serialized per guild with other RRQ queue mutations so snapshot/reorder cannot race concurrent splices.
+ * Uses the shared guild player queue lock so rebalance cannot race dashboard/Discord clears
+ * (a separate RRQ-only chain could splice a pre-clear snapshot back after clear).
  */
 export async function rebalancePlayerQueueRoundRobin(player: Player): Promise<void> {
-    return enqueueRrqMutation(player.guildId, () => rebalancePlayerQueueRoundRobinImpl(player))
+    return withGuildPlayerQueueLock(player.guildId, () =>
+        rebalancePlayerQueueRoundRobinAssumingLock(player)
+    )
 }
 
 /** Returns the per-player map of users pending RRQ disconnect cleanup, creating it if missing. */
@@ -216,8 +223,6 @@ export async function removeUserTracksFromQueue(player: Player, userId: string):
     return removed
 }
 
-const enqueueRrqMutation = createGuildAsyncChain()
-
 export type RemoveAndRebalanceRrqHooks = {
     onRemoveError?: (err: unknown) => void
     onRebalanceError?: (err: unknown) => void
@@ -225,14 +230,14 @@ export type RemoveAndRebalanceRrqHooks = {
 
 /**
  * Runs disconnect cleanup (remove user’s queued tracks, clear disconnect tracking, optional rebalance)
- * serialized per guild so reordering cannot race with other RRQ queue mutations for that player.
+ * under the shared guild player queue lock so clear/enqueue/reorder cannot interleave with splices.
  */
 export async function removeAndRebalanceRrqAfterDisconnect(
     player: Player,
     userId: string,
     hooks?: RemoveAndRebalanceRrqHooks
 ): Promise<number> {
-    return enqueueRrqMutation(player.guildId, async () => {
+    return withGuildPlayerQueueLock(player.guildId, async () => {
         let removedCount = 0
         try {
             removedCount = await removeUserTracksFromQueue(player, userId)
@@ -244,10 +249,14 @@ export async function removeAndRebalanceRrqAfterDisconnect(
 
         if (removedCount > 0 && isRRQActive(player)) {
             try {
-                await rebalancePlayerQueueRoundRobinImpl(player)
+                await rebalancePlayerQueueRoundRobinAssumingLock(player)
             } catch (rebalErr: unknown) {
                 hooks?.onRebalanceError?.(rebalErr)
             }
+        }
+
+        if (removedCount > 0) {
+            schedulePlayerSessionSave(player)
         }
 
         return removedCount

--- a/src/util/rrqQueueLock.test.ts
+++ b/src/util/rrqQueueLock.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player, Track } from "lavalink-client"
+import { createGuildAsyncChain } from "./guildAsyncChain.js"
+import { withGuildPlayerQueueLock } from "./guildPlayerQueueLock.js"
+import {
+    rebalancePlayerQueueRoundRobin,
+    removeAndRebalanceRrqAfterDisconnect,
+    stampRequesterUserIdOnTracks,
+} from "./rrqDisconnect.js"
+
+function mockTrack(id: string, requesterId: string): Track {
+    return {
+        encoded: `enc-${id}`,
+        info: {
+            title: id,
+            author: "Artist",
+            uri: `https://example.com/${id}`,
+            duration: 1000,
+            isStream: false,
+            identifier: id,
+            isSeekable: true,
+            sourceName: "http",
+            artworkUrl: null,
+            isrc: null,
+        },
+        requester: requesterId,
+    } as unknown as Track
+}
+
+function mockMutablePlayer(guildId: string, initial: Track[] = []): Player {
+    const tracks = [...initial]
+    const store = new Map<string, unknown>()
+    store.set("rrqEnabled", true)
+    return {
+        guildId,
+        playing: true,
+        queue: {
+            current: null,
+            tracks,
+            add(items: Track | Track[], index?: number) {
+                const list = Array.isArray(items) ? items : [items]
+                if (typeof index === "number") tracks.splice(index, 0, ...list)
+                else tracks.push(...list)
+            },
+            async splice(start: number, deleteCount: number, ...insert: Track[]) {
+                return tracks.splice(start, deleteCount, ...insert.flat())
+            },
+        },
+        get(key: string) {
+            return store.get(key)
+        },
+        set(key: string, value: unknown) {
+            store.set(key, value)
+        },
+    } as unknown as Player
+}
+
+describe("RRQ vs guild queue lock", () => {
+    it("legacy separate RRQ chain can resurrect tracks after a guild-locked clear", async () => {
+        // Documents the pre-fix race: RRQ splice on its own chain after clear under guild lock.
+        const guildId = "guild-rrq-legacy-race"
+        const player = mockMutablePlayer(guildId, [
+            mockTrack("a1", "user-a"),
+            mockTrack("b1", "user-b"),
+            mockTrack("a2", "user-a"),
+        ])
+        const rrqOnlyChain = createGuildAsyncChain()
+
+        let releaseRebalance!: () => void
+        const rebalanceGate = new Promise<void>((resolve) => {
+            releaseRebalance = resolve
+        })
+
+        const rebalanceP = rrqOnlyChain(guildId, async () => {
+            const snapshot = [...player.queue.tracks]
+            const n = snapshot.length
+            await rebalanceGate
+            await player.queue.splice(0, n, snapshot)
+        })
+
+        await Promise.resolve()
+
+        const clearP = withGuildPlayerQueueLock(guildId, async () => {
+            const size = player.queue.tracks.length
+            if (size > 0) await player.queue.splice(0, size)
+        })
+
+        // Clear can finish while rebalance is still gated (separate chains).
+        await clearP
+        assert.equal(player.queue.tracks.length, 0)
+
+        releaseRebalance()
+        await rebalanceP
+        assert.equal(player.queue.tracks.length, 3, "separate RRQ chain resurrects cleared queue")
+    })
+
+    it("shared guild lock prevents rebalance from resurrecting a concurrent clear", async () => {
+        const guildId = "guild-rrq-shared-lock"
+        const player = mockMutablePlayer(guildId, [
+            mockTrack("a1", "user-a"),
+            mockTrack("b1", "user-b"),
+            mockTrack("a2", "user-a"),
+        ])
+
+        let releaseRebalance!: () => void
+        const rebalanceGate = new Promise<void>((resolve) => {
+            releaseRebalance = resolve
+        })
+
+        const rebalanceP = withGuildPlayerQueueLock(guildId, async () => {
+            const snapshot = [...player.queue.tracks]
+            const n = snapshot.length
+            await rebalanceGate
+            await player.queue.splice(0, n, snapshot)
+        })
+
+        await Promise.resolve()
+
+        const clearP = withGuildPlayerQueueLock(guildId, async () => {
+            const size = player.queue.tracks.length
+            if (size > 0) await player.queue.splice(0, size)
+        })
+
+        releaseRebalance()
+        await Promise.all([rebalanceP, clearP])
+        assert.equal(player.queue.tracks.length, 0)
+    })
+
+    it("rebalancePlayerQueueRoundRobin serializes with clear on the guild lock", async () => {
+        const guildId = "guild-rrq-public-api"
+        const a1 = mockTrack("a1", "user-a")
+        const b1 = mockTrack("b1", "user-b")
+        stampRequesterUserIdOnTracks([a1], "user-a")
+        stampRequesterUserIdOnTracks([b1], "user-b")
+        const player = mockMutablePlayer(guildId, [a1, b1])
+
+        const rebalanceP = rebalancePlayerQueueRoundRobin(player)
+        const clearP = withGuildPlayerQueueLock(guildId, async () => {
+            const size = player.queue.tracks.length
+            if (size > 0) await player.queue.splice(0, size)
+        })
+        await Promise.all([rebalanceP, clearP])
+        assert.equal(player.queue.tracks.length, 0)
+    })
+
+    it("removeAndRebalanceRrqAfterDisconnect removes only the disconnected user's tracks", async () => {
+        const guildId = "guild-rrq-remove-user"
+        const a1 = mockTrack("a1", "user-a")
+        const b1 = mockTrack("b1", "user-b")
+        const a2 = mockTrack("a2", "user-a")
+        stampRequesterUserIdOnTracks([a1, a2], "user-a")
+        stampRequesterUserIdOnTracks([b1], "user-b")
+        const player = mockMutablePlayer(guildId, [a1, b1, a2])
+
+        const removed = await removeAndRebalanceRrqAfterDisconnect(player, "user-a")
+        assert.equal(removed, 2)
+        assert.equal(player.queue.tracks.length, 1)
+        assert.equal(player.queue.tracks[0]?.info.title, "b1")
+    })
+})

--- a/src/util/sameVoiceChannel.test.ts
+++ b/src/util/sameVoiceChannel.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { memberMayControlPlayerVoice } from "./sameVoiceChannel.js"
+
+describe("memberMayControlPlayerVoice", () => {
+    it("allows when the player has no voice channel id", () => {
+        assert.equal(memberMayControlPlayerVoice(undefined, "vc-a"), true)
+        assert.equal(memberMayControlPlayerVoice(null, "vc-a"), true)
+        assert.equal(memberMayControlPlayerVoice("", "vc-a"), true)
+    })
+
+    it("allows when member is in the same channel as the player", () => {
+        assert.equal(memberMayControlPlayerVoice("vc-a", "vc-a"), true)
+    })
+
+    it("rejects when member is in a different channel", () => {
+        assert.equal(memberMayControlPlayerVoice("vc-a", "vc-b"), false)
+    })
+})

--- a/src/util/sameVoiceChannel.ts
+++ b/src/util/sameVoiceChannel.ts
@@ -1,0 +1,11 @@
+/**
+ * Whether a member in `memberVoiceChannelId` may control a player in `playerVoiceChannelId`.
+ * Matches Skip / control-button semantics: missing player channel is treated as allowed.
+ */
+export function memberMayControlPlayerVoice(
+    playerVoiceChannelId: string | null | undefined,
+    memberVoiceChannelId: string
+): boolean {
+    if (!playerVoiceChannelId) return true
+    return playerVoiceChannelId === memberVoiceChannelId
+}

--- a/src/util/skipCurrentTrack.test.ts
+++ b/src/util/skipCurrentTrack.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { skipCurrentTrack } from "./skipCurrentTrack.js"
+
+describe("skipCurrentTrack", () => {
+    it("uses default skip when upcoming tracks exist", async () => {
+        const calls: Array<{ skipTo?: number; throwError?: boolean }> = []
+        await skipCurrentTrack({
+            queue: { tracks: { length: 2 } },
+            skip: async (skipTo, throwError) => {
+                calls.push({ skipTo, throwError })
+            },
+        })
+        assert.deepEqual(calls, [{ skipTo: undefined, throwError: undefined }])
+    })
+
+    it("uses skip(0, false) when only the current track remains", async () => {
+        const calls: Array<{ skipTo?: number; throwError?: boolean }> = []
+        await skipCurrentTrack({
+            queue: { tracks: { length: 0 } },
+            skip: async (skipTo, throwError) => {
+                calls.push({ skipTo, throwError })
+            },
+        })
+        assert.deepEqual(calls, [{ skipTo: 0, throwError: false }])
+    })
+})

--- a/src/util/skipCurrentTrack.ts
+++ b/src/util/skipCurrentTrack.ts
@@ -1,0 +1,14 @@
+/**
+ * Advances past the current track without using default `skip()`, which throws when the
+ * upcoming queue is empty (lavalink-client). Matches `/skip`, control buttons, and web player.
+ */
+export async function skipCurrentTrack(player: {
+    queue: { tracks: { length: number } }
+    skip: (skipTo?: number, throwError?: boolean) => Promise<unknown>
+}): Promise<void> {
+    if (player.queue.tracks.length > 0) {
+        await player.skip()
+        return
+    }
+    await player.skip(0, false)
+}

--- a/src/util/trackThumbnail.test.ts
+++ b/src/util/trackThumbnail.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { thumbnailFromLavalinkTrack, thumbnailUrlFromUri } from "./trackThumbnail.js"
+
+describe("thumbnailUrlFromUri", () => {
+    it("extracts YouTube ids across common host/path shapes", () => {
+        const id = "dQw4w9WgXcQ"
+        const expected = `https://img.youtube.com/vi/${id}/hqdefault.jpg`
+        assert.equal(thumbnailUrlFromUri(`https://www.youtube.com/watch?v=${id}`), expected)
+        assert.equal(thumbnailUrlFromUri(`https://youtu.be/${id}`), expected)
+        assert.equal(thumbnailUrlFromUri(`https://www.youtube.com/embed/${id}`), expected)
+        assert.equal(thumbnailUrlFromUri(`https://www.youtube.com/shorts/${id}`), expected)
+        assert.equal(
+            thumbnailUrlFromUri(`https://music.youtube.com/watch?v=${id}&list=x`),
+            expected
+        )
+    })
+
+    it("returns null for blank or non-YouTube URIs", () => {
+        assert.equal(thumbnailUrlFromUri(""), null)
+        assert.equal(thumbnailUrlFromUri("   "), null)
+        assert.equal(thumbnailUrlFromUri("https://open.spotify.com/track/abc"), null)
+        assert.equal(thumbnailUrlFromUri("https://www.youtube.com/watch?v=short"), null)
+    })
+})
+
+describe("thumbnailFromLavalinkTrack", () => {
+    it("prefers artworkUrl, then YouTube identifier, then URI parse", () => {
+        assert.equal(
+            thumbnailFromLavalinkTrack({
+                info: { artworkUrl: "https://cdn.example/art.jpg", uri: "" },
+            } as never),
+            "https://cdn.example/art.jpg"
+        )
+        assert.equal(
+            thumbnailFromLavalinkTrack({
+                info: {
+                    identifier: "dQw4w9WgXcQ",
+                    sourceName: "youtube",
+                    uri: "https://example.com",
+                },
+            } as never),
+            "https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+        )
+        assert.equal(
+            thumbnailFromLavalinkTrack({
+                info: {
+                    sourceName: "http",
+                    uri: "https://youtu.be/dQw4w9WgXcQ",
+                },
+            } as never),
+            "https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+        )
+    })
+})

--- a/src/util/voiceChannelMembers.test.ts
+++ b/src/util/voiceChannelMembers.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { VoiceBasedChannel } from "discord.js"
+import { countHumanMembers } from "./voiceChannelMembers.js"
+
+type VoiceStateLike = { channelId: string | null; id: string }
+
+function mockVoiceChannel(opts: {
+    channelId: string
+    botId?: string | null
+    voiceStates: VoiceStateLike[]
+}): VoiceBasedChannel {
+    const cache = {
+        filter(predicate: (vs: VoiceStateLike) => boolean) {
+            const matches = opts.voiceStates.filter(predicate)
+            return { size: matches.length }
+        },
+    }
+    return {
+        id: opts.channelId,
+        guild: {
+            client: { user: opts.botId === null ? null : { id: opts.botId ?? "bot-1" } },
+            voiceStates: { cache },
+        },
+    } as unknown as VoiceBasedChannel
+}
+
+describe("countHumanMembers", () => {
+    it("counts voiceStates in this channel and excludes the bot by id", () => {
+        const channel = mockVoiceChannel({
+            channelId: "vc-1",
+            botId: "bot-1",
+            voiceStates: [
+                { id: "bot-1", channelId: "vc-1" },
+                { id: "human-1", channelId: "vc-1" },
+                { id: "human-2", channelId: "vc-1" },
+                { id: "human-other", channelId: "vc-2" },
+            ],
+        })
+        assert.equal(countHumanMembers(channel), 2)
+    })
+
+    it("returns 0 when only the bot (or nobody) is in the channel", () => {
+        assert.equal(
+            countHumanMembers(
+                mockVoiceChannel({
+                    channelId: "vc-1",
+                    voiceStates: [{ id: "bot-1", channelId: "vc-1" }],
+                })
+            ),
+            0
+        )
+        assert.equal(
+            countHumanMembers(mockVoiceChannel({ channelId: "vc-1", voiceStates: [] })),
+            0
+        )
+    })
+
+    it("does not rely on GuildMember cache (voiceStates remain authoritative)", () => {
+        // Regression: voiceChannel.members can be empty when members are uncached even though
+        // humans are connected — restore must not delete the session in that case.
+        const channel = mockVoiceChannel({
+            channelId: "vc-1",
+            voiceStates: [{ id: "human-uncached", channelId: "vc-1" }],
+        })
+        assert.equal(countHumanMembers(channel), 1)
+    })
+})

--- a/src/util/voiceChannelMembers.test.ts
+++ b/src/util/voiceChannelMembers.test.ts
@@ -50,10 +50,7 @@ describe("countHumanMembers", () => {
             ),
             0
         )
-        assert.equal(
-            countHumanMembers(mockVoiceChannel({ channelId: "vc-1", voiceStates: [] })),
-            0
-        )
+        assert.equal(countHumanMembers(mockVoiceChannel({ channelId: "vc-1", voiceStates: [] })), 0)
     })
 
     it("does not rely on GuildMember cache (voiceStates remain authoritative)", () => {

--- a/src/util/webAuthAndSanitize.test.ts
+++ b/src/util/webAuthAndSanitize.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { authErrorMessage } from "../web/lib/auth-error-message.js"
+import { normalizeSearchParam } from "../web/lib/normalize-search-param.js"
+import { sanitizeErrorText } from "../web/lib/sanitize-log-text.js"
+
+describe("sanitizeErrorText", () => {
+    it("redacts bearer/basic auth, password, and token key=value forms", () => {
+        const out = sanitizeErrorText(
+            "Authorization Bearer abc.def-ghi Authorization Basic dXNlcjpwYXNz password=supersecret token=xyz apikey=abc123 secret=shh",
+            2000
+        )
+        assert.match(out, /Bearer \[REDACTED]/)
+        assert.match(out, /Basic \[REDACTED]/)
+        assert.match(out, /password=\[REDACTED]/)
+        assert.match(out, /token=\[REDACTED]/)
+        assert.match(out, /secret=\[REDACTED]/)
+        assert.doesNotMatch(out, /supersecret|xyz|abc123|shh|abc\.def/)
+    })
+
+    it("redacts JSON secret keys, DB URLs, and JWTs", () => {
+        const jwt =
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP2S3AkMNUzSOQy6lc45VWXisES5l2kCuba8"
+        const out = sanitizeErrorText(
+            `{"access_token":"tok","client_secret":"cs","api_key":"k"} postgres://user:pass@host/db ${jwt}`,
+            4000
+        )
+        assert.match(out, /"access_token":"\[REDACTED]"/)
+        assert.match(out, /"client_secret":"\[REDACTED]"/)
+        assert.match(out, /"api_key":"\[REDACTED]"/)
+        assert.match(out, /postgres:\/\/\[REDACTED]@/)
+        assert.match(out, /\[REDACTED_JWT]/)
+        assert.doesNotMatch(out, /user:pass|tok"|"cs"|"k"|eyJhbGci/)
+    })
+
+    it("truncates output to maxLen with an ellipsis", () => {
+        const out = sanitizeErrorText("abcdefghij", 5)
+        assert.equal(out, "abcde…")
+    })
+})
+
+describe("normalizeSearchParam", () => {
+    it("returns undefined for missing values", () => {
+        assert.equal(normalizeSearchParam(undefined), undefined)
+    })
+
+    it("returns the first non-empty trimmed entry from repeated keys", () => {
+        assert.equal(normalizeSearchParam(["", "  ", " first ", "second"]), "first")
+        assert.equal(normalizeSearchParam(["only"]), "only")
+    })
+
+    it("falls back to the first string when all entries are empty", () => {
+        assert.equal(normalizeSearchParam(["", "  "]), "")
+        assert.equal(normalizeSearchParam([]), undefined)
+    })
+
+    it("passes through a single string unchanged", () => {
+        assert.equal(normalizeSearchParam("access_denied"), "access_denied")
+    })
+})
+
+describe("authErrorMessage", () => {
+    it("maps known OAuth codes to specific copy", () => {
+        assert.match(authErrorMessage("please_restart_the_process"), /expired or was interrupted/i)
+        assert.match(authErrorMessage("ACCESS_DENIED"), /cancelled/i)
+        assert.match(authErrorMessage(" invalid_code "), /already been used/i)
+        assert.match(authErrorMessage("invalid_grant"), /already been used/i)
+    })
+
+    it("uses a generic message for missing or unknown codes", () => {
+        assert.match(authErrorMessage(undefined), /could not be completed/i)
+        assert.match(authErrorMessage(""), /could not be completed/i)
+        assert.match(authErrorMessage("totally_unknown"), /Try again from the home page/i)
+    })
+})

--- a/src/util/webUrlAndPlaylistTimeout.test.ts
+++ b/src/util/webUrlAndPlaylistTimeout.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { playlistPlayTimeoutMs } from "../web/lib/playlist-play-timeout.js"
+import { sanitizeHttpUrl } from "../web/lib/url-utils.js"
+
+describe("sanitizeHttpUrl", () => {
+    it("accepts http(s) URLs and normalizes via URL", () => {
+        assert.equal(sanitizeHttpUrl("https://example.com/a"), "https://example.com/a")
+        assert.equal(sanitizeHttpUrl("http://example.com"), "http://example.com/")
+    })
+
+    it("rejects non-strings, empty values, and non-http(s) schemes", () => {
+        assert.equal(sanitizeHttpUrl(null), null)
+        assert.equal(sanitizeHttpUrl(undefined), null)
+        assert.equal(sanitizeHttpUrl(""), null)
+        assert.equal(sanitizeHttpUrl("javascript:alert(1)"), null)
+        assert.equal(sanitizeHttpUrl("data:text/html,hi"), null)
+        assert.equal(sanitizeHttpUrl("ftp://example.com/file"), null)
+        assert.equal(sanitizeHttpUrl("not a url"), null)
+    })
+})
+
+describe("playlistPlayTimeoutMs", () => {
+    it("uses a one-track baseline for non-positive or non-finite counts", () => {
+        assert.equal(playlistPlayTimeoutMs(1), 32_500)
+        assert.equal(playlistPlayTimeoutMs(0), 32_500)
+        assert.equal(playlistPlayTimeoutMs(-3), 32_500)
+        assert.equal(playlistPlayTimeoutMs(Number.NaN), 32_500)
+    })
+
+    it("scales with track count and floors fractional counts", () => {
+        assert.equal(playlistPlayTimeoutMs(2), 35_000)
+        assert.equal(playlistPlayTimeoutMs(2.9), 35_000)
+        assert.equal(playlistPlayTimeoutMs(10), 55_000)
+    })
+
+    it("caps at five minutes for very large playlists", () => {
+        assert.equal(playlistPlayTimeoutMs(200), 300_000)
+        assert.equal(playlistPlayTimeoutMs(10_000), 300_000)
+    })
+})


### PR DESCRIPTION
## Summary

- Consolidates open Cursor bot/automation PRs into one review branch for CodeRabbit and human review
- Integration branch: `chore/consolidated-cursor-fixes-jul-2026` from current `main`
- Source PRs closed as superseded on create (skill override of close-after-merge)
- Conflicts resolved while merging: `lavaManagerEvents.ts` (session clear + orphan destroy + stuck skip), `playlistPlay.ts` (lifecycle reservation + atomic replace), `playlistQueue.ts` (RRQ lock-aware rebalance), `discordLogForward.test.ts` (merged guild-scope + channel tests)
- Follow-up on integration branch: cast permission test mocks for duck-typed `PermissionClient`; Prettier on touched paths

## Supersedes

- #133 — test: regression coverage for restore/countdown/download edges (https://github.com/bpeters132/DimbyBot2/pull/133)
- #134 — fix: stop idle destroy from killing reserved players / wiping sessions (https://github.com/bpeters132/DimbyBot2/pull/134)
- #135 — fix: require Manage Guild for /downloads cleanup (https://github.com/bpeters132/DimbyBot2/pull/135)
- #137 — test: regression coverage for RRQ reorder and disconnect tracking (https://github.com/bpeters132/DimbyBot2/pull/137)
- #138 — fix: require same voice channel for /leave and /stop (https://github.com/bpeters132/DimbyBot2/pull/138)
- #139 — fix: reject oversized /download WAV that bypasses guild quota (https://github.com/bpeters132/DimbyBot2/pull/139)
- #140 — test: regression coverage for autoplay matching and history (https://github.com/bpeters132/DimbyBot2/pull/140)
- #141 — fix: preserve player sessions on Discord disconnect and infra destroys (https://github.com/bpeters132/DimbyBot2/pull/141)
- #142 — fix: require same voice channel for /seek (https://github.com/bpeters132/DimbyBot2/pull/142)
- #143 — test: regression coverage for permissions, snowflake, and countdown format (https://github.com/bpeters132/DimbyBot2/pull/143)
- #144 — fix: serialize playlist replace and dashboard queue mutations (https://github.com/bpeters132/DimbyBot2/pull/144)
- #145 — test: regression coverage for voice summary, URL sanitize, thumbnails (https://github.com/bpeters132/DimbyBot2/pull/145)
- #146 — fix: skip stuck tracks safely when upcoming queue is empty (https://github.com/bpeters132/DimbyBot2/pull/146)
- #147 — fix: require same voice channel for /download autoplay (https://github.com/bpeters132/DimbyBot2/pull/147)
- #148 — test: regression coverage for discord logs, requester snapshots, and web sanitize/auth (https://github.com/bpeters132/DimbyBot2/pull/148)
- #149 — fix: serialize RRQ mutations on guild queue lock (stop clear resurrection) (https://github.com/bpeters132/DimbyBot2/pull/149)
- #150 — fix: scope Discord log forwarding to guild (cross-tenant leak) (https://github.com/bpeters132/DimbyBot2/pull/150)

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` (162 pass)
- [x] Prettier on consolidated branch paths
- [ ] Spot-check voice-channel gates, session preserve/clear, RRQ lock, Discord log guild scoping in the diff
- Skipped: `audit:check-imports` (not in this repo)

## Notes

- Cherry-picked oldest-first; conflicts resolved on the integration branch
- Do not merge source PRs individually; this PR is the single review unit