### PR TITLE
chore: consolidate Cursor fixes and regression tests (Jul 2026 wave 2)

### DIFF
--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -17,7 +17,7 @@ import {
     snapshotUpcomingQueue,
 } from "../../util/playlistQueue.js"
 import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
-import { acquirePlayerSessionClearSuppressLease } from "../../util/playerSessionPersistence.js"
+import { destroyPlayerSuppressingSessionClear } from "../../util/playerSessionPersistence.js"
 
 export async function playerPlaylistPlayPOST(
     headers: Headers,
@@ -149,11 +149,9 @@ export async function playerPlaylistPlayPOST(
             // land between the check and teardown.
             await withGuildPlayerQueueLock(guildId, async () => {
                 if (playerHasQueueContent(player)) return
-                const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
-                await client.lavalink.destroyPlayer(guildId).catch(() => {
-                    // Release only this attempt's lease; clearPlayerSession consumes on success.
-                    suppressLease.release()
-                })
+                await destroyPlayerSuppressingSessionClear(guildId, () =>
+                    client.lavalink.destroyPlayer(guildId)
+                )
             })
             return {
                 status: 404,

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -7,7 +7,7 @@ import { stampRequesterUserIdOnTracks } from "../../util/rrqDisconnect.js"
 import type { PermissionGuardSuccess } from "../../shared/api-auth.js"
 import { resolveWebDashboardTextChannelId } from "../webDashboardTextChannel.js"
 import {
-    acquirePlayerSessionClearSuppressLease,
+    destroyPlayerSuppressingSessionClear,
     schedulePlayerSessionSave,
 } from "../../util/playerSessionPersistence.js"
 import {
@@ -167,11 +167,9 @@ export async function searchAndEnqueue(
                     return playerHasQueueContent(live)
                 },
                 destroyPlayer: async () => {
-                    const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
-                    await client.lavalink.destroyPlayer(guildId).catch(() => {
-                        // Release only this attempt's lease; clearPlayerSession consumes on success.
-                        suppressLease.release()
-                    })
+                    await destroyPlayerSuppressingSessionClear(guildId, () =>
+                        client.lavalink.destroyPlayer(guildId)
+                    )
                 },
             })
         }

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -16,6 +16,10 @@ import {
     withGuildPlayerQueueLock,
 } from "../../util/guildPlayerQueueLock.js"
 import { playerHasQueueContent } from "../../util/playlistQueue.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 
 export type SearchAndEnqueueGuard = Pick<PermissionGuardSuccess, "session">
 
@@ -125,6 +129,19 @@ export async function searchAndEnqueue(
             ok: false,
             status: 403,
             error: { error: "Bot lacks permission to join this voice channel." },
+        }
+    }
+
+    // Refuse takeover while bot occupies another VC (incl. local playback with no Lavalink player).
+    {
+        const existingPlayer = client.lavalink.getPlayer(guildId)
+        const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+        if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+            return {
+                ok: false,
+                status: 403,
+                error: { error: "You need to be in the same voice channel as the bot." },
+            }
         }
     }
 

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -128,32 +128,37 @@ export async function searchAndEnqueue(
         }
     }
 
-    let player = client.lavalink.getPlayer(guildId)
-    let createdHere = false
-    if (!player) {
-        try {
-            player = await client.lavalink.createPlayer({
-                guildId,
-                voiceChannelId: voiceChannel.id,
-                textChannelId,
-                selfDeaf: true,
-                volume: 100,
-            })
-            createdHere = true
-        } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err)
-            console.error("[searchAndEnqueue] createPlayer failed", { guildId, requesterId, err })
-            return {
-                ok: false,
-                status: 503,
-                error: { error: "Could not create the player.", details: message },
-            }
-        }
-    }
-
-    // Cover acquisition → search/enqueue so concurrent orphan cleanup cannot destroy mid-use.
+    // Reserve before createPlayer so concurrent orphan/idle destroy cannot tear down a
+    // freshly created player in the window between create and the old post-create acquire.
     const lifecycleReservation = await acquireGuildPlayerLifecycleReservation(guildId)
     try {
+        let player = client.lavalink.getPlayer(guildId)
+        let createdHere = false
+        if (!player) {
+            try {
+                player = await client.lavalink.createPlayer({
+                    guildId,
+                    voiceChannelId: voiceChannel.id,
+                    textChannelId,
+                    selfDeaf: true,
+                    volume: 100,
+                })
+                createdHere = true
+            } catch (err: unknown) {
+                const message = err instanceof Error ? err.message : String(err)
+                console.error("[searchAndEnqueue] createPlayer failed", {
+                    guildId,
+                    requesterId,
+                    err,
+                })
+                return {
+                    ok: false,
+                    status: 503,
+                    error: { error: "Could not create the player.", details: message },
+                }
+            }
+        }
+
         if (textChannelId) {
             player.textChannelId = textChannelId
         }

--- a/src/botApi/httpUtil.test.ts
+++ b/src/botApi/httpUtil.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict"
+import type { IncomingMessage } from "http"
+import { describe, it } from "node:test"
+import { incomingMessageToHeaders } from "./httpUtil.js"
+
+function fakeReq(headers: IncomingMessage["headers"]): IncomingMessage {
+    return { headers } as IncomingMessage
+}
+
+describe("incomingMessageToHeaders", () => {
+    it("copies string header values with set()", () => {
+        const headers = incomingMessageToHeaders(
+            fakeReq({
+                cookie: "session=abc",
+                "content-type": "application/json",
+            })
+        )
+        assert.equal(headers.get("cookie"), "session=abc")
+        assert.equal(headers.get("content-type"), "application/json")
+    })
+
+    it("appends each value when Node supplies a string array", () => {
+        const headers = incomingMessageToHeaders(
+            fakeReq({
+                "set-cookie": ["a=1", "b=2"],
+                "x-forwarded-for": ["1.1.1.1", "2.2.2.2"],
+            })
+        )
+        assert.deepEqual(headers.getSetCookie(), ["a=1", "b=2"])
+        assert.equal(headers.get("x-forwarded-for"), "1.1.1.1, 2.2.2.2")
+    })
+
+    it("skips undefined header values without throwing", () => {
+        const headers = incomingMessageToHeaders(
+            fakeReq({
+                authorization: "Bearer tok",
+                "x-missing": undefined,
+            })
+        )
+        assert.equal(headers.get("authorization"), "Bearer tok")
+        assert.equal(headers.has("x-missing"), false)
+    })
+})

--- a/src/botApi/resolveWebRequesterId.test.ts
+++ b/src/botApi/resolveWebRequesterId.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { resolveWebRequesterDiscordId } from "./resolveWebRequesterId.js"
+
+const SESSION_ID = "123456789012345678"
+
+describe("resolveWebRequesterDiscordId", () => {
+    it("defaults to the authenticated Discord snowflake when body omits requester id", () => {
+        assert.deepEqual(resolveWebRequesterDiscordId({}, SESSION_ID), {
+            ok: true,
+            requesterId: SESSION_ID,
+        })
+        assert.deepEqual(resolveWebRequesterDiscordId(null, SESSION_ID), {
+            ok: true,
+            requesterId: SESSION_ID,
+        })
+        assert.deepEqual(resolveWebRequesterDiscordId("not-an-object", SESSION_ID), {
+            ok: true,
+            requesterId: SESSION_ID,
+        })
+    })
+
+    it("accepts a matching requesterDiscordUserId (trimmed)", () => {
+        assert.deepEqual(
+            resolveWebRequesterDiscordId(
+                { requesterDiscordUserId: `  ${SESSION_ID}  ` },
+                SESSION_ID
+            ),
+            { ok: true, requesterId: SESSION_ID }
+        )
+    })
+
+    it("rejects empty or non-string requesterDiscordUserId when provided", () => {
+        assert.deepEqual(
+            resolveWebRequesterDiscordId({ requesterDiscordUserId: "" }, SESSION_ID),
+            {
+                ok: false,
+                status: 400,
+                error: "Invalid requesterDiscordUserId.",
+                details: "Must be a non-empty string when provided.",
+            }
+        )
+        assert.deepEqual(
+            resolveWebRequesterDiscordId({ requesterDiscordUserId: "   " }, SESSION_ID),
+            {
+                ok: false,
+                status: 400,
+                error: "Invalid requesterDiscordUserId.",
+                details: "Must be a non-empty string when provided.",
+            }
+        )
+        assert.deepEqual(
+            resolveWebRequesterDiscordId({ requesterDiscordUserId: 42 }, SESSION_ID),
+            {
+                ok: false,
+                status: 400,
+                error: "Invalid requesterDiscordUserId.",
+                details: "Must be a non-empty string when provided.",
+            }
+        )
+    })
+
+    it("rejects a requesterDiscordUserId that does not match the signed-in account", () => {
+        assert.deepEqual(
+            resolveWebRequesterDiscordId(
+                { requesterDiscordUserId: "999999999999999999" },
+                SESSION_ID
+            ),
+            {
+                ok: false,
+                status: 403,
+                error: "Forbidden",
+                details: "requesterDiscordUserId does not match the signed-in account.",
+            }
+        )
+    })
+})

--- a/src/botApi/resolveWebRequesterId.test.ts
+++ b/src/botApi/resolveWebRequesterId.test.ts
@@ -31,15 +31,12 @@ describe("resolveWebRequesterDiscordId", () => {
     })
 
     it("rejects empty or non-string requesterDiscordUserId when provided", () => {
-        assert.deepEqual(
-            resolveWebRequesterDiscordId({ requesterDiscordUserId: "" }, SESSION_ID),
-            {
-                ok: false,
-                status: 400,
-                error: "Invalid requesterDiscordUserId.",
-                details: "Must be a non-empty string when provided.",
-            }
-        )
+        assert.deepEqual(resolveWebRequesterDiscordId({ requesterDiscordUserId: "" }, SESSION_ID), {
+            ok: false,
+            status: 400,
+            error: "Invalid requesterDiscordUserId.",
+            details: "Must be a non-empty string when provided.",
+        })
         assert.deepEqual(
             resolveWebRequesterDiscordId({ requesterDiscordUserId: "   " }, SESSION_ID),
             {
@@ -49,15 +46,12 @@ describe("resolveWebRequesterDiscordId", () => {
                 details: "Must be a non-empty string when provided.",
             }
         )
-        assert.deepEqual(
-            resolveWebRequesterDiscordId({ requesterDiscordUserId: 42 }, SESSION_ID),
-            {
-                ok: false,
-                status: 400,
-                error: "Invalid requesterDiscordUserId.",
-                details: "Must be a non-empty string when provided.",
-            }
-        )
+        assert.deepEqual(resolveWebRequesterDiscordId({ requesterDiscordUserId: 42 }, SESSION_ID), {
+            ok: false,
+            status: 400,
+            error: "Invalid requesterDiscordUserId.",
+            details: "Must be a non-empty string when provided.",
+        })
     })
 
     it("rejects a requesterDiscordUserId that does not match the signed-in account", () => {

--- a/src/commands/developer/DownloadLimit.ts
+++ b/src/commands/developer/DownloadLimit.ts
@@ -3,9 +3,12 @@ import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import type { GuildSettingsStore } from "../../types/index.js"
 
+import {
+    DEFAULT_DOWNLOADS_MAX_MB,
+    isCustomDownloadsMaxMb,
+    resolveDownloadsMaxMb,
+} from "../../util/downloadsMaxMb.js"
 import { getGuildSettings, saveGuildSettings } from "../../util/saveControlChannel.js"
-
-const DEFAULT_MAX_DIR_SIZE_MB = 1000
 
 export default {
     data: new SlashCommandBuilder()
@@ -99,9 +102,8 @@ export default {
 
         if (subcommand === "show") {
             const configured = settings[targetGuildId].downloadsMaxMb
-            const parsed = Number(configured ?? Number.NaN)
-            const validCustom = Number.isFinite(parsed) && parsed >= 1
-            const limit = validCustom ? parsed : DEFAULT_MAX_DIR_SIZE_MB
+            const validCustom = isCustomDownloadsMaxMb(configured)
+            const limit = resolveDownloadsMaxMb(configured)
             const suffix = validCustom ? " (custom)" : " (default)"
             return interaction.reply({
                 content: `Download limit for guild ${targetGuildId}: ${limit}MB${suffix}.`,
@@ -148,7 +150,7 @@ export default {
                 }
             }
             return interaction.reply({
-                content: `Cleared custom download limit for guild ${targetGuildId}. Default is ${DEFAULT_MAX_DIR_SIZE_MB}MB.`,
+                content: `Cleared custom download limit for guild ${targetGuildId}. Default is ${DEFAULT_DOWNLOADS_MAX_MB}MB.`,
                 flags: [MessageFlags.Ephemeral],
             })
         }

--- a/src/commands/music/Genre.ts
+++ b/src/commands/music/Genre.ts
@@ -3,6 +3,7 @@ import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction, GuildMember } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
 
+import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 import { seedAutoplayHistoryFromPlayer } from "../../util/autoplayHistory.js"
 
@@ -52,33 +53,6 @@ export default {
 
         const voiceChannel = member.voice.channel
 
-        let player = client.lavalink.getPlayer(guild.id)
-
-        if (!player) {
-            try {
-                player = await client.lavalink.createPlayer({
-                    guildId: guild.id,
-                    voiceChannelId: voiceChannel.id,
-                    textChannelId: interaction.channelId,
-                    selfDeaf: true,
-                    volume: 100,
-                })
-            } catch (err) {
-                client.error("[GenreCmd] createPlayer failed:", err)
-                return interaction.editReply({
-                    content: "Could not join voice right now. Try again in a moment.",
-                    ...noMentions,
-                })
-            }
-        }
-
-        if (player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
-            return interaction.editReply({
-                content: "You need to be in the same voice channel as the bot!",
-                ...noMentions,
-            })
-        }
-
         const textChannel = interaction.channel
         if (!textChannel?.isTextBased() || textChannel.isDMBased()) {
             return interaction.editReply({
@@ -87,16 +61,56 @@ export default {
             })
         }
 
-        const result = await handleQueryAndPlay(
-            client,
-            guild.id,
-            voiceChannel,
-            textChannel,
-            genreName,
-            interaction.user,
-            player
-        )
+        const playOutcome = await withGuildPlayerLifecycleReservation(guild.id, async () => {
+            let player = client.lavalink.getPlayer(guild.id)
 
+            if (!player) {
+                try {
+                    player = await client.lavalink.createPlayer({
+                        guildId: guild.id,
+                        voiceChannelId: voiceChannel.id,
+                        textChannelId: interaction.channelId,
+                        selfDeaf: true,
+                        volume: 100,
+                    })
+                } catch (err) {
+                    client.error("[GenreCmd] createPlayer failed:", err)
+                    return {
+                        kind: "create_failed" as const,
+                    }
+                }
+            }
+
+            if (player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
+                return { kind: "wrong_channel" as const }
+            }
+
+            const result = await handleQueryAndPlay(
+                client,
+                guild.id,
+                voiceChannel,
+                textChannel,
+                genreName,
+                interaction.user,
+                player
+            )
+            return { kind: "played" as const, player, result }
+        })
+
+        if (playOutcome.kind === "create_failed") {
+            return interaction.editReply({
+                content: "Could not join voice right now. Try again in a moment.",
+                ...noMentions,
+            })
+        }
+        if (playOutcome.kind === "wrong_channel") {
+            return interaction.editReply({
+                content: "You need to be in the same voice channel as the bot!",
+                ...noMentions,
+            })
+        }
+
+        const { player, result } = playOutcome
         if (result.success) {
             player.set("autoplay", true)
             seedAutoplayHistoryFromPlayer(player)

--- a/src/commands/music/Genre.ts
+++ b/src/commands/music/Genre.ts
@@ -6,6 +6,10 @@ import { guildMemberFromInteraction } from "../../util/guildMember.js"
 import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 import { seedAutoplayHistoryFromPlayer } from "../../util/autoplayHistory.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -52,6 +56,17 @@ export default {
         }
 
         const voiceChannel = member.voice.channel
+
+        {
+            const existingPlayer = client.lavalink.getPlayer(guild.id)
+            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+            if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                return interaction.editReply({
+                    content: "You need to be in the same voice channel as the bot!",
+                    ...noMentions,
+                })
+            }
+        }
 
         const textChannel = interaction.channel
         if (!textChannel?.isTextBased() || textChannel.isDMBased()) {

--- a/src/commands/music/Play.ts
+++ b/src/commands/music/Play.ts
@@ -4,6 +4,10 @@ import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
 import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 import { webDashboardPromoAppend } from "../../util/webDashboardUrl.js"
 
 export default {
@@ -35,6 +39,18 @@ export default {
         const voiceChannel = member.voice.channel
         if (!voiceChannel) {
             return interaction.reply({ content: "Join a voice channel first!", ephemeral: true })
+        }
+
+        // Cover local @discordjs/voice playback (Lavalink player destroyed) and connected sessions.
+        {
+            const existingPlayer = client.lavalink.getPlayer(guild.id)
+            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+            if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                return interaction.reply({
+                    content: "You need to be in the same voice channel as the bot!",
+                    ephemeral: true,
+                })
+            }
         }
 
         const textChannel = interaction.channel

--- a/src/commands/music/Play.ts
+++ b/src/commands/music/Play.ts
@@ -2,6 +2,7 @@ import { SlashCommandBuilder } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 import { webDashboardPromoAppend } from "../../util/webDashboardUrl.js"
 
@@ -36,30 +37,6 @@ export default {
             return interaction.reply({ content: "Join a voice channel first!", ephemeral: true })
         }
 
-        // Use getPlayer first to potentially reuse existing player
-        let player = client.lavalink.getPlayer(guild.id)
-        let createdNewPlayer = false
-
-        if (!player) {
-            player = await client.lavalink.createPlayer({
-                guildId: guild.id,
-                voiceChannelId: voiceChannel.id,
-                textChannelId: interaction.channelId, // Bind player to interaction channel initially
-                selfDeaf: true,
-                // selfMute: false, // Default is false
-                volume: 100, // Default volume
-            })
-            createdNewPlayer = true
-        }
-
-        if (player.connected && player.voiceChannelId !== voiceChannel.id) {
-            // Optional: Handle user being in a different channel than the bot
-            return interaction.reply({
-                content: "You need to be in the same voice channel as the bot!",
-                ephemeral: true,
-            })
-        }
-
         const textChannel = interaction.channel
         if (!textChannel?.isTextBased() || textChannel.isDMBased()) {
             return interaction.reply({
@@ -70,14 +47,46 @@ export default {
 
         await interaction.deferReply()
 
-        const result = await handleQueryAndPlay(
-            client,
+        // Hold a lifecycle reservation across create + search so web orphan cleanup cannot
+        // destroy the player while Discord /play is still resolving tracks.
+        const { createdNewPlayer, result } = await withGuildPlayerLifecycleReservation(
             guild.id,
-            voiceChannel,
-            textChannel,
-            query,
-            interaction.user,
-            player
+            async () => {
+                let player = client.lavalink.getPlayer(guild.id)
+                let createdNewPlayer = false
+
+                if (!player) {
+                    player = await client.lavalink.createPlayer({
+                        guildId: guild.id,
+                        voiceChannelId: voiceChannel.id,
+                        textChannelId: interaction.channelId,
+                        selfDeaf: true,
+                        volume: 100,
+                    })
+                    createdNewPlayer = true
+                }
+
+                if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+                    return {
+                        createdNewPlayer: false,
+                        result: {
+                            success: false,
+                            feedbackText: "You need to be in the same voice channel as the bot!",
+                        },
+                    }
+                }
+
+                const result = await handleQueryAndPlay(
+                    client,
+                    guild.id,
+                    voiceChannel,
+                    textChannel,
+                    query,
+                    interaction.user,
+                    player
+                )
+                return { createdNewPlayer, result }
+            }
         )
 
         let replyText = result.feedbackText || "Something went wrong."

--- a/src/commands/music/Playlist.ts
+++ b/src/commands/music/Playlist.ts
@@ -98,7 +98,10 @@ export default {
                     opt.setName("name").setDescription("Playlist name").setRequired(true)
                 )
                 .addBooleanOption((opt) =>
-                    opt.setName("shuffle").setDescription("Shuffle before queuing").setRequired(false)
+                    opt
+                        .setName("shuffle")
+                        .setDescription("Shuffle before queuing")
+                        .setRequired(false)
                 )
         ),
 
@@ -122,269 +125,280 @@ export default {
         const subcommand = interaction.options.getSubcommand()
 
         try {
-        if (subcommand === "create") {
-            const name = interaction.options.getString("name", true)
-            const existing = await getPlaylist(userId, name)
-            if (existing) {
+            if (subcommand === "create") {
+                const name = interaction.options.getString("name", true)
+                const existing = await getPlaylist(userId, name)
+                if (existing) {
+                    return interaction.reply({
+                        content: `You already have a playlist named **${name}**.`,
+                        ephemeral: true,
+                    })
+                }
+                await createPlaylist(userId, name)
                 return interaction.reply({
-                    content: `You already have a playlist named **${name}**.`,
-                    ephemeral: true,
-                })
-            }
-            await createPlaylist(userId, name)
-            return interaction.reply({
-                content: `Created playlist **${name}**.`,
-                ephemeral: true,
-            })
-        }
-
-        if (subcommand === "delete") {
-            const name = interaction.options.getString("name", true)
-            const existing = await getPlaylist(userId, name)
-            if (!existing) {
-                return interaction.reply({
-                    content: `No playlist named **${name}** found.`,
-                    ephemeral: true,
-                })
-            }
-            await deletePlaylist(userId, name)
-            return interaction.reply({
-                content: `Deleted playlist **${name}**.`,
-                ephemeral: true,
-            })
-        }
-
-        if (subcommand === "list") {
-            const playlists = await getUserPlaylists(userId)
-            if (playlists.length === 0) {
-                return interaction.reply({
-                    content:
-                        "You don't have any playlists yet. Use `/playlist create` to make one!",
-                    ephemeral: true,
-                })
-            }
-            const embed = new EmbedBuilder()
-                .setColor(0x0099ff)
-                .setTitle("Your Playlists")
-                .setDescription(
-                    playlists
-                        .map(
-                            (p) =>
-                                `**${p.name}** — ${p.trackCount} track${p.trackCount === 1 ? "" : "s"}`
-                        )
-                        .join("\n")
-                )
-                .setTimestamp()
-            return interaction.reply({ embeds: [embed], ephemeral: true })
-        }
-
-        if (subcommand === "view") {
-            const name = interaction.options.getString("name", true)
-            const playlist = await getPlaylist(userId, name)
-            if (!playlist) {
-                return interaction.reply({
-                    content: `No playlist named **${name}** found.`,
-                    ephemeral: true,
-                })
-            }
-            return showPaginatedPlaylistView(interaction, client, playlist.name, playlist.tracks)
-        }
-
-        if (subcommand === "add") {
-            const name = interaction.options.getString("name", true)
-            const query = interaction.options.getString("query")
-            const playlist = await getPlaylist(userId, name)
-            if (!playlist) {
-                return interaction.reply({
-                    content: `No playlist named **${name}** found.`,
+                    content: `Created playlist **${name}**.`,
                     ephemeral: true,
                 })
             }
 
-            if (query) {
-                await interaction.deferReply({ ephemeral: true })
-                const player = pickPlayerForPlaylistSearch(client.lavalink, guild.id)
-                if (!player) {
-                    return interaction.editReply({
+            if (subcommand === "delete") {
+                const name = interaction.options.getString("name", true)
+                const existing = await getPlaylist(userId, name)
+                if (!existing) {
+                    return interaction.reply({
+                        content: `No playlist named **${name}** found.`,
+                        ephemeral: true,
+                    })
+                }
+                await deletePlaylist(userId, name)
+                return interaction.reply({
+                    content: `Deleted playlist **${name}**.`,
+                    ephemeral: true,
+                })
+            }
+
+            if (subcommand === "list") {
+                const playlists = await getUserPlaylists(userId)
+                if (playlists.length === 0) {
+                    return interaction.reply({
                         content:
-                            "The bot is not in a voice channel anywhere. Join voice in a server with the bot, or try again later.",
+                            "You don't have any playlists yet. Use `/playlist create` to make one!",
+                        ephemeral: true,
                     })
                 }
-                const found = await searchTracksForPlaylist(player, query, interaction.user)
-                if (found.ok === false) {
-                    return interaction.editReply({ content: found.error })
+                const embed = new EmbedBuilder()
+                    .setColor(0x0099ff)
+                    .setTitle("Your Playlists")
+                    .setDescription(
+                        playlists
+                            .map(
+                                (p) =>
+                                    `**${p.name}** — ${p.trackCount} track${p.trackCount === 1 ? "" : "s"}`
+                            )
+                            .join("\n")
+                    )
+                    .setTimestamp()
+                return interaction.reply({ embeds: [embed], ephemeral: true })
+            }
+
+            if (subcommand === "view") {
+                const name = interaction.options.getString("name", true)
+                const playlist = await getPlaylist(userId, name)
+                if (!playlist) {
+                    return interaction.reply({
+                        content: `No playlist named **${name}** found.`,
+                        ephemeral: true,
+                    })
                 }
-                const addedAt = new Date()
-                const added = await addTracksToPlaylist(
-                    playlist.id,
-                    found.tracks.map((t) => ({
-                        title: t.title,
-                        uri: t.uri,
-                        author: t.author,
-                        duration: t.duration,
-                        thumbnailUrl: t.thumbnailUrl,
-                        addedAt,
-                    }))
+                return showPaginatedPlaylistView(
+                    interaction,
+                    client,
+                    playlist.name,
+                    playlist.tracks
                 )
-                if (added.length === 1) {
-                    const t = added[0]!
-                    return interaction.editReply({
-                        content: `Added **[${t.title}](${t.uri})** to **${name}**.`,
+            }
+
+            if (subcommand === "add") {
+                const name = interaction.options.getString("name", true)
+                const query = interaction.options.getString("query")
+                const playlist = await getPlaylist(userId, name)
+                if (!playlist) {
+                    return interaction.reply({
+                        content: `No playlist named **${name}** found.`,
+                        ephemeral: true,
                     })
                 }
-                return interaction.editReply({
-                    content: `Added **${added.length}** tracks to **${name}**.`,
+
+                if (query) {
+                    await interaction.deferReply({ ephemeral: true })
+                    const player = pickPlayerForPlaylistSearch(client.lavalink, guild.id)
+                    if (!player) {
+                        return interaction.editReply({
+                            content:
+                                "The bot is not in a voice channel anywhere. Join voice in a server with the bot, or try again later.",
+                        })
+                    }
+                    const found = await searchTracksForPlaylist(player, query, interaction.user)
+                    if (found.ok === false) {
+                        return interaction.editReply({ content: found.error })
+                    }
+                    const addedAt = new Date()
+                    const added = await addTracksToPlaylist(
+                        playlist.id,
+                        found.tracks.map((t) => ({
+                            title: t.title,
+                            uri: t.uri,
+                            author: t.author,
+                            duration: t.duration,
+                            thumbnailUrl: t.thumbnailUrl,
+                            addedAt,
+                        }))
+                    )
+                    if (added.length === 1) {
+                        const t = added[0]!
+                        return interaction.editReply({
+                            content: `Added **[${t.title}](${t.uri})** to **${name}**.`,
+                        })
+                    }
+                    return interaction.editReply({
+                        content: `Added **${added.length}** tracks to **${name}**.`,
+                    })
+                }
+
+                const player = client.lavalink.players.get(guild.id)
+                const current = player?.queue.current
+                if (!current) {
+                    return interaction.reply({
+                        content: "Nothing is playing. Provide a `query` or start playback first.",
+                        ephemeral: true,
+                    })
+                }
+                const info = current.info
+                const uri = typeof info.uri === "string" ? info.uri.trim() : ""
+                if (!uri) {
+                    return interaction.reply({
+                        content: "The current track has no URL and cannot be saved to a playlist.",
+                        ephemeral: true,
+                    })
+                }
+                await addTracksToPlaylist(playlist.id, [
+                    {
+                        title: info.title ?? "Unknown",
+                        uri,
+                        author: info.author ?? "Unknown",
+                        duration: info.duration ?? 0,
+                        thumbnailUrl: thumbnailFromLavalinkTrack(current),
+                        addedAt: new Date(),
+                    },
+                ])
+                return interaction.reply({
+                    content: `Added **[${info.title}](${uri})** to **${name}**.`,
+                    ephemeral: true,
                 })
             }
 
-            const player = client.lavalink.players.get(guild.id)
-            const current = player?.queue.current
-            if (!current) {
+            if (subcommand === "remove") {
+                const name = interaction.options.getString("name", true)
+                const index = interaction.options.getInteger("index", true)
+                const playlist = await getPlaylist(userId, name)
+                if (!playlist) {
+                    return interaction.reply({
+                        content: `No playlist named **${name}** found.`,
+                        ephemeral: true,
+                    })
+                }
+                if (index < 1 || index > playlist.tracks.length) {
+                    return interaction.reply({
+                        content: `Invalid index. Choose between 1 and ${playlist.tracks.length}.`,
+                        ephemeral: true,
+                    })
+                }
+                const track = playlist.tracks[index - 1]!
+                await removeTrackFromPlaylistById(playlist.id, track.id)
                 return interaction.reply({
-                    content: "Nothing is playing. Provide a `query` or start playback first.",
+                    content: `Removed **${track.title}** from **${name}**.`,
                     ephemeral: true,
                 })
             }
-            const info = current.info
-            const uri = typeof info.uri === "string" ? info.uri.trim() : ""
-            if (!uri) {
-                return interaction.reply({
-                    content: "The current track has no URL and cannot be saved to a playlist.",
-                    ephemeral: true,
-                })
-            }
-            await addTracksToPlaylist(playlist.id, [
+
+            if (subcommand === "play") {
+                const name = interaction.options.getString("name", true)
+                const shuffle = interaction.options.getBoolean("shuffle") ?? false
+
+                const voiceChannel = member.voice.channel
+                if (!voiceChannel) {
+                    return interaction.reply({
+                        content: "Join a voice channel first!",
+                        ephemeral: true,
+                    })
+                }
+
+                await interaction.deferReply({ ephemeral: true })
+
+                const playlist = await getPlaylist(userId, name)
+                if (!playlist) {
+                    return interaction.editReply({
+                        content: `No playlist named **${name}** found.`,
+                    })
+                }
+                if (playlist.tracks.length === 0) {
+                    return interaction.editReply({
+                        content: `**${name}** has no tracks.`,
+                    })
+                }
+
                 {
-                    title: info.title ?? "Unknown",
-                    uri,
-                    author: info.author ?? "Unknown",
-                    duration: info.duration ?? 0,
-                    thumbnailUrl: thumbnailFromLavalinkTrack(current),
-                    addedAt: new Date(),
-                },
-            ])
-            return interaction.reply({
-                content: `Added **[${info.title}](${uri})** to **${name}**.`,
-                ephemeral: true,
-            })
-        }
+                    const existingPlayer = client.lavalink.getPlayer(guild.id)
+                    const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(
+                        guild,
+                        existingPlayer
+                    )
+                    if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                        return interaction.editReply({
+                            content: "You need to be in the same voice channel as the bot!",
+                        })
+                    }
+                }
 
-        if (subcommand === "remove") {
-            const name = interaction.options.getString("name", true)
-            const index = interaction.options.getInteger("index", true)
-            const playlist = await getPlaylist(userId, name)
-            if (!playlist) {
-                return interaction.reply({
-                    content: `No playlist named **${name}** found.`,
-                    ephemeral: true,
-                })
-            }
-            if (index < 1 || index > playlist.tracks.length) {
-                return interaction.reply({
-                    content: `Invalid index. Choose between 1 and ${playlist.tracks.length}.`,
-                    ephemeral: true,
-                })
-            }
-            const track = playlist.tracks[index - 1]!
-            await removeTrackFromPlaylistById(playlist.id, track.id)
-            return interaction.reply({
-                content: `Removed **${track.title}** from **${name}**.`,
-                ephemeral: true,
-            })
-        }
+                const playOutcome = await withGuildPlayerLifecycleReservation(
+                    guild.id,
+                    async () => {
+                        let player = client.lavalink.getPlayer(guild.id)
+                        if (!player) {
+                            player = await client.lavalink.createPlayer({
+                                guildId: guild.id,
+                                voiceChannelId: voiceChannel.id,
+                                textChannelId: interaction.channelId,
+                                selfDeaf: true,
+                                volume: 100,
+                            })
+                        }
 
-        if (subcommand === "play") {
-            const name = interaction.options.getString("name", true)
-            const shuffle = interaction.options.getBoolean("shuffle") ?? false
+                        if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+                            return { kind: "wrong_channel" as const }
+                        }
 
-            const voiceChannel = member.voice.channel
-            if (!voiceChannel) {
-                return interaction.reply({
-                    content: "Join a voice channel first!",
-                    ephemeral: true,
-                })
-            }
+                        const { resolved, failed } = await resolveStoredPlaylistTracks(
+                            player,
+                            playlist.tracks,
+                            interaction.user
+                        )
 
-            await interaction.deferReply({ ephemeral: true })
+                        if (resolved.length === 0) {
+                            return { kind: "no_tracks" as const, name }
+                        }
 
-            const playlist = await getPlaylist(userId, name)
-            if (!playlist) {
-                return interaction.editReply({
-                    content: `No playlist named **${name}** found.`,
-                })
-            }
-            if (playlist.tracks.length === 0) {
-                return interaction.editReply({
-                    content: `**${name}** has no tracks.`,
-                })
-            }
+                        const enqueue = await enqueueResolvedPlaylistTracks(
+                            player,
+                            resolved,
+                            interaction.user.id,
+                            shuffle
+                        )
+                        return { kind: "queued" as const, name, enqueue, failed }
+                    }
+                )
 
-            {
-                const existingPlayer = client.lavalink.getPlayer(guild.id)
-                const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
-                if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                if (playOutcome.kind === "wrong_channel") {
                     return interaction.editReply({
                         content: "You need to be in the same voice channel as the bot!",
                     })
                 }
-            }
-
-            const playOutcome = await withGuildPlayerLifecycleReservation(guild.id, async () => {
-                let player = client.lavalink.getPlayer(guild.id)
-                if (!player) {
-                    player = await client.lavalink.createPlayer({
-                        guildId: guild.id,
-                        voiceChannelId: voiceChannel.id,
-                        textChannelId: interaction.channelId,
-                        selfDeaf: true,
-                        volume: 100,
+                if (playOutcome.kind === "no_tracks") {
+                    return interaction.editReply({
+                        content: `Could not resolve any tracks from **${playOutcome.name}**.`,
                     })
                 }
 
-                if (player.connected && player.voiceChannelId !== voiceChannel.id) {
-                    return { kind: "wrong_channel" as const }
-                }
-
-                const { resolved, failed } = await resolveStoredPlaylistTracks(
-                    player,
-                    playlist.tracks,
-                    interaction.user
-                )
-
-                if (resolved.length === 0) {
-                    return { kind: "no_tracks" as const, name }
-                }
-
-                const enqueue = await enqueueResolvedPlaylistTracks(
-                    player,
-                    resolved,
-                    interaction.user.id,
-                    shuffle
-                )
-                return { kind: "queued" as const, name, enqueue, failed }
-            })
-
-            if (playOutcome.kind === "wrong_channel") {
+                const failPart =
+                    playOutcome.failed > 0
+                        ? ` ${playOutcome.failed} track${playOutcome.failed === 1 ? "" : "s"} could not be resolved.`
+                        : ""
                 return interaction.editReply({
-                    content: "You need to be in the same voice channel as the bot!",
-                })
-            }
-            if (playOutcome.kind === "no_tracks") {
-                return interaction.editReply({
-                    content: `Could not resolve any tracks from **${playOutcome.name}**.`,
+                    content: `Queued ${playOutcome.enqueue.queued} track${playOutcome.enqueue.queued === 1 ? "" : "s"} from **${playOutcome.name}**.${failPart}`,
                 })
             }
 
-            const failPart =
-                playOutcome.failed > 0
-                    ? ` ${playOutcome.failed} track${playOutcome.failed === 1 ? "" : "s"} could not be resolved.`
-                    : ""
-            return interaction.editReply({
-                content: `Queued ${playOutcome.enqueue.queued} track${playOutcome.enqueue.queued === 1 ? "" : "s"} from **${playOutcome.name}**.${failPart}`,
-            })
-        }
-
-        return interaction.reply({ content: "Unknown subcommand.", ephemeral: true })
+            return interaction.reply({ content: "Unknown subcommand.", ephemeral: true })
         } catch (err: unknown) {
             console.error("[Playlist command] execute failed", err)
             const content = "An error occurred while processing your request."

--- a/src/commands/music/Playlist.ts
+++ b/src/commands/music/Playlist.ts
@@ -25,6 +25,7 @@ import {
     resolveStoredPlaylistTracks,
     searchTracksForPlaylist,
 } from "../../util/playlistQueue.js"
+import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { thumbnailFromLavalinkTrack } from "../../util/trackThumbnail.js"
 
 export default {
@@ -314,46 +315,58 @@ export default {
                 })
             }
 
-            let player = client.lavalink.getPlayer(guild.id)
-            if (!player) {
-                player = await client.lavalink.createPlayer({
-                    guildId: guild.id,
-                    voiceChannelId: voiceChannel.id,
-                    textChannelId: interaction.channelId,
-                    selfDeaf: true,
-                    volume: 100,
-                })
-            }
+            const playOutcome = await withGuildPlayerLifecycleReservation(guild.id, async () => {
+                let player = client.lavalink.getPlayer(guild.id)
+                if (!player) {
+                    player = await client.lavalink.createPlayer({
+                        guildId: guild.id,
+                        voiceChannelId: voiceChannel.id,
+                        textChannelId: interaction.channelId,
+                        selfDeaf: true,
+                        volume: 100,
+                    })
+                }
 
-            if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+                if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+                    return { kind: "wrong_channel" as const }
+                }
+
+                const { resolved, failed } = await resolveStoredPlaylistTracks(
+                    player,
+                    playlist.tracks,
+                    interaction.user
+                )
+
+                if (resolved.length === 0) {
+                    return { kind: "no_tracks" as const, name }
+                }
+
+                const enqueue = await enqueueResolvedPlaylistTracks(
+                    player,
+                    resolved,
+                    interaction.user.id,
+                    shuffle
+                )
+                return { kind: "queued" as const, name, enqueue, failed }
+            })
+
+            if (playOutcome.kind === "wrong_channel") {
                 return interaction.editReply({
                     content: "You need to be in the same voice channel as the bot!",
                 })
             }
-
-            const { resolved, failed } = await resolveStoredPlaylistTracks(
-                player,
-                playlist.tracks,
-                interaction.user
-            )
-
-            if (resolved.length === 0) {
+            if (playOutcome.kind === "no_tracks") {
                 return interaction.editReply({
-                    content: `Could not resolve any tracks from **${name}**.`,
+                    content: `Could not resolve any tracks from **${playOutcome.name}**.`,
                 })
             }
 
-            const enqueue = await enqueueResolvedPlaylistTracks(
-                player,
-                resolved,
-                interaction.user.id,
-                shuffle
-            )
-
             const failPart =
-                failed > 0 ? ` ${failed} track${failed === 1 ? "" : "s"} could not be resolved.` : ""
+                playOutcome.failed > 0
+                    ? ` ${playOutcome.failed} track${playOutcome.failed === 1 ? "" : "s"} could not be resolved.`
+                    : ""
             return interaction.editReply({
-                content: `Queued ${enqueue.queued} track${enqueue.queued === 1 ? "" : "s"} from **${name}**.${failPart}`,
+                content: `Queued ${playOutcome.enqueue.queued} track${playOutcome.enqueue.queued === 1 ? "" : "s"} from **${playOutcome.name}**.${failPart}`,
             })
         }
 

--- a/src/commands/music/Playlist.ts
+++ b/src/commands/music/Playlist.ts
@@ -27,6 +27,10 @@ import {
 } from "../../util/playlistQueue.js"
 import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { thumbnailFromLavalinkTrack } from "../../util/trackThumbnail.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -313,6 +317,16 @@ export default {
                 return interaction.editReply({
                     content: `**${name}** has no tracks.`,
                 })
+            }
+
+            {
+                const existingPlayer = client.lavalink.getPlayer(guild.id)
+                const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+                if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                    return interaction.editReply({
+                        content: "You need to be in the same voice channel as the bot!",
+                    })
+                }
             }
 
             const playOutcome = await withGuildPlayerLifecycleReservation(guild.id, async () => {

--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -4,6 +4,7 @@ import { spawn } from "child_process"
 import path from "path"
 import fs from "fs"
 import type BotClient from "../../lib/BotClient.js"
+import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 import { getGuildSettings } from "../../util/saveControlChannel.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
@@ -576,31 +577,39 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                         })
                         return
                     }
-                    let player = client.lavalink.getPlayer(guildId)
-                    if (!player) {
-                        player = client.lavalink.createPlayer({
-                            guildId,
-                            voiceChannelId: voiceChannel.id,
-                            textChannelId: textChannel.id,
-                            selfDeaf: true,
-                        })
-                    }
-                    if (!player) {
+                    const playResult = await withGuildPlayerLifecycleReservation(
+                        guildId,
+                        async () => {
+                            let player = client.lavalink.getPlayer(guildId)
+                            if (!player) {
+                                player = client.lavalink.createPlayer({
+                                    guildId,
+                                    voiceChannelId: voiceChannel.id,
+                                    textChannelId: textChannel.id,
+                                    selfDeaf: true,
+                                })
+                            }
+                            if (!player) {
+                                return null
+                            }
+
+                            return handleQueryAndPlay(
+                                client,
+                                guildId,
+                                voiceChannel,
+                                textChannel,
+                                filePath,
+                                interaction.user,
+                                player
+                            )
+                        }
+                    )
+                    if (!playResult) {
                         await interaction.editReply({
                             content: "Could not start the music player.",
                         })
                         return
                     }
-
-                    const playResult = await handleQueryAndPlay(
-                        client,
-                        guildId,
-                        voiceChannel,
-                        textChannel,
-                        filePath,
-                        interaction.user,
-                        player
-                    )
 
                     await interaction
                         .editReply({

--- a/src/events/handlers/handleControlMessages.ts
+++ b/src/events/handlers/handleControlMessages.ts
@@ -8,6 +8,10 @@ import type BotClient from "../../lib/BotClient.js"
 import { discordDeleteErrorDetails } from "../../util/discordErrorDetails.js"
 import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 
 export default async function handleControlMessages(client: BotClient, message: Message) {
     if (!message.member) {
@@ -67,8 +71,33 @@ export default async function handleControlMessages(client: BotClient, message: 
             `[ControlHandler] Bot has Connect/Speak permissions for VC ${voiceChannel.id}.`
         )
 
+        // 3. Refuse if bot occupies another VC (incl. local playback), then reserve + get/create.
+        const guild = message.guild
+        if (!guild) return
+        {
+            const existingPlayer = client.lavalink?.getPlayer(guildId)
+            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+            if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                client.warn(
+                    `[ControlHandler] User ${member.id} in VC ${voiceChannel.id}, but bot occupies VC ${occupiedVoiceChannelId} for guild ${guildId}.`
+                )
+                const otherVc = occupiedVoiceChannelId
+                    ? client.channels.cache.get(occupiedVoiceChannelId)
+                    : undefined
+                const otherName =
+                    otherVc &&
+                    "name" in otherVc &&
+                    typeof (otherVc as { name: string }).name === "string"
+                        ? (otherVc as { name: string }).name
+                        : "Unknown Channel"
+                feedbackMessage = await sendChannel.send(
+                    `${member}, I'm already playing in another voice channel (${otherName}).`
+                )
+                return
+            }
+        }
+
         const controlOutcome = await withGuildPlayerLifecycleReservation(guildId, async () => {
-            // 3. Get/Create player
             let player = client.lavalink?.getPlayer(guildId)
             if (!player) {
                 client.debug(

--- a/src/events/handlers/handleControlMessages.ts
+++ b/src/events/handlers/handleControlMessages.ts
@@ -6,6 +6,7 @@ import {
 } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import { discordDeleteErrorDetails } from "../../util/discordErrorDetails.js"
+import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 
 export default async function handleControlMessages(client: BotClient, message: Message) {
@@ -66,93 +67,108 @@ export default async function handleControlMessages(client: BotClient, message: 
             `[ControlHandler] Bot has Connect/Speak permissions for VC ${voiceChannel.id}.`
         )
 
-        // 3. Get/Create player
-        let player = client.lavalink?.getPlayer(guildId)
-        if (!player) {
-            client.debug(`[ControlHandler] No existing player for guild ${guildId}. Creating one.`)
-            player = client.lavalink?.createPlayer({
-                guildId,
-                voiceChannelId: voiceChannel.id,
-                textChannelId: sendChannel.id,
-                selfDeaf: true,
-                volume: 100, // TODO: Make volume configurable?
-            })
-            client.debug(`[ControlHandler] Created Lavalink player for guild ${guildId}.`)
-        } else {
-            client.debug(
-                `[ControlHandler] Found existing player for guild ${guildId}. Connected: ${player.connected}`
-            )
-        }
+        const controlOutcome = await withGuildPlayerLifecycleReservation(guildId, async () => {
+            // 3. Get/Create player
+            let player = client.lavalink?.getPlayer(guildId)
+            if (!player) {
+                client.debug(
+                    `[ControlHandler] No existing player for guild ${guildId}. Creating one.`
+                )
+                player = client.lavalink?.createPlayer({
+                    guildId,
+                    voiceChannelId: voiceChannel.id,
+                    textChannelId: sendChannel.id,
+                    selfDeaf: true,
+                    volume: 100, // TODO: Make volume configurable?
+                })
+                client.debug(`[ControlHandler] Created Lavalink player for guild ${guildId}.`)
+            } else {
+                client.debug(
+                    `[ControlHandler] Found existing player for guild ${guildId}. Connected: ${player.connected}`
+                )
+            }
 
-        if (!player) {
+            if (!player) {
+                return { kind: "no_player" as const }
+            }
+
+            if (!player.connected) {
+                client.debug(
+                    `[ControlHandler] Player not connected for guild ${guildId}. Attempting connection to VC ${voiceChannel.id}.`
+                )
+                player.voiceChannelId = voiceChannel.id
+                player.textChannelId = sendChannel.id
+                try {
+                    await player.connect()
+                    client.debug(
+                        `[ControlHandler] Player successfully connected to VC ${voiceChannel.id} in guild ${guildId}.`
+                    )
+                } catch (connectError: unknown) {
+                    client.error(
+                        `[ControlHandler] Player failed to connect in guild ${guildId}:`,
+                        connectError
+                    )
+                    return { kind: "connect_failed" as const }
+                }
+            } else if (player.voiceChannelId !== voiceChannel.id) {
+                // If the user is in a different VC than the bot
+                client.warn(
+                    `[ControlHandler] User ${member.id} in VC ${voiceChannel.id}, but player is in VC ${player.voiceChannelId} for guild ${guildId}.`
+                )
+                const otherVc = player.voiceChannelId
+                    ? client.channels.cache.get(player.voiceChannelId)
+                    : undefined
+                const otherName =
+                    otherVc &&
+                    "name" in otherVc &&
+                    typeof (otherVc as { name: string }).name === "string"
+                        ? (otherVc as { name: string }).name
+                        : "Unknown Channel"
+                return { kind: "wrong_channel" as const, otherName }
+            }
+            client.debug(
+                `[ControlHandler] Player connected status checked/handled for guild ${guildId}.`
+            )
+
+            // 5, 6, 7: Use the centralized handler
+            const result = await handleQueryAndPlay(
+                client,
+                guildId,
+                voiceChannel,
+                sendChannel,
+                content,
+                message.author,
+                player
+            )
+            return { kind: "played" as const, result }
+        })
+
+        if (controlOutcome.kind === "no_player") {
             feedbackMessage = await sendChannel.send(
                 `${member}, Could not start the music player. Try again in a moment.`
             )
             return
         }
-
-        if (!player.connected) {
-            client.debug(
-                `[ControlHandler] Player not connected for guild ${guildId}. Attempting connection to VC ${voiceChannel.id}.`
-            )
-            player.voiceChannelId = voiceChannel.id
-            player.textChannelId = sendChannel.id
-            try {
-                await player.connect()
-                client.debug(
-                    `[ControlHandler] Player successfully connected to VC ${voiceChannel.id} in guild ${guildId}.`
-                )
-            } catch (connectError: unknown) {
-                client.error(
-                    `[ControlHandler] Player failed to connect in guild ${guildId}:`,
-                    connectError
-                )
-                feedbackMessage = await sendChannel.send(
-                    `${member}, I couldn't connect to your voice channel.`
-                )
-                return
-            }
-        } else if (player.voiceChannelId !== voiceChannel.id) {
-            // If the user is in a different VC than the bot
-            client.warn(
-                `[ControlHandler] User ${member.id} in VC ${voiceChannel.id}, but player is in VC ${player.voiceChannelId} for guild ${guildId}.`
-            )
-            const otherVc = player.voiceChannelId
-                ? client.channels.cache.get(player.voiceChannelId)
-                : undefined
-            const otherName =
-                otherVc &&
-                "name" in otherVc &&
-                typeof (otherVc as { name: string }).name === "string"
-                    ? (otherVc as { name: string }).name
-                    : "Unknown Channel"
+        if (controlOutcome.kind === "connect_failed") {
             feedbackMessage = await sendChannel.send(
-                `${member}, I'm already playing in another voice channel (${otherName}).`
+                `${member}, I couldn't connect to your voice channel.`
             )
             return
         }
-        client.debug(
-            `[ControlHandler] Player connected status checked/handled for guild ${guildId}.`
-        )
-
-        // 5, 6, 7: Use the centralized handler
-        const result = await handleQueryAndPlay(
-            client,
-            guildId,
-            voiceChannel,
-            sendChannel,
-            content,
-            message.author,
-            player
-        )
+        if (controlOutcome.kind === "wrong_channel") {
+            feedbackMessage = await sendChannel.send(
+                `${member}, I'm already playing in another voice channel (${controlOutcome.otherName}).`
+            )
+            return
+        }
 
         client.debug(
-            `[ControlHandler] handleQueryAndPlay result for guild ${guildId}: Success=${result.success}, Feedback="${result.feedbackText}"`
+            `[ControlHandler] handleQueryAndPlay result for guild ${guildId}: Success=${controlOutcome.result.success}, Feedback="${controlOutcome.result.feedbackText}"`
         )
 
         // Send feedback from the result
-        if (result.feedbackText) {
-            feedbackMessage = await sendChannel.send(result.feedbackText)
+        if (controlOutcome.result.feedbackText) {
+            feedbackMessage = await sendChannel.send(controlOutcome.result.feedbackText)
         }
         // Note: updateControlMessage is called inside handleQueryAndPlay if needed.
     } catch (error: unknown) {

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -37,6 +37,9 @@ import {
 import { playerBroadcaster } from "../shared/websocket/PlayerBroadcaster.js"
 import { clearPlayerSession, schedulePlayerSessionSave } from "../util/playerSessionPersistence.js"
 import { countHumanMembers } from "../util/voiceChannelMembers.js"
+import { tryDestroyOrphanGuildPlayer } from "../util/guildPlayerQueueLock.js"
+import { playerHasQueueContent } from "../util/playlistQueue.js"
+import { skipCurrentTrack } from "../util/skipCurrentTrack.js"
 
 /** Rate-limit `queueUpdate` websocket fan-out on Lavalink position ticks (pause/resume still immediate). */
 const lastQueueUpdateBroadcastAtMs = new Map<string, number>()
@@ -263,7 +266,15 @@ export default async (client: BotClient) => {
             client.debug(
                 `[LavaMgrEvents] Attempting to skip stuck track in guild ${player.guildId}.`
             )
-            await player.skip()
+            try {
+                // Default skip() throws when upcoming queue is empty (e.g. last/autoplay track).
+                await skipCurrentTrack(player)
+            } catch (e: unknown) {
+                client.error(
+                    `[LavaMgrEvents] Failed to skip stuck track in guild ${player.guildId}:`,
+                    e
+                )
+            }
         })
         .on(
             "trackError",
@@ -349,12 +360,55 @@ export default async (client: BotClient) => {
                     `[LavaMgrEvents] Attempting to skip track after error in guild ${player.guildId}.`
                 )
                 if (player.queue.tracks.length > 0) {
-                    await player.skip()
-                } else {
+                    try {
+                        await skipCurrentTrack(player)
+                    } catch (e: unknown) {
+                        client.error(
+                            `[LavaMgrEvents] Failed to skip after track error in guild ${player.guildId}:`,
+                            e
+                        )
+                    }
+                } else if (player.get("autoplay") === true) {
+                    // Library trackError does not advance to queueEnd; ending the current track
+                    // lets onEmptyQueue.autoPlayFunction run instead of wiping the session.
                     client.debug(
-                        `[LavaMgrEvents] Queue is empty, not skipping after error in guild ${player.guildId}.`
+                        `[LavaMgrEvents] Queue empty with autoplay on; ending current track for guild ${player.guildId}.`
                     )
-                    await player.destroy()
+                    try {
+                        await skipCurrentTrack(player)
+                    } catch (e: unknown) {
+                        client.error(
+                            `[LavaMgrEvents] Failed to end track for autoplay after error in guild ${player.guildId}:`,
+                            e
+                        )
+                    }
+                } else {
+                    // Reservation-aware: in-flight dashboard search/enqueue must not be destroyed.
+                    const trackErrorGuildId = player.guildId
+                    client.debug(
+                        `[LavaMgrEvents] Queue is empty after track error in guild ${trackErrorGuildId}; attempting reservation-aware destroy.`
+                    )
+                    await tryDestroyOrphanGuildPlayer(
+                        trackErrorGuildId,
+                        {
+                            hasQueueContent: () => {
+                                const live = client.lavalink.getPlayer(trackErrorGuildId)
+                                if (!live) return true
+                                return playerHasQueueContent(live)
+                            },
+                            destroyPlayer: async () => {
+                                const live = client.lavalink.getPlayer(trackErrorGuildId)
+                                if (!live || playerHasQueueContent(live)) {
+                                    client.debug(
+                                        `[LavaMgrEvents] Player ${trackErrorGuildId} regained queue content after track error; not destroying.`
+                                    )
+                                    return
+                                }
+                                await live.destroy()
+                            },
+                        },
+                        0
+                    )
                 }
             }
         )
@@ -424,53 +478,86 @@ export default async (client: BotClient) => {
             client.debug(
                 `[LavaMgrEvents] User left player's channel: Guild ${player.guildId}, User: ${userId}`
             )
+            const aloneGuildId = player.guildId
             const voiceChannel = player.voiceChannelId
                 ? client.channels.cache.get(player.voiceChannelId)
                 : undefined
             if (voiceChannel) {
                 client.debug(
-                    `[LavaMgrEvents] Setting timeout to check if bot is alone in VC ${player.voiceChannelId} for guild ${player.guildId}.`
+                    `[LavaMgrEvents] Setting timeout to check if bot is alone in VC ${player.voiceChannelId} for guild ${aloneGuildId}.`
                 )
                 setTimeout(async () => {
                     client.debug(
-                        `[LavaMgrEvents] Executing check if bot is alone for player ${player.guildId}.`
+                        `[LavaMgrEvents] Executing check if bot is alone for player ${aloneGuildId}.`
                     )
                     try {
-                        const vcId = player.voiceChannelId
-                        if (!vcId) return
+                        const livePlayer = client.lavalink.getPlayer(aloneGuildId)
+                        const vcId = livePlayer?.voiceChannelId
+                        if (!livePlayer || !vcId) return
                         const updatedVoiceChannel = await client.channels
                             .fetch(vcId)
                             .catch(() => null)
                         if (updatedVoiceChannel && updatedVoiceChannel.isVoiceBased()) {
                             const humanCount = countHumanMembers(updatedVoiceChannel)
                             client.debug(
-                                `[LavaMgrEvents] Current human member count in VC ${player.voiceChannelId}: ${humanCount}`
-                            ) // Log count
+                                `[LavaMgrEvents] Current human member count in VC ${vcId}: ${humanCount}`
+                            )
                             if (humanCount === 0) {
                                 client.info(
-                                    `[LavaMgrEvents] Destroying player in Guild ${player.guildId} as bot is alone.`
+                                    `[LavaMgrEvents] Bot alone in Guild ${aloneGuildId}; reservation-aware destroy.`
                                 )
-                                await updateControlMessage(client, player.guildId).catch(
-                                    (ctrlErr: unknown) => {
-                                        const msg =
-                                            ctrlErr instanceof Error
-                                                ? ctrlErr.message
-                                                : String(ctrlErr)
-                                        client.error(
-                                            `[LavaMgrEvents] updateControlMessage failed (beforeDestroyAlone, guildId=${player.guildId}): ${msg}`
-                                        )
-                                    }
+                                // reservedByCaller=0: in-flight search/playlist resolve must finish
+                                // (or defer teardown) instead of being killed mid-request.
+                                await tryDestroyOrphanGuildPlayer(
+                                    aloneGuildId,
+                                    {
+                                        // Alone policy destroys even with queue content; only
+                                        // lifecycle reservations should defer. destroyPlayer
+                                        // re-checks humans so a deferred run after rejoin is safe.
+                                        hasQueueContent: () => false,
+                                        destroyPlayer: async () => {
+                                            const live = client.lavalink.getPlayer(aloneGuildId)
+                                            if (!live) return
+                                            const liveVcId = live.voiceChannelId
+                                            if (!liveVcId) return
+                                            const stillAloneChannel = await client.channels
+                                                .fetch(liveVcId)
+                                                .catch(() => null)
+                                            if (
+                                                !stillAloneChannel ||
+                                                !stillAloneChannel.isVoiceBased() ||
+                                                countHumanMembers(stillAloneChannel) > 0
+                                            ) {
+                                                client.debug(
+                                                    `[LavaMgrEvents] Skipping alone destroy for ${aloneGuildId}; humans present or channel gone.`
+                                                )
+                                                return
+                                            }
+                                            await updateControlMessage(client, aloneGuildId).catch(
+                                                (ctrlErr: unknown) => {
+                                                    const msg =
+                                                        ctrlErr instanceof Error
+                                                            ? ctrlErr.message
+                                                            : String(ctrlErr)
+                                                    client.error(
+                                                        `[LavaMgrEvents] updateControlMessage failed (beforeDestroyAlone, guildId=${aloneGuildId}): ${msg}`
+                                                    )
+                                                }
+                                            )
+                                            await live.destroy()
+                                        },
+                                    },
+                                    0
                                 )
-                                await player.destroy()
                             }
                         } else {
                             client.warn(
-                                `[LavaMgrEvents] Could not verify member count for player ${player.guildId}. Channel ${player.voiceChannelId} not found or not voice-based.`
+                                `[LavaMgrEvents] Could not verify member count for player ${aloneGuildId}. Channel ${vcId} not found or not voice-based.`
                             )
                         }
                     } catch (error: unknown) {
                         client.error(
-                            `[LavaMgrEvents] Error checking channel members for player ${player.guildId}:`,
+                            `[LavaMgrEvents] Error checking channel members for player ${aloneGuildId}:`,
                             error
                         )
                     }

--- a/src/lib/botApiPortEnv.test.ts
+++ b/src/lib/botApiPortEnv.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { resolvedBotApiPort } from "./botApiPortEnv.js"
+
+describe("resolvedBotApiPort", () => {
+    it("defaults to 3001 when unset or whitespace", () => {
+        const prev = process.env.BOT_API_PORT
+        try {
+            delete process.env.BOT_API_PORT
+            assert.equal(resolvedBotApiPort(), 3001)
+            process.env.BOT_API_PORT = "   "
+            assert.equal(resolvedBotApiPort(), 3001)
+        } finally {
+            if (prev === undefined) delete process.env.BOT_API_PORT
+            else process.env.BOT_API_PORT = prev
+        }
+    })
+
+    it("accepts integers in 1–65535 and rejects floats, zero, and out-of-range", () => {
+        const prev = process.env.BOT_API_PORT
+        try {
+            process.env.BOT_API_PORT = "1"
+            assert.equal(resolvedBotApiPort(), 1)
+            process.env.BOT_API_PORT = "65535"
+            assert.equal(resolvedBotApiPort(), 65535)
+            process.env.BOT_API_PORT = "8080"
+            assert.equal(resolvedBotApiPort(), 8080)
+
+            process.env.BOT_API_PORT = "0"
+            assert.equal(resolvedBotApiPort(), 3001)
+            process.env.BOT_API_PORT = "65536"
+            assert.equal(resolvedBotApiPort(), 3001)
+            process.env.BOT_API_PORT = "3001.5"
+            assert.equal(resolvedBotApiPort(), 3001)
+            process.env.BOT_API_PORT = "abc"
+            assert.equal(resolvedBotApiPort(), 3001)
+            process.env.BOT_API_PORT = "-1"
+            assert.equal(resolvedBotApiPort(), 3001)
+        } finally {
+            if (prev === undefined) delete process.env.BOT_API_PORT
+            else process.env.BOT_API_PORT = prev
+        }
+    })
+})

--- a/src/lib/errorHistory.test.ts
+++ b/src/lib/errorHistory.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict"
+import { afterEach, beforeEach, describe, it } from "node:test"
+import {
+    captureError,
+    clearErrorHistory,
+    getErrorsByGuild,
+    getRecentErrors,
+} from "./errorHistory.js"
+
+const GUILD_A = "123456789012345678"
+const GUILD_B = "987654321098765432"
+
+describe("errorHistory", () => {
+    beforeEach(() => {
+        clearErrorHistory()
+    })
+
+    afterEach(() => {
+        clearErrorHistory()
+    })
+
+    it("extracts the first Discord snowflake from the message as guildId", () => {
+        captureError("error", `player failed in guild ${GUILD_A} after skip`, 1_000)
+        const [entry] = getRecentErrors(1)
+        assert.equal(entry?.guildId, GUILD_A)
+        assert.equal(entry?.level, "error")
+        assert.equal(entry?.timestamp, 1_000)
+    })
+
+    it("ignores short numeric ids and leaves guildId unset when none match", () => {
+        captureError("warn", "code 404 for user 12345", 2_000)
+        const [entry] = getRecentErrors(1)
+        assert.equal(entry?.guildId, undefined)
+        assert.equal(entry?.level, "warn")
+    })
+
+    it("filters by extracted guildId and returns newest first", () => {
+        captureError("error", `guild ${GUILD_A} first`, 1)
+        captureError("error", `guild ${GUILD_B} only`, 2)
+        captureError("warn", `guild ${GUILD_A} second`, 3)
+
+        const forA = getErrorsByGuild(GUILD_A, 10)
+        assert.equal(forA.length, 2)
+        assert.equal(forA[0]?.timestamp, 3)
+        assert.equal(forA[1]?.timestamp, 1)
+
+        const forB = getErrorsByGuild(GUILD_B, 10)
+        assert.equal(forB.length, 1)
+        assert.equal(forB[0]?.timestamp, 2)
+    })
+
+    it("caps getRecentErrors / getErrorsByGuild limits and clears the buffer", () => {
+        for (let i = 0; i < 5; i++) {
+            captureError("error", `guild ${GUILD_A} n=${i}`, i)
+        }
+        assert.equal(getRecentErrors(2).length, 2)
+        assert.equal(getRecentErrors(0).length, 1)
+        assert.equal(getErrorsByGuild(GUILD_A, 3).length, 3)
+
+        clearErrorHistory()
+        assert.equal(getRecentErrors(10).length, 0)
+        assert.equal(getErrorsByGuild(GUILD_A, 10).length, 0)
+    })
+
+    it("preserves an optional stack on captured entries", () => {
+        captureError("error", "boom", 9, "Error: boom\n    at x")
+        const [entry] = getRecentErrors(1)
+        assert.equal(entry?.stack, "Error: boom\n    at x")
+    })
+})

--- a/src/shared/admin-access-decision.test.ts
+++ b/src/shared/admin-access-decision.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { decideAdminAccess } from "../shared/admin-access-decision.js"
+
+describe("decideAdminAccess", () => {
+    it("returns 503 when session load fails", () => {
+        assert.deepEqual(
+            decideAdminAccess({
+                sessionLoadFailed: true,
+                hasSessionUser: false,
+                discordUserId: null,
+                ownerId: "owner-1",
+            }),
+            {
+                ok: false,
+                status: 503,
+                error: "Service Unavailable",
+                details: "Could not load your session. Please try again later.",
+            }
+        )
+    })
+
+    it("returns 401 without a session user", () => {
+        assert.deepEqual(
+            decideAdminAccess({
+                hasSessionUser: false,
+                discordUserId: null,
+                ownerId: "owner-1",
+            }),
+            { ok: false, status: 401, error: "Unauthorized" }
+        )
+    })
+
+    it("returns 403 when Discord resolution fails or yields no snowflake", () => {
+        assert.equal(
+            decideAdminAccess({
+                hasSessionUser: true,
+                discordResolveFailed: true,
+                discordUserId: null,
+                ownerId: "owner-1",
+            }).ok,
+            false
+        )
+        const missing = decideAdminAccess({
+            hasSessionUser: true,
+            discordUserId: null,
+            ownerId: "owner-1",
+        })
+        assert.equal(missing.ok, false)
+        if (missing.ok) return
+        assert.equal(missing.status, 403)
+        assert.equal(missing.error, "Discord account required")
+    })
+
+    it("returns 403 when OWNER_ID is unset or the caller is not the owner", () => {
+        assert.deepEqual(
+            decideAdminAccess({
+                hasSessionUser: true,
+                discordUserId: "user-2",
+                ownerId: undefined,
+            }),
+            {
+                ok: false,
+                status: 403,
+                error: "Forbidden",
+                details: "Developer access required.",
+            }
+        )
+        assert.deepEqual(
+            decideAdminAccess({
+                hasSessionUser: true,
+                discordUserId: "user-2",
+                ownerId: "owner-1",
+            }),
+            {
+                ok: false,
+                status: 403,
+                error: "Forbidden",
+                details: "Developer access required.",
+            }
+        )
+    })
+
+    it("allows the owner when session and Discord id resolve", () => {
+        assert.deepEqual(
+            decideAdminAccess({
+                hasSessionUser: true,
+                discordUserId: "owner-1",
+                ownerId: "owner-1",
+            }),
+            { ok: true, discordUserId: "owner-1" }
+        )
+    })
+})

--- a/src/shared/admin-access-decision.ts
+++ b/src/shared/admin-access-decision.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure owner-gate decision for dashboard admin routes (no Next.js / Better Auth imports).
+ * Maps session + Discord snowflake + `OWNER_ID` into the same status/error shape as
+ * {@link resolveAdminAccess} in `src/web/lib/admin-access.ts`.
+ */
+export type AdminAccessDecision =
+    | { ok: true; discordUserId: string }
+    | { ok: false; status: number; error: string; details?: string }
+
+export type AdminAccessDecisionInput = {
+    /** Session lookup threw (treat as service unavailable). */
+    sessionLoadFailed?: boolean
+    /** Better Auth session has a user id. */
+    hasSessionUser: boolean
+    /** Discord account resolution threw. */
+    discordResolveFailed?: boolean
+    /** Resolved Discord snowflake, or null when missing. */
+    discordUserId: string | null
+    /** Cached `OWNER_ID` (bot developer). */
+    ownerId: string | null | undefined
+}
+
+/** Decides whether the caller may use developer admin surfaces. */
+export function decideAdminAccess(input: AdminAccessDecisionInput): AdminAccessDecision {
+    if (input.sessionLoadFailed) {
+        return {
+            ok: false,
+            status: 503,
+            error: "Service Unavailable",
+            details: "Could not load your session. Please try again later.",
+        }
+    }
+    if (!input.hasSessionUser) {
+        return { ok: false, status: 401, error: "Unauthorized" }
+    }
+    if (input.discordResolveFailed) {
+        return {
+            ok: false,
+            status: 403,
+            error: "Discord account required",
+            details: "Sign in with Discord, or sign out and sign in again.",
+        }
+    }
+    if (!input.discordUserId) {
+        return {
+            ok: false,
+            status: 403,
+            error: "Discord account required",
+            details:
+                "We could not resolve your Discord user id. Sign in with Discord, or sign out and sign in again.",
+        }
+    }
+    const ownerId = input.ownerId
+    if (!ownerId || input.discordUserId !== ownerId) {
+        return {
+            ok: false,
+            status: 403,
+            error: "Forbidden",
+            details: "Developer access required.",
+        }
+    }
+    return { ok: true, discordUserId: input.discordUserId }
+}

--- a/src/shared/api-auth.ts
+++ b/src/shared/api-auth.ts
@@ -15,6 +15,7 @@ import { auth } from "./auth-node.js"
 import { tryGetBotClient } from "../lib/botClientRegistry.js"
 import { webPlayerDebug, webPlayerWarn } from "./web-player-debug-log.js"
 import { getBotApiOrigin } from "./bot-api-origin.js"
+import { normalizeDashboardPermissionSnapshotResponse } from "./dashboard-permission-snapshot.js"
 
 export interface AuthenticatedSession {
     user: {
@@ -278,115 +279,6 @@ export async function resolveAuthenticatedGuildAccess(
 }
 
 const DASHBOARD_PERM_UPSTREAM_FETCH_MS = 10_000
-
-function snapshotErrorMessageFromPayload(body: Record<string, unknown>): string {
-    if (typeof body.error === "string") return body.error
-    const nested = body.error
-    if (nested && typeof nested === "object" && nested !== null && "error" in nested) {
-        const inner = (nested as { error?: unknown }).error
-        if (typeof inner === "string") return inner
-    }
-    return "Request failed"
-}
-
-function snapshotErrorDetailsFromPayload(body: Record<string, unknown>): string | undefined {
-    if (typeof body.details === "string") return body.details
-    const nested = body.error
-    if (nested && typeof nested === "object" && nested !== null && "details" in nested) {
-        const d = (nested as { details?: unknown }).details
-        if (typeof d === "string") return d
-    }
-    return undefined
-}
-
-/**
- * Maps bot Express JSON (including generic `{ ok: false, error: { error } }` errors) into
- * {@link GuildDashboardSnapshotResult}.
- */
-function normalizeDashboardPermissionSnapshotResponse(
-    parsed: unknown,
-    httpStatus: number
-): GuildDashboardSnapshotResult {
-    if (!parsed || typeof parsed !== "object" || !("ok" in parsed)) {
-        return {
-            ok: false,
-            status: httpStatus >= 400 ? httpStatus : 502,
-            error: "Invalid bot response",
-            details: "The bot API returned an unexpected payload for dashboard permissions.",
-        }
-    }
-    const body = parsed as Record<string, unknown>
-    if (body.ok === false) {
-        const status =
-            typeof body.status === "number" && Number.isFinite(body.status)
-                ? Math.floor(body.status)
-                : httpStatus >= 400
-                  ? httpStatus
-                  : 502
-        return {
-            ok: false,
-            status,
-            error: snapshotErrorMessageFromPayload(body),
-            details: snapshotErrorDetailsFromPayload(body),
-        }
-    }
-    if (body.ok !== true) {
-        return {
-            ok: false,
-            status: 502,
-            error: "Invalid bot response",
-            details: "The bot API returned an unexpected `ok` field for dashboard permissions.",
-        }
-    }
-
-    const discordUserId = body.discordUserId
-    if (typeof discordUserId !== "string") {
-        return {
-            ok: false,
-            status: 502,
-            error: "Invalid bot response",
-            details: "Dashboard permission snapshot is missing `discordUserId`.",
-        }
-    }
-
-    const snap = body.snapshot
-    if (!snap || typeof snap !== "object") {
-        return {
-            ok: false,
-            status: 502,
-            error: "Invalid bot response",
-            details: "Dashboard permission snapshot is missing `snapshot`.",
-        }
-    }
-    const s = snap as Record<string, unknown>
-    const primary = s.primaryPermissions
-    const oauth = s.oauthPermissions
-    const allowedWebPermissions = new Set<string>(Object.values(WebPermission))
-    const isValidPermissionList = (value: unknown): value is string[] =>
-        Array.isArray(value) &&
-        value.every((p) => typeof p === "string" && allowedWebPermissions.has(p))
-    if (!isValidPermissionList(primary) || !isValidPermissionList(oauth)) {
-        return {
-            ok: false,
-            status: 502,
-            error: "Invalid bot response",
-            details: "Dashboard permission snapshot has invalid permission arrays.",
-        }
-    }
-
-    return {
-        ok: true,
-        snapshot: {
-            memberResolved: Boolean(s.memberResolved),
-            primaryPermissions: primary,
-            oauthPermissions: oauth,
-            ...(typeof s.optimisticBotUnavailable === "boolean"
-                ? { optimisticBotUnavailable: s.optimisticBotUnavailable }
-                : {}),
-        },
-        discordUserId,
-    }
-}
 
 /**
  * Resolves primary + OAuth permission lists when a {@link BotClient} is already available (in-process

--- a/src/shared/api-auth.ts
+++ b/src/shared/api-auth.ts
@@ -577,8 +577,7 @@ export async function requireDeveloperAccess(
             ok: false,
             status: 403,
             error: "Discord account required",
-            details:
-                "Discord account required — please sign in with Discord or try again.",
+            details: "Discord account required — please sign in with Discord or try again.",
         }
     }
     if (!discordUserId) {

--- a/src/shared/bot-api-origin.test.ts
+++ b/src/shared/bot-api-origin.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { getBotApiOrigin } from "./bot-api-origin.js"
+
+function withEnv(
+    overrides: Record<string, string | undefined>,
+    fn: () => void
+): void {
+    const previous = new Map<string, string | undefined>()
+    for (const key of Object.keys(overrides)) {
+        previous.set(key, process.env[key])
+        const next = overrides[key]
+        if (next === undefined) delete process.env[key]
+        else process.env[key] = next
+    }
+    try {
+        fn()
+    } finally {
+        for (const [key, value] of previous) {
+            if (value === undefined) delete process.env[key]
+            else process.env[key] = value
+        }
+    }
+}
+
+describe("getBotApiOrigin", () => {
+    it("returns null when API_PROXY_TARGET is unset outside development", () => {
+        withEnv({ API_PROXY_TARGET: undefined, NODE_ENV: "production" }, () => {
+            assert.equal(getBotApiOrigin(), null)
+        })
+    })
+
+    it("falls back to localhost and BOT_API_PORT in development when unset", () => {
+        withEnv(
+            { API_PROXY_TARGET: undefined, NODE_ENV: "development", BOT_API_PORT: "4123" },
+            () => {
+                assert.equal(getBotApiOrigin(), "http://localhost:4123")
+            }
+        )
+        withEnv(
+            { API_PROXY_TARGET: "   ", NODE_ENV: "development", BOT_API_PORT: undefined },
+            () => {
+                assert.equal(getBotApiOrigin(), "http://localhost:3001")
+            }
+        )
+    })
+
+    it("accepts http/https origins and strips trailing slashes", () => {
+        withEnv({ API_PROXY_TARGET: "https://bot.example.com/" }, () => {
+            assert.equal(getBotApiOrigin(), "https://bot.example.com")
+        })
+        withEnv({ API_PROXY_TARGET: "http://127.0.0.1:3001///" }, () => {
+            assert.equal(getBotApiOrigin(), "http://127.0.0.1:3001")
+        })
+    })
+
+    it("rejects invalid URLs, non-http protocols, and non-origin shapes", () => {
+        withEnv({ API_PROXY_TARGET: "not a url" }, () => {
+            assert.throws(() => getBotApiOrigin(), /not a valid URL/)
+        })
+        withEnv({ API_PROXY_TARGET: "ftp://bot.example.com" }, () => {
+            assert.throws(() => getBotApiOrigin(), /protocol must be http or https/)
+        })
+        withEnv({ API_PROXY_TARGET: "https://bot.example.com/api" }, () => {
+            assert.throws(() => getBotApiOrigin(), /origin-only URL/)
+        })
+        withEnv({ API_PROXY_TARGET: "https://bot.example.com?x=1" }, () => {
+            assert.throws(() => getBotApiOrigin(), /origin-only URL/)
+        })
+        withEnv({ API_PROXY_TARGET: "https://bot.example.com#frag" }, () => {
+            assert.throws(() => getBotApiOrigin(), /origin-only URL/)
+        })
+        withEnv({ API_PROXY_TARGET: "https://user:pass@bot.example.com" }, () => {
+            assert.throws(() => getBotApiOrigin(), /origin-only URL/)
+        })
+    })
+})

--- a/src/shared/bot-api-origin.test.ts
+++ b/src/shared/bot-api-origin.test.ts
@@ -2,10 +2,7 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 import { getBotApiOrigin } from "./bot-api-origin.js"
 
-function withEnv(
-    overrides: Record<string, string | undefined>,
-    fn: () => void
-): void {
+function withEnv(overrides: Record<string, string | undefined>, fn: () => void): void {
     const previous = new Map<string, string | undefined>()
     for (const key of Object.keys(overrides)) {
         previous.set(key, process.env[key])

--- a/src/shared/bot-api-origin.test.ts
+++ b/src/shared/bot-api-origin.test.ts
@@ -45,11 +45,11 @@ describe("getBotApiOrigin", () => {
         )
     })
 
-    it("accepts http/https origins and strips trailing slashes", () => {
+    it("accepts http/https origins and strips a single trailing slash", () => {
         withEnv({ API_PROXY_TARGET: "https://bot.example.com/" }, () => {
             assert.equal(getBotApiOrigin(), "https://bot.example.com")
         })
-        withEnv({ API_PROXY_TARGET: "http://127.0.0.1:3001///" }, () => {
+        withEnv({ API_PROXY_TARGET: "http://127.0.0.1:3001" }, () => {
             assert.equal(getBotApiOrigin(), "http://127.0.0.1:3001")
         })
     })
@@ -62,6 +62,10 @@ describe("getBotApiOrigin", () => {
             assert.throws(() => getBotApiOrigin(), /protocol must be http or https/)
         })
         withEnv({ API_PROXY_TARGET: "https://bot.example.com/api" }, () => {
+            assert.throws(() => getBotApiOrigin(), /origin-only URL/)
+        })
+        // Extra path slashes parse as pathname "///", not origin-only "/".
+        withEnv({ API_PROXY_TARGET: "http://127.0.0.1:3001///" }, () => {
             assert.throws(() => getBotApiOrigin(), /origin-only URL/)
         })
         withEnv({ API_PROXY_TARGET: "https://bot.example.com?x=1" }, () => {

--- a/src/shared/dashboard-permission-snapshot.test.ts
+++ b/src/shared/dashboard-permission-snapshot.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { WebPermission } from "./permissions.js"
+import { normalizeDashboardPermissionSnapshotResponse } from "./dashboard-permission-snapshot.js"
+
+describe("normalizeDashboardPermissionSnapshotResponse", () => {
+    it("rejects non-object and missing-ok payloads", () => {
+        assert.deepEqual(normalizeDashboardPermissionSnapshotResponse(null, 200), {
+            ok: false,
+            status: 502,
+            error: "Invalid bot response",
+            details: "The bot API returned an unexpected payload for dashboard permissions.",
+        })
+        const missingOk = normalizeDashboardPermissionSnapshotResponse({}, 404)
+        assert.equal(missingOk.ok, false)
+        if (missingOk.ok === false) assert.equal(missingOk.status, 404)
+        assert.equal(normalizeDashboardPermissionSnapshotResponse({ ok: "yes" }, 200).ok, false)
+    })
+
+    it("maps ok:false with nested error shapes and status fallback", () => {
+        assert.deepEqual(
+            normalizeDashboardPermissionSnapshotResponse(
+                {
+                    ok: false,
+                    status: 403.9,
+                    error: { error: "Forbidden", details: "no access" },
+                },
+                200
+            ),
+            {
+                ok: false,
+                status: 403,
+                error: "Forbidden",
+                details: "no access",
+            }
+        )
+        const fromHttp = normalizeDashboardPermissionSnapshotResponse(
+            { ok: false, error: "boom" },
+            503
+        )
+        assert.equal(fromHttp.ok, false)
+        if (fromHttp.ok === false) assert.equal(fromHttp.status, 503)
+        const defaultStatus = normalizeDashboardPermissionSnapshotResponse({ ok: false }, 200)
+        assert.equal(defaultStatus.ok, false)
+        if (defaultStatus.ok === false) assert.equal(defaultStatus.status, 502)
+    })
+
+    it("accepts a valid success snapshot including optimisticBotUnavailable", () => {
+        const result = normalizeDashboardPermissionSnapshotResponse(
+            {
+                ok: true,
+                discordUserId: "123456789012345678",
+                snapshot: {
+                    memberResolved: 1,
+                    primaryPermissions: [WebPermission.VIEW_PLAYER],
+                    oauthPermissions: [WebPermission.MANAGE_QUEUE],
+                    optimisticBotUnavailable: true,
+                },
+            },
+            200
+        )
+        assert.deepEqual(result, {
+            ok: true,
+            discordUserId: "123456789012345678",
+            snapshot: {
+                memberResolved: true,
+                primaryPermissions: [WebPermission.VIEW_PLAYER],
+                oauthPermissions: [WebPermission.MANAGE_QUEUE],
+                optimisticBotUnavailable: true,
+            },
+        })
+    })
+
+    it("rejects missing discordUserId, snapshot, or invalid permission arrays", () => {
+        assert.match(
+            (
+                normalizeDashboardPermissionSnapshotResponse(
+                    { ok: true, snapshot: { primaryPermissions: [], oauthPermissions: [] } },
+                    200
+                ) as { details?: string }
+            ).details ?? "",
+            /discordUserId/
+        )
+        assert.match(
+            (
+                normalizeDashboardPermissionSnapshotResponse(
+                    { ok: true, discordUserId: "1" },
+                    200
+                ) as { details?: string }
+            ).details ?? "",
+            /snapshot/
+        )
+        assert.match(
+            (
+                normalizeDashboardPermissionSnapshotResponse(
+                    {
+                        ok: true,
+                        discordUserId: "1",
+                        snapshot: {
+                            memberResolved: false,
+                            primaryPermissions: ["NOT_A_REAL_PERM"],
+                            oauthPermissions: [],
+                        },
+                    },
+                    200
+                ) as { details?: string }
+            ).details ?? "",
+            /invalid permission arrays/i
+        )
+    })
+})

--- a/src/shared/dashboard-permission-snapshot.ts
+++ b/src/shared/dashboard-permission-snapshot.ts
@@ -1,0 +1,111 @@
+import { WebPermission } from "./permissions.js"
+import type { GuildDashboardSnapshotResult } from "../types/web.js"
+
+function snapshotErrorMessageFromPayload(body: Record<string, unknown>): string {
+    if (typeof body.error === "string") return body.error
+    const nested = body.error
+    if (nested && typeof nested === "object" && nested !== null && "error" in nested) {
+        const inner = (nested as { error?: unknown }).error
+        if (typeof inner === "string") return inner
+    }
+    return "Request failed"
+}
+
+function snapshotErrorDetailsFromPayload(body: Record<string, unknown>): string | undefined {
+    if (typeof body.details === "string") return body.details
+    const nested = body.error
+    if (nested && typeof nested === "object" && nested !== null && "details" in nested) {
+        const d = (nested as { details?: unknown }).details
+        if (typeof d === "string") return d
+    }
+    return undefined
+}
+
+/**
+ * Maps bot Express JSON (including generic `{ ok: false, error: { error } }` errors) into
+ * {@link GuildDashboardSnapshotResult}.
+ */
+export function normalizeDashboardPermissionSnapshotResponse(
+    parsed: unknown,
+    httpStatus: number
+): GuildDashboardSnapshotResult {
+    if (!parsed || typeof parsed !== "object" || !("ok" in parsed)) {
+        return {
+            ok: false,
+            status: httpStatus >= 400 ? httpStatus : 502,
+            error: "Invalid bot response",
+            details: "The bot API returned an unexpected payload for dashboard permissions.",
+        }
+    }
+    const body = parsed as Record<string, unknown>
+    if (body.ok === false) {
+        const status =
+            typeof body.status === "number" && Number.isFinite(body.status)
+                ? Math.floor(body.status)
+                : httpStatus >= 400
+                  ? httpStatus
+                  : 502
+        return {
+            ok: false,
+            status,
+            error: snapshotErrorMessageFromPayload(body),
+            details: snapshotErrorDetailsFromPayload(body),
+        }
+    }
+    if (body.ok !== true) {
+        return {
+            ok: false,
+            status: 502,
+            error: "Invalid bot response",
+            details: "The bot API returned an unexpected `ok` field for dashboard permissions.",
+        }
+    }
+
+    const discordUserId = body.discordUserId
+    if (typeof discordUserId !== "string") {
+        return {
+            ok: false,
+            status: 502,
+            error: "Invalid bot response",
+            details: "Dashboard permission snapshot is missing `discordUserId`.",
+        }
+    }
+
+    const snap = body.snapshot
+    if (!snap || typeof snap !== "object") {
+        return {
+            ok: false,
+            status: 502,
+            error: "Invalid bot response",
+            details: "Dashboard permission snapshot is missing `snapshot`.",
+        }
+    }
+    const s = snap as Record<string, unknown>
+    const primary = s.primaryPermissions
+    const oauth = s.oauthPermissions
+    const allowedWebPermissions = new Set<string>(Object.values(WebPermission))
+    const isValidPermissionList = (value: unknown): value is string[] =>
+        Array.isArray(value) &&
+        value.every((p) => typeof p === "string" && allowedWebPermissions.has(p))
+    if (!isValidPermissionList(primary) || !isValidPermissionList(oauth)) {
+        return {
+            ok: false,
+            status: 502,
+            error: "Invalid bot response",
+            details: "Dashboard permission snapshot has invalid permission arrays.",
+        }
+    }
+
+    return {
+        ok: true,
+        snapshot: {
+            memberResolved: Boolean(s.memberResolved),
+            primaryPermissions: primary,
+            oauthPermissions: oauth,
+            ...(typeof s.optimisticBotUnavailable === "boolean"
+                ? { optimisticBotUnavailable: s.optimisticBotUnavailable }
+                : {}),
+        },
+        discordUserId,
+    }
+}

--- a/src/shared/dashboard-web-permission.test.ts
+++ b/src/shared/dashboard-web-permission.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { WebPermission } from "./permissions.js"
+import {
+    dashboardHasAllWebPermissions,
+    dashboardHasWebPermission,
+    explainDashboardWebPermission,
+} from "./dashboard-web-permission.js"
+
+describe("dashboard web permission merge", () => {
+    it("allows from primaryPermissions regardless of memberResolved", () => {
+        const snapshot = {
+            memberResolved: true,
+            primaryPermissions: [WebPermission.CONTROL_PLAYBACK],
+            oauthPermissions: [],
+        }
+        assert.equal(
+            dashboardHasWebPermission(snapshot, WebPermission.CONTROL_PLAYBACK),
+            true
+        )
+        assert.equal(
+            explainDashboardWebPermission(snapshot, WebPermission.CONTROL_PLAYBACK),
+            "allow:primaryPermissions"
+        )
+    })
+
+    it("allows OAuth fallback only when the bot has not resolved a member", () => {
+        const unresolved = {
+            memberResolved: false,
+            primaryPermissions: [],
+            oauthPermissions: [WebPermission.MANAGE_QUEUE],
+        }
+        assert.equal(dashboardHasWebPermission(unresolved, WebPermission.MANAGE_QUEUE), true)
+        assert.match(
+            explainDashboardWebPermission(unresolved, WebPermission.MANAGE_QUEUE),
+            /oauthPermissions/
+        )
+
+        const resolved = {
+            memberResolved: true,
+            primaryPermissions: [],
+            oauthPermissions: [WebPermission.MANAGE_QUEUE],
+        }
+        assert.equal(dashboardHasWebPermission(resolved, WebPermission.MANAGE_QUEUE), false)
+        assert.match(
+            explainDashboardWebPermission(resolved, WebPermission.MANAGE_QUEUE),
+            /memberResolved=true/
+        )
+    })
+
+    it("denies when neither list includes the permission", () => {
+        const snapshot = {
+            memberResolved: false,
+            primaryPermissions: [WebPermission.VIEW_PLAYER],
+            oauthPermissions: [],
+        }
+        assert.equal(dashboardHasWebPermission(snapshot, WebPermission.MANAGE_QUEUE), false)
+        assert.match(
+            explainDashboardWebPermission(snapshot, WebPermission.MANAGE_QUEUE),
+            /neither primary nor oauth/
+        )
+    })
+
+    it("requires every permission for dashboardHasAllWebPermissions", () => {
+        const snapshot = {
+            memberResolved: false,
+            primaryPermissions: [WebPermission.VIEW_PLAYER],
+            oauthPermissions: [WebPermission.MANAGE_QUEUE],
+        }
+        assert.equal(
+            dashboardHasAllWebPermissions(snapshot, [
+                WebPermission.VIEW_PLAYER,
+                WebPermission.MANAGE_QUEUE,
+            ]),
+            true
+        )
+        assert.equal(
+            dashboardHasAllWebPermissions(snapshot, [
+                WebPermission.VIEW_PLAYER,
+                WebPermission.CONTROL_PLAYBACK,
+            ]),
+            false
+        )
+    })
+})

--- a/src/shared/dashboard-web-permission.test.ts
+++ b/src/shared/dashboard-web-permission.test.ts
@@ -14,10 +14,7 @@ describe("dashboard web permission merge", () => {
             primaryPermissions: [WebPermission.CONTROL_PLAYBACK],
             oauthPermissions: [],
         }
-        assert.equal(
-            dashboardHasWebPermission(snapshot, WebPermission.CONTROL_PLAYBACK),
-            true
-        )
+        assert.equal(dashboardHasWebPermission(snapshot, WebPermission.CONTROL_PLAYBACK), true)
         assert.equal(
             explainDashboardWebPermission(snapshot, WebPermission.CONTROL_PLAYBACK),
             "allow:primaryPermissions"

--- a/src/shared/dashboard-web-permission.ts
+++ b/src/shared/dashboard-web-permission.ts
@@ -1,0 +1,68 @@
+import type { GuildDashboardPermissionSnapshot } from "../types/web.js"
+
+type WebPermissionDecision =
+    | { allowed: true; reason: string; memberResolved: boolean }
+    | { allowed: false; reason: string; memberResolved: boolean }
+
+/**
+ * Shared primary vs OAuth-fallback rules for dashboard gating (matches {@link requirePermissions}).
+ * Pure helper — callers may add tracing around denials.
+ */
+export function resolveWebPermissionDecision(
+    snapshot: GuildDashboardPermissionSnapshot,
+    perm: string
+): WebPermissionDecision {
+    if (snapshot.primaryPermissions.includes(perm)) {
+        return {
+            allowed: true,
+            reason: "allow:primaryPermissions",
+            memberResolved: snapshot.memberResolved,
+        }
+    }
+    if (!snapshot.memberResolved && snapshot.oauthPermissions.includes(perm)) {
+        return {
+            allowed: true,
+            reason: "allow:oauthPermissions (member not resolved by bot)",
+            memberResolved: snapshot.memberResolved,
+        }
+    }
+    if (snapshot.memberResolved) {
+        return {
+            allowed: false,
+            reason: `deny:memberResolved=true but primaryPermissions lacks "${perm}" (OAuth fallback is not used when the bot resolved a member)`,
+            memberResolved: true,
+        }
+    }
+    return {
+        allowed: false,
+        reason: `deny:neither primary nor oauth lists include "${perm}"`,
+        memberResolved: false,
+    }
+}
+
+/** Human-readable reason for {@link dashboardHasWebPermission} (for troubleshooting). */
+export function explainDashboardWebPermission(
+    snapshot: GuildDashboardPermissionSnapshot,
+    perm: string
+): string {
+    return resolveWebPermissionDecision(snapshot, perm).reason
+}
+
+/**
+ * Whether the user may perform an action that the bot API would allow, using the same primary vs
+ * OAuth-fallback merge as {@link requirePermissions}.
+ */
+export function dashboardHasWebPermission(
+    snapshot: GuildDashboardPermissionSnapshot,
+    perm: string
+): boolean {
+    return resolveWebPermissionDecision(snapshot, perm).allowed
+}
+
+/** True if every listed permission is satisfied (AND). */
+export function dashboardHasAllWebPermissions(
+    snapshot: GuildDashboardPermissionSnapshot,
+    perms: string[]
+): boolean {
+    return perms.every((perm) => dashboardHasWebPermission(snapshot, perm))
+}

--- a/src/util/botApiVerboseEnv.test.ts
+++ b/src/util/botApiVerboseEnv.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { isBotApiVerbose } from "./botApiVerboseEnv.js"
+
+describe("isBotApiVerbose", () => {
+    it("treats BOT_API_VERBOSE / WEB_BOT_API_VERBOSE truthy flags as enabled", () => {
+        const prevBot = process.env.BOT_API_VERBOSE
+        const prevWeb = process.env.WEB_BOT_API_VERBOSE
+        try {
+            delete process.env.BOT_API_VERBOSE
+            delete process.env.WEB_BOT_API_VERBOSE
+            assert.equal(isBotApiVerbose(), false)
+
+            process.env.BOT_API_VERBOSE = "1"
+            assert.equal(isBotApiVerbose(), true)
+
+            // Non-empty BOT_API_VERBOSE wins over WEB (including falsy-looking "0").
+            process.env.BOT_API_VERBOSE = "0"
+            process.env.WEB_BOT_API_VERBOSE = "yes"
+            assert.equal(isBotApiVerbose(), false)
+
+            delete process.env.BOT_API_VERBOSE
+            process.env.WEB_BOT_API_VERBOSE = "yes"
+            assert.equal(isBotApiVerbose(), true)
+
+            process.env.WEB_BOT_API_VERBOSE = " off "
+            assert.equal(isBotApiVerbose(), false)
+
+            process.env.BOT_API_VERBOSE = "TRUE"
+            assert.equal(isBotApiVerbose(), true)
+        } finally {
+            if (prevBot === undefined) delete process.env.BOT_API_VERBOSE
+            else process.env.BOT_API_VERBOSE = prevBot
+            if (prevWeb === undefined) delete process.env.WEB_BOT_API_VERBOSE
+            else process.env.WEB_BOT_API_VERBOSE = prevWeb
+        }
+    })
+})

--- a/src/util/countdownEmbed.test.ts
+++ b/src/util/countdownEmbed.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { CountdownEntry } from "../types/index.js"
+import {
+    DEFAULT_COUNTDOWN_COLOR,
+    buildCountdownEmbed,
+    buildCountdownFinishEmbed,
+} from "./countdownEmbed.js"
+
+function entry(overrides: Partial<CountdownEntry> = {}): CountdownEntry {
+    return {
+        id: 7,
+        guildId: "g1",
+        channelId: "c1",
+        messageId: "m1",
+        eventName: "Launch Party",
+        description: null,
+        imageUrl: null,
+        color: null,
+        footer: null,
+        finishMessage: null,
+        mentionRoleId: null,
+        targetTime: new Date("2030-01-01T00:00:00.000Z"),
+        createdBy: "u1",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        ...overrides,
+    }
+}
+
+describe("buildCountdownEmbed", () => {
+    it("shows remaining time, default color/footer, and optional description/image", () => {
+        const target = new Date("2030-01-01T00:00:00.000Z")
+        const now = target.getTime() - 90 * 60 * 1000
+        const embed = buildCountdownEmbed(
+            entry({
+                description: "Bring snacks",
+                imageUrl: "https://cdn.example.com/party.png",
+                targetTime: target,
+            }),
+            now
+        )
+        const data = embed.toJSON()
+        assert.equal(data.title, "Launch Party")
+        assert.equal(data.color, DEFAULT_COUNTDOWN_COLOR)
+        assert.equal(data.footer?.text, "Countdown #7")
+        assert.equal(data.image?.url, "https://cdn.example.com/party.png")
+        assert.match(String(data.description), /Bring snacks/)
+        assert.match(String(data.description), /\*\*Starts:\*\* <t:1893456000:F>/)
+        assert.match(String(data.description), /\*\*Time remaining:\*\* 1 hour, 30 minutes/)
+    })
+
+    it("marks the event as started and honors custom color/footer", () => {
+        const target = new Date("2030-01-01T00:00:00.000Z")
+        const embed = buildCountdownEmbed(
+            entry({
+                color: 0xff0000,
+                footer: "Custom footer",
+                targetTime: target,
+            }),
+            target.getTime() + 1
+        )
+        const data = embed.toJSON()
+        assert.equal(data.color, 0xff0000)
+        assert.equal(data.footer?.text, "Custom footer")
+        assert.match(String(data.description), /\*\*Time remaining:\*\* Event started!/)
+        assert.equal(data.image, undefined)
+    })
+})
+
+describe("buildCountdownFinishEmbed", () => {
+    it("returns null when there is no image to re-post", () => {
+        assert.equal(buildCountdownFinishEmbed(entry({ imageUrl: null })), null)
+    })
+
+    it("builds a title+image finish embed with default or custom color", () => {
+        const withDefault = buildCountdownFinishEmbed(
+            entry({ imageUrl: "https://cdn.example.com/done.png" })
+        )
+        assert.ok(withDefault)
+        const defaultData = withDefault.toJSON()
+        assert.equal(defaultData.title, "Launch Party")
+        assert.equal(defaultData.color, DEFAULT_COUNTDOWN_COLOR)
+        assert.equal(defaultData.image?.url, "https://cdn.example.com/done.png")
+
+        const withColor = buildCountdownFinishEmbed(
+            entry({ imageUrl: "https://cdn.example.com/done.png", color: 0x00ff00 })
+        )
+        assert.ok(withColor)
+        assert.equal(withColor.toJSON().color, 0x00ff00)
+    })
+})

--- a/src/util/discordBotInvite.test.ts
+++ b/src/util/discordBotInvite.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { DISCORD_BOT_INVITE_PERMISSIONS } from "../shared/discordBotPermissions.js"
+import { getDiscordBotInviteUrl } from "../web/lib/discord-bot-invite.js"
+
+describe("getDiscordBotInviteUrl", () => {
+    it("builds an authorize URL with encoded client id, shared permissions, and bot scopes", () => {
+        const prev = process.env.CLIENT_ID
+        try {
+            process.env.CLIENT_ID = "123456789012345678"
+            const url = getDiscordBotInviteUrl()
+            assert.ok(url)
+            const parsed = new URL(url!)
+            assert.equal(parsed.origin + parsed.pathname, "https://discord.com/oauth2/authorize")
+            assert.equal(parsed.searchParams.get("client_id"), "123456789012345678")
+            assert.equal(parsed.searchParams.get("permissions"), DISCORD_BOT_INVITE_PERMISSIONS)
+            assert.equal(parsed.searchParams.get("scope"), "bot applications.commands")
+        } finally {
+            if (prev === undefined) delete process.env.CLIENT_ID
+            else process.env.CLIENT_ID = prev
+        }
+    })
+
+    it("returns null when CLIENT_ID is missing or blank", () => {
+        const prev = process.env.CLIENT_ID
+        try {
+            delete process.env.CLIENT_ID
+            assert.equal(getDiscordBotInviteUrl(), null)
+            process.env.CLIENT_ID = "   "
+            assert.equal(getDiscordBotInviteUrl(), null)
+        } finally {
+            if (prev === undefined) delete process.env.CLIENT_ID
+            else process.env.CLIENT_ID = prev
+        }
+    })
+})

--- a/src/util/downloadsMaxMb.test.ts
+++ b/src/util/downloadsMaxMb.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    DEFAULT_DOWNLOADS_MAX_MB,
+    isCustomDownloadsMaxMb,
+    resolveDownloadsMaxMb,
+} from "./downloadsMaxMb.js"
+
+describe("resolveDownloadsMaxMb", () => {
+    it("returns a finite custom limit of at least 1 MB", () => {
+        assert.equal(resolveDownloadsMaxMb(250), 250)
+        assert.equal(resolveDownloadsMaxMb("1000"), 1000)
+        assert.equal(resolveDownloadsMaxMb(1), 1)
+        assert.equal(resolveDownloadsMaxMb("12.5"), 12.5)
+    })
+
+    it("falls back for missing, non-finite, zero, and negative values", () => {
+        assert.equal(resolveDownloadsMaxMb(undefined), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(null), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(""), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb("nope"), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(Number.NaN), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(0), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(-5), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(Number.POSITIVE_INFINITY), DEFAULT_DOWNLOADS_MAX_MB)
+    })
+
+    it("honors an explicit default override", () => {
+        assert.equal(resolveDownloadsMaxMb(0, 42), 42)
+    })
+})
+
+describe("isCustomDownloadsMaxMb", () => {
+    it("is true only for finite limits ≥ 1", () => {
+        assert.equal(isCustomDownloadsMaxMb(1), true)
+        assert.equal(isCustomDownloadsMaxMb(500), true)
+        assert.equal(isCustomDownloadsMaxMb(0), false)
+        assert.equal(isCustomDownloadsMaxMb(-1), false)
+        assert.equal(isCustomDownloadsMaxMb(undefined), false)
+        assert.equal(isCustomDownloadsMaxMb("abc"), false)
+    })
+})

--- a/src/util/downloadsMaxMb.ts
+++ b/src/util/downloadsMaxMb.ts
@@ -1,0 +1,24 @@
+/** Default guild download directory cap when no valid custom limit is configured. */
+export const DEFAULT_DOWNLOADS_MAX_MB = 1000
+
+/**
+ * Resolves a guild downloads size limit in MB.
+ * Invalid, non-finite, or sub-1 values fall back to {@link DEFAULT_DOWNLOADS_MAX_MB}
+ * (or `defaultMb`) so a corrupt settings row cannot enforce a zero/negative quota.
+ */
+export function resolveDownloadsMaxMb(
+    configured: unknown,
+    defaultMb: number = DEFAULT_DOWNLOADS_MAX_MB
+): number {
+    const parsed = Number.parseFloat(String(configured ?? ""))
+    if (!Number.isFinite(parsed) || parsed < 1) {
+        return defaultMb
+    }
+    return parsed
+}
+
+/** True when `configured` is a usable custom downloads limit (≥ 1 MB). */
+export function isCustomDownloadsMaxMb(configured: unknown): boolean {
+    const parsed = Number(configured ?? Number.NaN)
+    return Number.isFinite(parsed) && parsed >= 1
+}

--- a/src/util/escapeLucenePhrase.test.ts
+++ b/src/util/escapeLucenePhrase.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { escapeLucenePhrase } from "./escapeLucenePhrase.js"
+
+describe("escapeLucenePhrase", () => {
+    it("trims and escapes backslashes and quotes for Lucene phrases", () => {
+        assert.equal(escapeLucenePhrase('  AC/DC "Live"  '), 'AC/DC \\"Live\\"')
+        assert.equal(escapeLucenePhrase("path\\name"), "path\\\\name")
+        assert.equal(escapeLucenePhrase('both\\"ends'), 'both\\\\\\"ends')
+    })
+
+    it("returns an empty string for blank or missing input", () => {
+        assert.equal(escapeLucenePhrase(""), "")
+        assert.equal(escapeLucenePhrase("   "), "")
+        assert.equal(escapeLucenePhrase(undefined as unknown as string), "")
+    })
+})

--- a/src/util/escapeLucenePhrase.ts
+++ b/src/util/escapeLucenePhrase.ts
@@ -1,0 +1,7 @@
+/** Escapes `\` and `"` so artist names are safe inside Lucene phrase queries. */
+export function escapeLucenePhrase(s: string): string {
+    return String(s || "")
+        .trim()
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+}

--- a/src/util/guildPlayerLifecycle.test.ts
+++ b/src/util/guildPlayerLifecycle.test.ts
@@ -118,4 +118,30 @@ describe("deferred orphan player cleanup", () => {
         holder.release()
         await waitForPendingOrphanDestroyForTests(guildId)
     })
+
+    it("defers idle destroy when reservedByCaller is 0 and a reservation is held", async () => {
+        const guildId = "guild-orphan-idle-timer"
+        let destroyed = false
+
+        const inFlight = await acquireGuildPlayerLifecycleReservation(guildId)
+
+        // trackError / alone-in-VC teardown does not itself hold a reservation.
+        await tryDestroyOrphanGuildPlayer(
+            guildId,
+            {
+                hasQueueContent: () => false,
+                destroyPlayer: async () => {
+                    destroyed = true
+                },
+            },
+            0
+        )
+        assert.equal(destroyed, false)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), true)
+
+        inFlight.release()
+        await waitForPendingOrphanDestroyForTests(guildId)
+        assert.equal(destroyed, true)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), false)
+    })
 })

--- a/src/util/guildPlayerLifecycle.test.ts
+++ b/src/util/guildPlayerLifecycle.test.ts
@@ -6,6 +6,7 @@ import {
     hasPendingOrphanDestroyForTests,
     tryDestroyOrphanGuildPlayer,
     waitForPendingOrphanDestroyForTests,
+    withGuildPlayerLifecycleReservation,
 } from "./guildPlayerQueueLock.js"
 
 describe("guild player lifecycle reservation", () => {
@@ -18,6 +19,53 @@ describe("guild player lifecycle reservation", () => {
         assert.ok(getGuildPlayerLifecycleReservationCount("guild-life") > 0)
         b.release()
         assert.equal(getGuildPlayerLifecycleReservationCount("guild-life"), 0)
+    })
+
+    it("withGuildPlayerLifecycleReservation always releases after work", async () => {
+        const guildId = "guild-with-reserve"
+        await withGuildPlayerLifecycleReservation(guildId, async () => {
+            assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 1)
+        })
+        assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 0)
+    })
+
+    it("withGuildPlayerLifecycleReservation releases when work throws", async () => {
+        const guildId = "guild-with-reserve-throw"
+        await assert.rejects(
+            () =>
+                withGuildPlayerLifecycleReservation(guildId, async () => {
+                    assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 1)
+                    throw new Error("boom")
+                }),
+            /boom/
+        )
+        assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 0)
+    })
+
+    it("defers orphan destroy while a Discord-style reservation is held without createdHere", async () => {
+        // Models Discord /play (or restore) holding a reservation while web search cleanup runs.
+        const guildId = "guild-discord-vs-web-orphan"
+        let destroyed = false
+
+        const discordPlay = await acquireGuildPlayerLifecycleReservation(guildId)
+        const webSearch = await acquireGuildPlayerLifecycleReservation(guildId)
+
+        await tryDestroyOrphanGuildPlayer(guildId, {
+            hasQueueContent: () => false,
+            destroyPlayer: async () => {
+                destroyed = true
+            },
+        })
+        assert.equal(destroyed, false)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), true)
+
+        webSearch.release()
+        assert.equal(destroyed, false)
+        assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 1)
+
+        discordPlay.release()
+        await waitForPendingOrphanDestroyForTests(guildId)
+        assert.equal(destroyed, true)
     })
 })
 

--- a/src/util/guildPlayerQueueLock.ts
+++ b/src/util/guildPlayerQueueLock.ts
@@ -65,21 +65,26 @@ export function getGuildPlayerLifecycleReservationCount(guildId: string): number
 }
 
 /**
- * Destroys an empty orphan player when safe. If other lifecycle reservations are held,
+ * Destroys an empty orphan player when safe. If conflicting lifecycle reservations are held,
  * records a pending cleanup and retries under the queue lock when the count reaches zero.
  * Destroy runs under the same lock as reservation grants, so acquire waits until it finishes.
+ *
+ * @param reservedByCaller How many of the current reservation count belong to this caller
+ *   (1 for search/enqueue cleanup that still holds a lease; 0 for idle timers / non-reserved paths).
  */
 export async function tryDestroyOrphanGuildPlayer(
     guildId: string,
-    hooks: PendingOrphanDestroy
+    hooks: PendingOrphanDestroy,
+    reservedByCaller = 1
 ): Promise<void> {
+    const selfReservations = reservedByCaller > 0 ? reservedByCaller : 0
     await withGuildPlayerQueueLock(guildId, async () => {
         if (hooks.hasQueueContent()) {
             pendingOrphanDestroyByGuild.delete(guildId)
             return
         }
-        // Count includes the caller; >1 means another in-flight request still needs the player.
-        if (getGuildPlayerLifecycleReservationCount(guildId) > 1) {
+        // Defer while other in-flight requests still need this player.
+        if (getGuildPlayerLifecycleReservationCount(guildId) > selfReservations) {
             pendingOrphanDestroyByGuild.set(guildId, hooks)
             return
         }

--- a/src/util/guildPlayerQueueLock.ts
+++ b/src/util/guildPlayerQueueLock.ts
@@ -59,6 +59,19 @@ export async function acquireGuildPlayerLifecycleReservation(
     })
 }
 
+/** Acquires a lifecycle reservation, runs `work`, then always releases. */
+export async function withGuildPlayerLifecycleReservation<T>(
+    guildId: string,
+    work: () => Promise<T>
+): Promise<T> {
+    const lease = await acquireGuildPlayerLifecycleReservation(guildId)
+    try {
+        return await work()
+    } finally {
+        lease.release()
+    }
+}
+
 /** Active lifecycle reservations for a guild (includes the calling request while it holds one). */
 export function getGuildPlayerLifecycleReservationCount(guildId: string): number {
     return guildPlayerLifecycleReservations.get(guildId) ?? 0

--- a/src/util/guildSettingsMerge.test.ts
+++ b/src/util/guildSettingsMerge.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { GUILD_SETTING_FIELD_KEYS, mergeGuildSettingsRow } from "./guildSettingsMerge.js"
+
+describe("mergeGuildSettingsRow", () => {
+    it("keeps DB fields omitted from the snapshot (no cross-field clobber)", () => {
+        const merged = mergeGuildSettingsRow(
+            {
+                controlChannelId: "c1",
+                controlMessageId: "m1",
+                downloadsMaxMb: 500,
+            },
+            { controlChannelId: "c2" }
+        )
+        assert.deepEqual(merged, {
+            controlChannelId: "c2",
+            controlMessageId: "m1",
+            downloadsMaxMb: 500,
+        })
+    })
+
+    it("applies clearedFields even when the snapshot still lists those keys", () => {
+        const merged = mergeGuildSettingsRow(
+            { controlChannelId: "c1", downloadsMaxMb: 200 },
+            { controlChannelId: "c1", downloadsMaxMb: 200 },
+            ["downloadsMaxMb"]
+        )
+        assert.deepEqual(merged, { controlChannelId: "c1" })
+        assert.equal("downloadsMaxMb" in merged, false)
+    })
+
+    it("builds a row from snapshot alone when the DB row is missing", () => {
+        const merged = mergeGuildSettingsRow(undefined, {
+            discordLog: { channelId: "log1" },
+            downloadsMaxMb: 100,
+        })
+        assert.deepEqual(merged, {
+            discordLog: { channelId: "log1" },
+            downloadsMaxMb: 100,
+        })
+    })
+
+    it("ignores undefined snapshot values and unknown cleared keys leave other fields", () => {
+        const merged = mergeGuildSettingsRow(
+            { controlChannelId: "c1", controlMessageId: "m1" },
+            { controlChannelId: undefined as unknown as string, controlMessageId: "m2" },
+            []
+        )
+        assert.deepEqual(merged, { controlChannelId: "c1", controlMessageId: "m2" })
+    })
+
+    it("returns an empty object when clearing every known field", () => {
+        const merged = mergeGuildSettingsRow(
+            {
+                controlChannelId: "c1",
+                controlMessageId: "m1",
+                downloadsMaxMb: 50,
+                discordLog: { channelId: "d1" },
+            },
+            {},
+            [...GUILD_SETTING_FIELD_KEYS]
+        )
+        assert.deepEqual(merged, {})
+    })
+
+    it("does not mutate the input DB row", () => {
+        const db = { controlChannelId: "c1", downloadsMaxMb: 10 }
+        const merged = mergeGuildSettingsRow(db, { downloadsMaxMb: 20 })
+        assert.equal(db.downloadsMaxMb, 10)
+        assert.equal(merged.downloadsMaxMb, 20)
+        assert.notEqual(merged, db)
+    })
+})

--- a/src/util/guildSettingsMerge.test.ts
+++ b/src/util/guildSettingsMerge.test.ts
@@ -31,11 +31,11 @@ describe("mergeGuildSettingsRow", () => {
 
     it("builds a row from snapshot alone when the DB row is missing", () => {
         const merged = mergeGuildSettingsRow(undefined, {
-            discordLog: { channelId: "log1" },
+            discordLog: { allChannelId: "log1" },
             downloadsMaxMb: 100,
         })
         assert.deepEqual(merged, {
-            discordLog: { channelId: "log1" },
+            discordLog: { allChannelId: "log1" },
             downloadsMaxMb: 100,
         })
     })
@@ -55,7 +55,7 @@ describe("mergeGuildSettingsRow", () => {
                 controlChannelId: "c1",
                 controlMessageId: "m1",
                 downloadsMaxMb: 50,
-                discordLog: { channelId: "d1" },
+                discordLog: { allChannelId: "d1" },
             },
             {},
             [...GUILD_SETTING_FIELD_KEYS]

--- a/src/util/guildSettingsMerge.ts
+++ b/src/util/guildSettingsMerge.ts
@@ -1,0 +1,52 @@
+import type { GuildSettings } from "../types/index.js"
+
+/** Fields that may be written or cleared on a guild settings row. */
+export const GUILD_SETTING_FIELD_KEYS: (keyof GuildSettings)[] = [
+    "controlChannelId",
+    "controlMessageId",
+    "downloadsMaxMb",
+    "discordLog",
+]
+
+function cloneGuildSettingsRow(row: GuildSettings): GuildSettings {
+    return typeof structuredClone === "function"
+        ? structuredClone(row)
+        : (JSON.parse(JSON.stringify(row)) as GuildSettings)
+}
+
+/**
+ * Merges only fields present in `snapshotRow` onto `dbRow`, then removes `clearedFields`.
+ * Omitted snapshot fields keep their latest database values (prevents cross-field clobber races).
+ */
+export function mergeGuildSettingsRow(
+    dbRow: GuildSettings | undefined,
+    snapshotRow: GuildSettings | undefined,
+    clearedFields: (keyof GuildSettings)[] = []
+): GuildSettings {
+    const merged: GuildSettings = dbRow ? cloneGuildSettingsRow(dbRow) : {}
+    if (snapshotRow) {
+        for (const key of GUILD_SETTING_FIELD_KEYS) {
+            if (key in snapshotRow) {
+                const value = snapshotRow[key]
+                if (value !== undefined) {
+                    switch (key) {
+                        case "controlChannelId":
+                        case "controlMessageId":
+                            merged[key] = value as string
+                            break
+                        case "downloadsMaxMb":
+                            merged.downloadsMaxMb = value as number
+                            break
+                        case "discordLog":
+                            merged.discordLog = value as GuildSettings["discordLog"]
+                            break
+                    }
+                }
+            }
+        }
+    }
+    for (const key of clearedFields) {
+        delete merged[key]
+    }
+    return merged
+}

--- a/src/util/localPlaySessionHandoff.test.ts
+++ b/src/util/localPlaySessionHandoff.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { afterEach, describe, it } from "node:test"
 import type { Player, Track } from "lavalink-client"
+import type { PlayerSessionSnapshotV1 } from "../types/index.js"
 import {
     acquirePlayerSessionClearSuppressLease,
     clearPlayerSession,
@@ -9,16 +10,16 @@ import {
 } from "./playerSessionPersistence.js"
 import { beginLocalPlaySessionHandoff } from "./localPlaySessionHandoff.js"
 
-function mockTrack(): Track {
+function mockTrack(title = "Song"): Track {
     return {
-        encoded: "enc",
+        encoded: `enc-${title}`,
         info: {
-            title: "Song",
+            title,
             author: "Artist",
-            uri: "https://example.com/t",
+            uri: `https://example.com/${title}`,
             duration: 1000,
             isStream: false,
-            identifier: "id",
+            identifier: title,
             isSeekable: true,
             sourceName: "http",
             artworkUrl: null,
@@ -28,7 +29,10 @@ function mockTrack(): Track {
     } as unknown as Track
 }
 
-function mockPlayer(guildId: string): Player {
+function mockPlayer(
+    guildId: string,
+    opts: { current?: Track | null; tracks?: Track[] } = {}
+): Player {
     const store = new Map<string, unknown>()
     return {
         guildId,
@@ -39,8 +43,8 @@ function mockPlayer(guildId: string): Player {
         paused: false,
         playing: true,
         queue: {
-            current: mockTrack(),
-            tracks: [],
+            current: opts.current === undefined ? mockTrack("Current") : opts.current,
+            tracks: opts.tracks ?? [],
         },
         get: (key: string) => store.get(key),
         set: (key: string, value: unknown) => {
@@ -52,6 +56,44 @@ function mockPlayer(guildId: string): Player {
 describe("beginLocalPlaySessionHandoff", () => {
     afterEach(() => {
         setPlayerSessionPersistenceDbForTests(null)
+    })
+
+    it("flushes upcoming queue before destroy callback clears tracks (join-fail restore)", async () => {
+        const guildId = "guild-local-handoff-queue-order"
+        const upsertedQueues: PlayerSessionSnapshotV1["queue"][] = []
+        const deletes: string[] = []
+
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async (_id, _vc, _text, snapshot) => {
+                upsertedQueues.push(snapshot.queue)
+            },
+            deletePlayerSession: async (id) => {
+                deletes.push(id)
+            },
+        })
+
+        const upcoming = [mockTrack("Next-1"), mockTrack("Next-2")]
+        const player = mockPlayer(guildId, { tracks: upcoming })
+
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            // Simulate stopPlaying(true) + destroy after the flush must already have run.
+            player.queue.tracks.length = 0
+            player.queue.current = null
+            assert.equal(shouldSkipPlayerSessionClear(guildId), true)
+            await clearPlayerSession(guildId)
+        })
+        handoff.markDestroyEventSeen()
+
+        assert.equal(handoff.destroyedLavalink, true)
+        assert.equal(upsertedQueues.length, 1)
+        assert.equal(upsertedQueues[0].length, 2)
+        assert.equal(upsertedQueues[0][0]?.info.title, "Next-1")
+        assert.equal(upsertedQueues[0][1]?.info.title, "Next-2")
+        assert.deepEqual(deletes, [])
+
+        // Failed local VC join: preserved row still has the full upcoming queue.
+        handoff.releaseLeftoverSuppressLease()
+        assert.deepEqual(deletes, [])
     })
 
     it("keeps the session row when local join fails after Lavalink destroy", async () => {

--- a/src/util/localPlaySessionHandoff.test.ts
+++ b/src/util/localPlaySessionHandoff.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict"
+import { afterEach, describe, it } from "node:test"
+import type { Player, Track } from "lavalink-client"
+import {
+    acquirePlayerSessionClearSuppressLease,
+    clearPlayerSession,
+    setPlayerSessionPersistenceDbForTests,
+    shouldSkipPlayerSessionClear,
+} from "./playerSessionPersistence.js"
+import { beginLocalPlaySessionHandoff } from "./localPlaySessionHandoff.js"
+
+function mockTrack(): Track {
+    return {
+        encoded: "enc",
+        info: {
+            title: "Song",
+            author: "Artist",
+            uri: "https://example.com/t",
+            duration: 1000,
+            isStream: false,
+            identifier: "id",
+            isSeekable: true,
+            sourceName: "http",
+            artworkUrl: null,
+            isrc: null,
+        },
+        requester: "user-1",
+    } as unknown as Track
+}
+
+function mockPlayer(guildId: string): Player {
+    const store = new Map<string, unknown>()
+    return {
+        guildId,
+        voiceChannelId: "vc-1",
+        textChannelId: "text-1",
+        volume: 80,
+        repeatMode: "off",
+        paused: false,
+        playing: true,
+        queue: {
+            current: mockTrack(),
+            tracks: [],
+        },
+        get: (key: string) => store.get(key),
+        set: (key: string, value: unknown) => {
+            store.set(key, value)
+        },
+    } as unknown as Player
+}
+
+describe("beginLocalPlaySessionHandoff", () => {
+    afterEach(() => {
+        setPlayerSessionPersistenceDbForTests(null)
+    })
+
+    it("keeps the session row when local join fails after Lavalink destroy", async () => {
+        const guildId = "guild-local-handoff-keep"
+        const deletes: string[] = []
+        const upserts: string[] = []
+
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async (id) => {
+                upserts.push(id)
+            },
+            deletePlayerSession: async (id) => {
+                deletes.push(id)
+            },
+        })
+
+        const player = mockPlayer(guildId)
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            // Simulate playerDestroy → clearPlayerSession while lease is held.
+            assert.equal(shouldSkipPlayerSessionClear(guildId), true)
+            await clearPlayerSession(guildId)
+        })
+        handoff.markDestroyEventSeen()
+
+        assert.equal(handoff.destroyedLavalink, true)
+        assert.deepEqual(deletes, [])
+        assert.ok(upserts.includes(guildId), "flush should persist snapshot before destroy")
+
+        // Failed local VC join: leave the row; leftover release is a no-op after consume.
+        handoff.releaseLeftoverSuppressLease()
+        assert.deepEqual(deletes, [])
+        assert.equal(shouldSkipPlayerSessionClear(guildId), false)
+
+        // Later intentional clear (e.g. user stops) can still delete.
+        await clearPlayerSession(guildId)
+        assert.deepEqual(deletes, [guildId])
+    })
+
+    it("clears the session only after local Ready succeeds", async () => {
+        const guildId = "guild-local-handoff-clear"
+        const deletes: string[] = []
+
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => undefined,
+            deletePlayerSession: async (id) => {
+                deletes.push(id)
+            },
+        })
+
+        const player = mockPlayer(guildId)
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            await clearPlayerSession(guildId)
+        })
+        handoff.markDestroyEventSeen()
+
+        assert.deepEqual(deletes, [])
+        await handoff.clearSessionAfterLocalReady()
+        assert.deepEqual(deletes, [guildId])
+    })
+
+    it("releases leftover suppress lease when playerDestroy never fires", async () => {
+        const guildId = "guild-local-handoff-timeout"
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => undefined,
+            deletePlayerSession: async () => undefined,
+        })
+
+        const player = mockPlayer(guildId)
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            // Destroy "succeeds" but no playerDestroy / clear ran (timeout path).
+        })
+
+        assert.equal(shouldSkipPlayerSessionClear(guildId), true)
+        handoff.releaseLeftoverSuppressLease()
+        assert.equal(shouldSkipPlayerSessionClear(guildId), false)
+    })
+
+    it("releases the lease immediately when destroy throws", async () => {
+        const guildId = "guild-local-handoff-destroy-fail"
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => undefined,
+            deletePlayerSession: async () => undefined,
+        })
+
+        const player = mockPlayer(guildId)
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            throw new Error("destroy failed")
+        })
+
+        assert.equal(handoff.destroyedLavalink, false)
+        assert.equal(shouldSkipPlayerSessionClear(guildId), false)
+    })
+
+    it("does not double-release after playerDestroy consumed the lease", async () => {
+        const guildId = "guild-local-handoff-no-double"
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => undefined,
+            deletePlayerSession: async () => undefined,
+        })
+
+        // Extra concurrent lease must survive releaseLeftover when destroy already consumed ours.
+        const other = acquirePlayerSessionClearSuppressLease(guildId)
+        const player = mockPlayer(guildId)
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            await clearPlayerSession(guildId)
+        })
+        handoff.markDestroyEventSeen()
+
+        handoff.releaseLeftoverSuppressLease()
+        assert.equal(shouldSkipPlayerSessionClear(guildId), true)
+        other.release()
+        assert.equal(shouldSkipPlayerSessionClear(guildId), false)
+    })
+})

--- a/src/util/localPlaySessionHandoff.test.ts
+++ b/src/util/localPlaySessionHandoff.test.ts
@@ -87,8 +87,8 @@ describe("beginLocalPlaySessionHandoff", () => {
         assert.equal(handoff.destroyedLavalink, true)
         assert.equal(upsertedQueues.length, 1)
         assert.equal(upsertedQueues[0].length, 2)
-        assert.equal(upsertedQueues[0][0]?.info.title, "Next-1")
-        assert.equal(upsertedQueues[0][1]?.info.title, "Next-2")
+        assert.equal(upsertedQueues[0][0]?.title, "Next-1")
+        assert.equal(upsertedQueues[0][1]?.title, "Next-2")
         assert.deepEqual(deletes, [])
 
         // Failed local VC join: preserved row still has the full upcoming queue.

--- a/src/util/localPlaySessionHandoff.ts
+++ b/src/util/localPlaySessionHandoff.ts
@@ -13,6 +13,9 @@ import {
  * Destroying Lavalink fires `playerDestroy` → `clearPlayerSession`. Without a suppress
  * lease, a failed local VC join after destroy permanently deletes the persisted queue.
  * Hold a suppress lease across destroy, then clear only after local Ready succeeds.
+ *
+ * Callers must not mutate the live queue (e.g. `stopPlaying(true)`) before this runs —
+ * the flush below captures `player.queue` as-is.
  */
 export type LocalPlaySessionHandoff = {
     /** True when Lavalink destroy was attempted successfully (player torn down). */
@@ -31,6 +34,9 @@ export type LocalPlaySessionHandoff = {
 /**
  * Flushes the live snapshot, acquires a suppress lease, then runs `destroyLavalink`.
  * On destroy failure the lease is released immediately.
+ *
+ * `destroyLavalink` may clear/stop the player — do that only inside the callback so the
+ * flushed snapshot still includes upcoming tracks.
  */
 export async function beginLocalPlaySessionHandoff(
     player: Player,

--- a/src/util/localPlaySessionHandoff.ts
+++ b/src/util/localPlaySessionHandoff.ts
@@ -1,0 +1,78 @@
+import type { Player } from "lavalink-client"
+import {
+    acquirePlayerSessionClearSuppressLease,
+    clearPlayerSession,
+    flushPlayerSessionSave,
+    schedulePlayerSessionSave,
+    type PlayerSessionClearSuppressLease,
+} from "./playerSessionPersistence.js"
+
+/**
+ * Session policy for Lavalink → @discordjs/voice local playback handoff.
+ *
+ * Destroying Lavalink fires `playerDestroy` → `clearPlayerSession`. Without a suppress
+ * lease, a failed local VC join after destroy permanently deletes the persisted queue.
+ * Hold a suppress lease across destroy, then clear only after local Ready succeeds.
+ */
+export type LocalPlaySessionHandoff = {
+    /** True when Lavalink destroy was attempted successfully (player torn down). */
+    readonly destroyedLavalink: boolean
+    /**
+     * Call after `playerDestroy` is observed (or known to have run). When true, the
+     * suppress lease was consumed by the skipped clear; do not release again.
+     */
+    markDestroyEventSeen(): void
+    /** Release a leftover lease if destroy never emitted `playerDestroy` (avoid leak). */
+    releaseLeftoverSuppressLease(): void
+    /** Intentional clear after local playback has started successfully. */
+    clearSessionAfterLocalReady(): Promise<void>
+}
+
+/**
+ * Flushes the live snapshot, acquires a suppress lease, then runs `destroyLavalink`.
+ * On destroy failure the lease is released immediately.
+ */
+export async function beginLocalPlaySessionHandoff(
+    player: Player,
+    destroyLavalink: () => Promise<void>
+): Promise<LocalPlaySessionHandoff> {
+    const guildId = player.guildId
+    schedulePlayerSessionSave(player)
+    await flushPlayerSessionSave(guildId)
+
+    let lease: PlayerSessionClearSuppressLease | null =
+        acquirePlayerSessionClearSuppressLease(guildId)
+    let destroyEventSeen = false
+    let destroyedLavalink = false
+
+    try {
+        await destroyLavalink()
+        destroyedLavalink = true
+    } catch {
+        lease.release()
+        lease = null
+    }
+
+    return {
+        get destroyedLavalink() {
+            return destroyedLavalink
+        },
+        markDestroyEventSeen() {
+            destroyEventSeen = true
+        },
+        releaseLeftoverSuppressLease() {
+            if (!lease || destroyEventSeen) return
+            lease.release()
+            lease = null
+        },
+        async clearSessionAfterLocalReady() {
+            // If playerDestroy never consumed the lease, release so clear can delete.
+            if (lease && !destroyEventSeen) {
+                lease.release()
+                lease = null
+            }
+            if (!destroyedLavalink) return
+            await clearPlayerSession(guildId)
+        },
+    }
+}

--- a/src/util/localPlayer.ts
+++ b/src/util/localPlayer.ts
@@ -17,30 +17,37 @@ import type {
     LocalPlayerState,
     QueryPlayResult,
 } from "../types/index.js"
+import {
+    beginLocalPlaySessionHandoff,
+    type LocalPlaySessionHandoff,
+} from "./localPlaySessionHandoff.js"
 
 const activeLocalPlayers = new Map<string, ActiveLocalPlayer>()
 const pendingLocalPlayGuildIds = new Set<string>()
 
-/** Resolves when Lavalink emits `playerDestroy` for the guild or after `timeoutMs` (teardown handoff). */
+/**
+ * Resolves when Lavalink emits `playerDestroy` for the guild or after `timeoutMs`.
+ * Returns whether the destroy event was observed (vs timeout).
+ */
 function waitForLavalinkPlayerDestroy(
     client: BotClient,
     guildId: string,
     timeoutMs: number
-): Promise<void> {
+): Promise<boolean> {
     return new Promise((resolve) => {
         let settled = false
-        const finish = () => {
+        const finish = (eventSeen: boolean) => {
             if (settled) return
             settled = true
             clearTimeout(timer)
             client.lavalink.off("playerDestroy", onDestroy)
-            resolve()
+            resolve(eventSeen)
         }
         const onDestroy = (p: Player) => {
             if (p.guildId !== guildId) return
-            finish()
+            finish(true)
         }
-        const timer = setTimeout(finish, timeoutMs)
+        const timer = setTimeout(() => finish(false), timeoutMs)
         client.lavalink.on("playerDestroy", onDestroy)
     })
 }
@@ -81,6 +88,7 @@ export async function playLocalFile(
     pendingLocalPlayGuildIds.add(guildId)
 
     let postLavalinkHandoff: Promise<void> = new Promise((r) => queueMicrotask(r))
+    let sessionHandoff: LocalPlaySessionHandoff | null = null
 
     if (lavalinkPlayer) {
         client.debug(
@@ -98,8 +106,11 @@ export async function playLocalFile(
             }
         }
         if (client.lavalink.players.has(guildId)) {
-            postLavalinkHandoff = waitForLavalinkPlayerDestroy(client, guildId, 2000)
-            try {
+            // Preserve the DB session across destroy until local Ready succeeds.
+            // Otherwise playerDestroy → clearPlayerSession wipes the queue on a failed join.
+            let destroyEventWait: Promise<boolean> = Promise.resolve(false)
+            sessionHandoff = await beginLocalPlaySessionHandoff(lavalinkPlayer, async () => {
+                destroyEventWait = waitForLavalinkPlayerDestroy(client, guildId, 2000)
                 client.debug(
                     `[LocalPlayer] Attempting to destroy existing Lavalink player for guild ${guildId}.`
                 )
@@ -116,12 +127,15 @@ export async function playLocalFile(
                         `[LocalPlayer] Attempted to delete player from Lavalink manager for guild ${guildId}, but it was not found (or delete returned false).`
                     )
                 }
-            } catch (e: unknown) {
-                const msg = e instanceof Error ? e.message : String(e)
+            })
+            if (!sessionHandoff.destroyedLavalink) {
                 client.warn(
-                    `[LocalPlayer] Failed to destroy or delete Lavalink player in guild ${guildId}: ${msg}. Proceeding with @discordjs/voice connection attempt.`
+                    `[LocalPlayer] Failed to destroy Lavalink player in guild ${guildId}. Proceeding with @discordjs/voice connection attempt.`
                 )
             }
+            postLavalinkHandoff = destroyEventWait.then((eventSeen) => {
+                if (eventSeen) sessionHandoff?.markDestroyEventSeen()
+            })
         } else {
             client.debug(
                 `[LocalPlayer] No Lavalink player found in manager for guild ${guildId} prior to local play.`
@@ -171,6 +185,9 @@ export async function playLocalFile(
                 `[LocalPlayer] Failed to join or get ready in voice channel ${voiceChannel.id} for guild ${guildId}:`,
                 error
             )
+            // Keep the persisted Lavalink session so a restart (or later restore) can recover
+            // the queue that was torn down before this failed local join.
+            sessionHandoff?.releaseLeftoverSuppressLease()
             if (connection && connection.state.status !== VoiceConnectionStatus.Destroyed) {
                 connection.destroy()
             }
@@ -179,6 +196,15 @@ export async function playLocalFile(
                 feedbackText: "I couldn't connect to your voice channel to play the local file.",
                 error: error instanceof Error ? error : new Error(String(error)),
             }
+        }
+
+        try {
+            await sessionHandoff?.clearSessionAfterLocalReady()
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e)
+            client.warn(
+                `[LocalPlayer] clearPlayerSession after local Ready failed for guild ${guildId}: ${msg}`
+            )
         }
 
         const conn = connection!

--- a/src/util/localPlayer.ts
+++ b/src/util/localPlayer.ts
@@ -94,22 +94,22 @@ export async function playLocalFile(
         client.debug(
             `[LocalPlayer] Checking Lavalink player state for guild ${guildId}. Connected: ${lavalinkPlayer.connected}, Playing: ${lavalinkPlayer.playing}`
         )
-        if (lavalinkPlayer.playing) {
-            try {
-                await lavalinkPlayer.stopPlaying(true, false)
-                client.debug(`[LocalPlayer] Stopped Lavalink player in guild ${guildId}.`)
-            } catch (e: unknown) {
-                const msg = e instanceof Error ? e.message : String(e)
-                client.warn(
-                    `[LocalPlayer] Failed to stop Lavalink player in guild ${guildId}: ${msg}`
-                )
-            }
-        }
         if (client.lavalink.players.has(guildId)) {
-            // Preserve the DB session across destroy until local Ready succeeds.
-            // Otherwise playerDestroy → clearPlayerSession wipes the queue on a failed join.
+            // Flush the full queue *before* stopPlaying(true) clears upcoming tracks, then
+            // suppress clearPlayerSession across destroy so a failed local join can restore.
             let destroyEventWait: Promise<boolean> = Promise.resolve(false)
             sessionHandoff = await beginLocalPlaySessionHandoff(lavalinkPlayer, async () => {
+                if (lavalinkPlayer.playing) {
+                    try {
+                        await lavalinkPlayer.stopPlaying(true, false)
+                        client.debug(`[LocalPlayer] Stopped Lavalink player in guild ${guildId}.`)
+                    } catch (e: unknown) {
+                        const msg = e instanceof Error ? e.message : String(e)
+                        client.warn(
+                            `[LocalPlayer] Failed to stop Lavalink player in guild ${guildId}: ${msg}`
+                        )
+                    }
+                }
                 destroyEventWait = waitForLavalinkPlayerDestroy(client, guildId, 2000)
                 client.debug(
                     `[LocalPlayer] Attempting to destroy existing Lavalink player for guild ${guildId}.`
@@ -140,6 +140,17 @@ export async function playLocalFile(
             client.debug(
                 `[LocalPlayer] No Lavalink player found in manager for guild ${guildId} prior to local play.`
             )
+            if (lavalinkPlayer.playing) {
+                try {
+                    await lavalinkPlayer.stopPlaying(true, false)
+                    client.debug(`[LocalPlayer] Stopped Lavalink player in guild ${guildId}.`)
+                } catch (e: unknown) {
+                    const msg = e instanceof Error ? e.message : String(e)
+                    client.warn(
+                        `[LocalPlayer] Failed to stop Lavalink player in guild ${guildId}: ${msg}`
+                    )
+                }
+            }
         }
     }
 
@@ -185,8 +196,7 @@ export async function playLocalFile(
                 `[LocalPlayer] Failed to join or get ready in voice channel ${voiceChannel.id} for guild ${guildId}:`,
                 error
             )
-            // Keep the persisted Lavalink session so a restart (or later restore) can recover
-            // the queue that was torn down before this failed local join.
+            // Keep the persisted Lavalink session (full queue flushed before stop/destroy).
             sessionHandoff?.releaseLeftoverSuppressLease()
             if (connection && connection.state.status !== VoiceConnectionStatus.Destroyed) {
                 connection.destroy()

--- a/src/util/musicBrainzSimilarService.ts
+++ b/src/util/musicBrainzSimilarService.ts
@@ -3,6 +3,8 @@
  * @see https://musicbrainz.org/doc/MusicBrainz_API — rate limit ~1 req/s; User-Agent required.
  */
 
+import { escapeLucenePhrase } from "./escapeLucenePhrase.js"
+
 const MB_ROOT = "https://musicbrainz.org/ws/2"
 
 let lastMbRequestAt = 0
@@ -46,16 +48,6 @@ async function mbFetch(pathQuery: string): Promise<Response> {
         },
     })
     return res
-}
-
-/**
- * @param {string} s
- */
-function escapeLucenePhrase(s: string) {
-    return String(s || "")
-        .trim()
-        .replace(/\\/g, "\\\\")
-        .replace(/"/g, '\\"')
 }
 
 /**

--- a/src/util/musicManager.ts
+++ b/src/util/musicManager.ts
@@ -22,6 +22,10 @@ import {
 import { downloadMetadataFileBelongsToGuild } from "./downloadMetadataKeys.js"
 import { getDownloadMetadataStore } from "./downloadMetadataStore.js"
 import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "./sameVoiceChannel.js"
 
 type SearchAttempt =
     | { source: string; success: true; loadType?: string }
@@ -432,6 +436,17 @@ export async function handleQueryAndPlay(
 
         const currentLocalPlayerState = getLocalPlayerState(guildId)
         if (currentLocalPlayerState && currentLocalPlayerState.isPlaying) {
+            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(
+                voiceChannel.guild,
+                player
+            )
+            if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                return {
+                    success: false,
+                    feedbackText: `${requester}, You need to be in the same voice channel as the bot!`,
+                    error: new Error("other voice channel during local playback"),
+                }
+            }
             client.debug(
                 `[MusicManager] Active local player found in guild ${guildId}. Stopping it before Lavalink playback.`
             )

--- a/src/util/musicManager.ts
+++ b/src/util/musicManager.ts
@@ -22,10 +22,7 @@ import {
 import { downloadMetadataFileBelongsToGuild } from "./downloadMetadataKeys.js"
 import { getDownloadMetadataStore } from "./downloadMetadataStore.js"
 import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
-import {
-    memberMayJoinOccupiedVoice,
-    resolveOccupiedVoiceChannelId,
-} from "./sameVoiceChannel.js"
+import { memberMayJoinOccupiedVoice, resolveOccupiedVoiceChannelId } from "./sameVoiceChannel.js"
 
 type SearchAttempt =
     | { source: string; success: true; loadType?: string }
@@ -436,10 +433,7 @@ export async function handleQueryAndPlay(
 
         const currentLocalPlayerState = getLocalPlayerState(guildId)
         if (currentLocalPlayerState && currentLocalPlayerState.isPlaying) {
-            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(
-                voiceChannel.guild,
-                player
-            )
+            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(voiceChannel.guild, player)
             if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
                 return {
                     success: false,

--- a/src/util/originFallback.test.ts
+++ b/src/util/originFallback.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { getOriginFallback } from "../web/server/origin-fallback.js"
+
+describe("getOriginFallback", () => {
+    it("returns the BETTER_AUTH_URL origin when set to a valid http(s) URL", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            process.env.BETTER_AUTH_URL = "https://dashboard.example/app"
+            assert.equal(getOriginFallback(), "https://dashboard.example")
+
+            process.env.BETTER_AUTH_URL = " http://localhost:3000/ "
+            assert.equal(getOriginFallback(), "http://localhost:3000")
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+
+    it("returns null when unset or not a valid URL", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            delete process.env.BETTER_AUTH_URL
+            assert.equal(getOriginFallback(), null)
+
+            process.env.BETTER_AUTH_URL = "   "
+            assert.equal(getOriginFallback(), null)
+
+            process.env.BETTER_AUTH_URL = "not a url"
+            assert.equal(getOriginFallback(), null)
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+})

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -5,6 +5,7 @@ import {
     acquirePlayerSessionClearSuppressLease,
     clearPlayerSession,
     clearPlayerSessionRestoreInProgress,
+    destroyPlayerSuppressingSessionClear,
     getSessionClearEpochForTests,
     markPlayerSessionRestoreInProgress,
     setPlayerSessionPersistenceDbForTests,
@@ -157,6 +158,28 @@ describe("shouldSkipPlayerSessionClear", () => {
         assert.equal(shouldSkipPlayerSessionClear("guild-lease"), true)
         leaseB.release()
         assert.equal(shouldSkipPlayerSessionClear("guild-lease"), false)
+    })
+
+    it("releases suppress lease when destroyPlayer returns undefined (already gone)", async () => {
+        // Mirrors LavalinkManager.destroyPlayer: sync undefined when no player exists.
+        // The old `.catch` pattern threw TypeError and leaked the lease forever.
+        await destroyPlayerSuppressingSessionClear("guild-gone", () => undefined)
+        assert.equal(shouldSkipPlayerSessionClear("guild-gone"), false)
+    })
+
+    it("releases suppress lease when destroyPlayer rejects", async () => {
+        await destroyPlayerSuppressingSessionClear("guild-reject", () =>
+            Promise.reject(new Error("destroy failed"))
+        )
+        assert.equal(shouldSkipPlayerSessionClear("guild-reject"), false)
+    })
+
+    it("keeps suppress lease when destroyPlayer resolves (clear consumes it)", async () => {
+        await destroyPlayerSuppressingSessionClear("guild-ok", () => Promise.resolve())
+        assert.equal(shouldSkipPlayerSessionClear("guild-ok"), true)
+        // Simulate playerDestroy → clearPlayerSession consuming the lease.
+        await clearPlayerSession("guild-ok")
+        assert.equal(shouldSkipPlayerSessionClear("guild-ok"), false)
     })
 })
 

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -142,6 +142,33 @@ export function acquirePlayerSessionClearSuppressLease(
     }
 }
 
+/**
+ * Runs an ephemeral destroy under a suppress lease.
+ * LavalinkManager.destroyPlayer returns `undefined` (not a Promise) when no player exists —
+ * calling `.catch` on that throws and would leak the lease. Release when destroy does not run
+ * or rejects; a successful destroy leaves the lease for playerDestroy → clearPlayerSession.
+ */
+export async function destroyPlayerSuppressingSessionClear(
+    guildId: string,
+    destroyPlayer: () => Promise<unknown> | void | undefined
+): Promise<void> {
+    const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
+    let result: Promise<unknown> | void | undefined
+    try {
+        result = destroyPlayer()
+    } catch {
+        suppressLease.release()
+        return
+    }
+    if (result == null || typeof (result as Promise<unknown>).then !== "function") {
+        suppressLease.release()
+        return
+    }
+    await (result as Promise<unknown>).catch(() => {
+        suppressLease.release()
+    })
+}
+
 /** Set during SIGINT/SIGTERM so playerDestroy does not wipe flushed session rows. */
 export function markPlayerSessionPersistenceShuttingDown(): void {
     persistenceShuttingDown = true

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -13,6 +13,7 @@ import {
     schedulePlayerSessionSave,
 } from "./playerSessionPersistence.js"
 import { resolvePersistedTracks } from "./playerSessionTracks.js"
+import { withGuildPlayerLifecycleReservation } from "./guildPlayerQueueLock.js"
 import { countHumanMembers } from "./voiceChannelMembers.js"
 
 let discordReady = false
@@ -133,51 +134,61 @@ async function restoreSingleSession(client: BotClient, session: PlayerSessionDat
     markPlayerSessionRestoreInProgress(guildId)
 
     try {
-        const player = await client.lavalink.createPlayer({
-            guildId,
-            voiceChannelId,
-            textChannelId: textChannelId ?? undefined,
-            selfDeaf: true,
-            volume: snapshot.volume,
+        await withGuildPlayerLifecycleReservation(guildId, async () => {
+            // Re-check under the reservation: a concurrent create may have won the race.
+            if (client.lavalink.getPlayer(guildId)) {
+                client.debug(
+                    `[playerSession] restore skipped for ${guildId}: player appeared before hydrate`
+                )
+                return
+            }
+
+            const player = await client.lavalink.createPlayer({
+                guildId,
+                voiceChannelId,
+                textChannelId: textChannelId ?? undefined,
+                selfDeaf: true,
+                volume: snapshot.volume,
+            })
+
+            await ensurePlayerConnected(client, player, voiceChannel)
+
+            const { resolved, failed } = await resolvePersistedTracks(player, tracksToRestore)
+            if (failed > 0) {
+                client.warn(
+                    `[playerSession] restore for ${guildId}: ${failed}/${tracksToRestore.length} tracks failed to resolve`
+                )
+            }
+            if (resolved.length === 0) {
+                client.warn(
+                    `[playerSession] restore for ${guildId}: no tracks resolved; destroying player`
+                )
+                await player.destroy()
+                await deletePlayerSession(guildId)
+                return
+            }
+
+            await player.queue.add(resolved)
+
+            if (snapshot.repeatMode !== "off") {
+                await player.setRepeatMode(snapshot.repeatMode)
+            }
+            player.set("autoplay", snapshot.autoplay)
+            player.set("rrqEnabled", snapshot.rrqEnabled)
+
+            await startPlaybackIfNeeded(player)
+            if (snapshot.paused && player.playing) {
+                await player.pause()
+            }
+
+            client.info(
+                `[playerSession] restored player for guild ${guildId} (${resolved.length} tracks, humans=${humans})`
+            )
+
+            scheduleControlMessageUpdate(client, guildId)
+            playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
+            schedulePlayerSessionSave(player)
         })
-
-        await ensurePlayerConnected(client, player, voiceChannel)
-
-        const { resolved, failed } = await resolvePersistedTracks(player, tracksToRestore)
-        if (failed > 0) {
-            client.warn(
-                `[playerSession] restore for ${guildId}: ${failed}/${tracksToRestore.length} tracks failed to resolve`
-            )
-        }
-        if (resolved.length === 0) {
-            client.warn(
-                `[playerSession] restore for ${guildId}: no tracks resolved; destroying player`
-            )
-            await player.destroy()
-            await deletePlayerSession(guildId)
-            return
-        }
-
-        await player.queue.add(resolved)
-
-        if (snapshot.repeatMode !== "off") {
-            await player.setRepeatMode(snapshot.repeatMode)
-        }
-        player.set("autoplay", snapshot.autoplay)
-        player.set("rrqEnabled", snapshot.rrqEnabled)
-
-        await startPlaybackIfNeeded(player)
-        if (snapshot.paused && player.playing) {
-            await player.pause()
-        }
-
-        client.info(
-            `[playerSession] restored player for guild ${guildId} (${resolved.length} tracks, humans=${humans})`
-        )
-
-        scheduleControlMessageUpdate(client, guildId)
-        playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
-        schedulePlayerSessionSave(player)
     } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
         client.error(`[playerSession] restore failed for guild ${guildId}: ${msg}`)

--- a/src/util/sameVoiceChannel.test.ts
+++ b/src/util/sameVoiceChannel.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "./sameVoiceChannel.js"
+
+describe("resolveOccupiedVoiceChannelId", () => {
+    it("prefers live bot Discord VC (local playback with no Lavalink player)", () => {
+        const guild = {
+            members: { me: { voice: { channelId: "bot-vc" } } },
+        }
+        assert.equal(resolveOccupiedVoiceChannelId(guild, null), "bot-vc")
+    })
+
+    it("falls back to player voiceChannelId when bot is not in a VC", () => {
+        const guild = {
+            members: { me: { voice: { channelId: null } } },
+        }
+        assert.equal(
+            resolveOccupiedVoiceChannelId(guild, { voiceChannelId: "player-vc" }),
+            "player-vc"
+        )
+    })
+
+    it("returns null when idle", () => {
+        const guild = {
+            members: { me: { voice: { channelId: null } } },
+        }
+        assert.equal(resolveOccupiedVoiceChannelId(guild, null), null)
+    })
+})
+
+describe("memberMayJoinOccupiedVoice", () => {
+    it("allows any channel when nothing is occupied", () => {
+        assert.equal(memberMayJoinOccupiedVoice(null, "any"), true)
+    })
+
+    it("requires the same channel when occupied", () => {
+        assert.equal(memberMayJoinOccupiedVoice("vc-a", "vc-a"), true)
+        assert.equal(memberMayJoinOccupiedVoice("vc-a", "vc-b"), false)
+    })
+})

--- a/src/util/sameVoiceChannel.test.ts
+++ b/src/util/sameVoiceChannel.test.ts
@@ -1,9 +1,6 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
-import {
-    memberMayJoinOccupiedVoice,
-    resolveOccupiedVoiceChannelId,
-} from "./sameVoiceChannel.js"
+import { memberMayJoinOccupiedVoice, resolveOccupiedVoiceChannelId } from "./sameVoiceChannel.js"
 
 describe("resolveOccupiedVoiceChannelId", () => {
     it("prefers live bot Discord VC (local playback with no Lavalink player)", () => {

--- a/src/util/sameVoiceChannel.ts
+++ b/src/util/sameVoiceChannel.ts
@@ -1,0 +1,34 @@
+/**
+ * Voice channel the bot currently occupies for playback.
+ * Prefers the live Discord voice state so local (@discordjs/voice) playback is
+ * visible when the Lavalink player was destroyed.
+ */
+export function resolveOccupiedVoiceChannelId(
+    guild: {
+        members: {
+            me?: {
+                voice?: {
+                    channelId?: string | null
+                    channel?: { id: string } | null
+                } | null
+            } | null
+        }
+    },
+    player?: { voiceChannelId?: string | null } | null
+): string | null {
+    const botVc = guild.members.me?.voice?.channelId ?? guild.members.me?.voice?.channel?.id ?? null
+    const playerVc = player?.voiceChannelId ?? null
+    return botVc || playerVc || null
+}
+
+/**
+ * Whether a member in `memberVoiceChannelId` may take over / play into an occupied channel.
+ * Empty occupation (bot idle, no player binding) is allowed.
+ */
+export function memberMayJoinOccupiedVoice(
+    occupiedVoiceChannelId: string | null | undefined,
+    memberVoiceChannelId: string
+): boolean {
+    if (!occupiedVoiceChannelId) return true
+    return occupiedVoiceChannelId === memberVoiceChannelId
+}

--- a/src/util/saveControlChannel.ts
+++ b/src/util/saveControlChannel.ts
@@ -7,6 +7,7 @@ import {
     replaceGuildSettingsStoreInDatabase,
 } from "../repositories/guildSettingsRepository.js"
 import { resolveGuildSettingsDeleteIds } from "./guildSettingsDeleteIds.js"
+import { GUILD_SETTING_FIELD_KEYS, mergeGuildSettingsRow } from "./guildSettingsMerge.js"
 import { loggerFromPartial } from "./loggerFromPartial.js"
 
 const __dirname = import.meta.dirname
@@ -98,56 +99,6 @@ async function withGuildSettingsSaveLock<T>(work: () => Promise<T>): Promise<T> 
     } finally {
         release()
     }
-}
-
-const GUILD_SETTING_FIELD_KEYS: (keyof GuildSettings)[] = [
-    "controlChannelId",
-    "controlMessageId",
-    "downloadsMaxMb",
-    "discordLog",
-]
-
-function cloneGuildSettingsRow(row: GuildSettings): GuildSettings {
-    return typeof structuredClone === "function"
-        ? structuredClone(row)
-        : (JSON.parse(JSON.stringify(row)) as GuildSettings)
-}
-
-/**
- * Merges only fields present in `snapshotRow` onto `dbRow`, then removes `clearedFields`.
- * Omitted snapshot fields keep their latest database values (prevents cross-field clobber races).
- */
-function mergeGuildSettingsRow(
-    dbRow: GuildSettings | undefined,
-    snapshotRow: GuildSettings | undefined,
-    clearedFields: (keyof GuildSettings)[] = []
-): GuildSettings {
-    const merged: GuildSettings = dbRow ? cloneGuildSettingsRow(dbRow) : {}
-    if (snapshotRow) {
-        for (const key of GUILD_SETTING_FIELD_KEYS) {
-            if (key in snapshotRow) {
-                const value = snapshotRow[key]
-                if (value !== undefined) {
-                    switch (key) {
-                        case "controlChannelId":
-                        case "controlMessageId":
-                            merged[key] = value as string
-                            break
-                        case "downloadsMaxMb":
-                            merged.downloadsMaxMb = value as number
-                            break
-                        case "discordLog":
-                            merged.discordLog = value as GuildSettings["discordLog"]
-                            break
-                    }
-                }
-            }
-        }
-    }
-    for (const key of clearedFields) {
-        delete merged[key]
-    }
-    return merged
 }
 
 export type SaveGuildSettingsOptions = {

--- a/src/util/similarSongsQueries.test.ts
+++ b/src/util/similarSongsQueries.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    formatTrackSearchQuery,
+    youtubeSearchQueriesForCatalogTrack,
+} from "./similarSongsService.js"
+
+describe("formatTrackSearchQuery", () => {
+    it("joins artist and title, and falls back when one side is missing", () => {
+        assert.equal(formatTrackSearchQuery({ artist: "A", title: "T" }), "A - T")
+        assert.equal(formatTrackSearchQuery({ artist: "  A  ", title: "  T  " }), "A - T")
+        assert.equal(formatTrackSearchQuery({ title: "Only Title" }), "Only Title")
+        assert.equal(formatTrackSearchQuery({ artist: "Only Artist" }), "Only Artist")
+        assert.equal(formatTrackSearchQuery({}), "")
+        assert.equal(formatTrackSearchQuery({ artist: "  ", title: "" }), "")
+    })
+})
+
+describe("youtubeSearchQueriesForCatalogTrack", () => {
+    it("returns an empty list when artist and title are blank", () => {
+        assert.deepEqual(youtubeSearchQueriesForCatalogTrack({}), [])
+        assert.deepEqual(youtubeSearchQueriesForCatalogTrack({ artist: " ", title: " " }), [])
+    })
+
+    it("orders ytsearch variants from specific official audio to bare query", () => {
+        const queries = youtubeSearchQueriesForCatalogTrack({
+            artist: "Artist",
+            title: "Song",
+        })
+        assert.deepEqual(queries, [
+            "ytsearch:Artist - Song official audio",
+            "ytsearch:Artist - Song official music video",
+            "ytsearch:Artist - Song audio",
+            "ytsearch:Artist - Song",
+        ])
+    })
+})

--- a/src/util/skipCurrentTrack.test.ts
+++ b/src/util/skipCurrentTrack.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { skipCurrentTrack } from "./skipCurrentTrack.js"
+
+describe("skipCurrentTrack", () => {
+    it("uses default skip when upcoming tracks exist", async () => {
+        const calls: Array<{ skipTo?: number; throwError?: boolean }> = []
+        await skipCurrentTrack({
+            queue: { tracks: { length: 2 } },
+            skip: async (skipTo, throwError) => {
+                calls.push({ skipTo, throwError })
+            },
+        })
+        assert.deepEqual(calls, [{ skipTo: undefined, throwError: undefined }])
+    })
+
+    it("uses skip(0, false) when the upcoming queue is empty", async () => {
+        const calls: Array<{ skipTo?: number; throwError?: boolean }> = []
+        await skipCurrentTrack({
+            queue: { tracks: { length: 0 } },
+            skip: async (skipTo, throwError) => {
+                calls.push({ skipTo, throwError })
+            },
+        })
+        assert.deepEqual(calls, [{ skipTo: 0, throwError: false }])
+    })
+})

--- a/src/util/skipCurrentTrack.ts
+++ b/src/util/skipCurrentTrack.ts
@@ -1,0 +1,14 @@
+/**
+ * Advances past the current track without using default `skip()`, which throws when the
+ * upcoming queue is empty (lavalink-client). Matches `/skip`, control buttons, and web player.
+ */
+export async function skipCurrentTrack(player: {
+    queue: { tracks: { length: number } }
+    skip: (skipTo?: number, throwError?: boolean) => Promise<unknown>
+}): Promise<void> {
+    if (player.queue.tracks.length > 0) {
+        await player.skip()
+        return
+    }
+    await player.skip(0, false)
+}

--- a/src/util/webDashboardUrl.test.ts
+++ b/src/util/webDashboardUrl.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { guildWebPlayerPageUrl, webDashboardPromoAppend } from "./webDashboardUrl.js"
+
+describe("guildWebPlayerPageUrl", () => {
+    it("returns null when BETTER_AUTH_URL is missing, invalid, or non-http", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            delete process.env.BETTER_AUTH_URL
+            assert.equal(guildWebPlayerPageUrl("123"), null)
+
+            process.env.BETTER_AUTH_URL = "   "
+            assert.equal(guildWebPlayerPageUrl("123"), null)
+
+            process.env.BETTER_AUTH_URL = "not a url"
+            assert.equal(guildWebPlayerPageUrl("123"), null)
+
+            process.env.BETTER_AUTH_URL = "ftp://dashboard.example.com"
+            assert.equal(guildWebPlayerPageUrl("123"), null)
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+
+    it("builds /dashboard/<guildId> from the public origin and encodes the id", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            process.env.BETTER_AUTH_URL = "https://dash.example.com/"
+            assert.equal(
+                guildWebPlayerPageUrl("987654321"),
+                "https://dash.example.com/dashboard/987654321"
+            )
+
+            process.env.BETTER_AUTH_URL = "http://localhost:3000///"
+            assert.equal(
+                guildWebPlayerPageUrl("guild/with spaces"),
+                "http://localhost:3000/dashboard/guild%2Fwith%20spaces"
+            )
+
+            // Path on BETTER_AUTH_URL is ignored; only origin is used.
+            process.env.BETTER_AUTH_URL = "https://dash.example.com/auth/callback"
+            assert.equal(
+                guildWebPlayerPageUrl("1"),
+                "https://dash.example.com/dashboard/1"
+            )
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+})
+
+describe("webDashboardPromoAppend", () => {
+    it("returns empty string without a resolvable dashboard URL", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            delete process.env.BETTER_AUTH_URL
+            assert.equal(webDashboardPromoAppend("1"), "")
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+
+    it("appends a markdown dashboard link when BETTER_AUTH_URL is set", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            process.env.BETTER_AUTH_URL = "https://dash.example.com"
+            const text = webDashboardPromoAppend("42")
+            assert.match(text, /^\n\n\*\*Web player:\*\*/)
+            assert.match(text, /\[dashboard\]\(https:\/\/dash\.example\.com\/dashboard\/42\)/)
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+})

--- a/src/util/webDashboardUrl.test.ts
+++ b/src/util/webDashboardUrl.test.ts
@@ -40,10 +40,7 @@ describe("guildWebPlayerPageUrl", () => {
 
             // Path on BETTER_AUTH_URL is ignored; only origin is used.
             process.env.BETTER_AUTH_URL = "https://dash.example.com/auth/callback"
-            assert.equal(
-                guildWebPlayerPageUrl("1"),
-                "https://dash.example.com/dashboard/1"
-            )
+            assert.equal(guildWebPlayerPageUrl("1"), "https://dash.example.com/dashboard/1")
         } finally {
             if (prev === undefined) delete process.env.BETTER_AUTH_URL
             else process.env.BETTER_AUTH_URL = prev

--- a/src/web/lib/admin-access.ts
+++ b/src/web/lib/admin-access.ts
@@ -22,20 +22,29 @@ export async function resolveAdminAccess(reqHeaders: Headers): Promise<AdminAcce
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)
         console.error("[admin-access] getSession failed:", message)
-        return decideAdminAccess({
+        const decision = decideAdminAccess({
             sessionLoadFailed: true,
             hasSessionUser: false,
             discordUserId: null,
             ownerId: null,
         })
+        if (decision.ok === false) return decision
+        return {
+            ok: false,
+            status: 503,
+            error: "Service Unavailable",
+            details: "Could not load your session. Please try again later.",
+        }
     }
 
     if (!session?.user?.id) {
-        return decideAdminAccess({
+        const decision = decideAdminAccess({
             hasSessionUser: false,
             discordUserId: null,
             ownerId: getCachedOwnerId(),
         })
+        if (decision.ok === false) return decision
+        return { ok: false, status: 401, error: "Unauthorized" }
     }
 
     let discordUserId: string | null

--- a/src/web/lib/admin-access.ts
+++ b/src/web/lib/admin-access.ts
@@ -2,6 +2,7 @@ import { headers } from "next/headers"
 import { NextResponse } from "next/server"
 import { auth } from "@/auth"
 import type { AuthenticatedSession } from "@/lib/api-auth"
+import { decideAdminAccess } from "../../shared/admin-access-decision.js"
 import { resolveDiscordUserSnowflake } from "../../shared/discord-user-id.js"
 import { getCachedOwnerId } from "../../shared/permissions.js"
 
@@ -21,52 +22,43 @@ export async function resolveAdminAccess(reqHeaders: Headers): Promise<AdminAcce
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)
         console.error("[admin-access] getSession failed:", message)
-        return {
-            ok: false,
-            status: 503,
-            error: "Service Unavailable",
-            details: "Could not load your session. Please try again later.",
-        }
+        return decideAdminAccess({
+            sessionLoadFailed: true,
+            hasSessionUser: false,
+            discordUserId: null,
+            ownerId: null,
+        })
     }
 
     if (!session?.user?.id) {
-        return { ok: false, status: 401, error: "Unauthorized" }
+        return decideAdminAccess({
+            hasSessionUser: false,
+            discordUserId: null,
+            ownerId: getCachedOwnerId(),
+        })
     }
 
     let discordUserId: string | null
+    let discordResolveFailed = false
     try {
         discordUserId = await resolveDiscordUserSnowflake(session.user.id, reqHeaders)
     } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
         console.error("[admin-access] resolveDiscordUserSnowflake failed:", msg)
-        return {
-            ok: false,
-            status: 403,
-            error: "Discord account required",
-            details: "Sign in with Discord, or sign out and sign in again.",
-        }
-    }
-    if (!discordUserId) {
-        return {
-            ok: false,
-            status: 403,
-            error: "Discord account required",
-            details:
-                "We could not resolve your Discord user id. Sign in with Discord, or sign out and sign in again.",
-        }
+        discordUserId = null
+        discordResolveFailed = true
     }
 
-    const ownerId = getCachedOwnerId()
-    if (!ownerId || discordUserId !== ownerId) {
-        return {
-            ok: false,
-            status: 403,
-            error: "Forbidden",
-            details: "Developer access required.",
-        }
+    const decision = decideAdminAccess({
+        hasSessionUser: true,
+        discordResolveFailed,
+        discordUserId,
+        ownerId: getCachedOwnerId(),
+    })
+    if (decision.ok === false) {
+        return decision
     }
-
-    return { ok: true, session, discordUserId }
+    return { ok: true, session, discordUserId: decision.discordUserId }
 }
 
 /** True when the current session is the bot owner (`OWNER_ID`). */

--- a/src/web/lib/dashboard-permissions.ts
+++ b/src/web/lib/dashboard-permissions.ts
@@ -1,43 +1,12 @@
 import type { GuildDashboardPermissionSnapshot } from "@/types/web"
 import type { WebPermissionKey } from "@/lib/web-permission-keys"
 import { webPlayerTrace } from "@/lib/web-player-debug-log"
-
-type WebPermissionDecision =
-    | { allowed: true; reason: string; memberResolved: boolean }
-    | { allowed: false; reason: string; memberResolved: boolean }
-
-/** Shared primary vs OAuth-fallback rules for dashboard gating (matches {@link requirePermissions}). */
-function resolveWebPermissionDecision(
-    snapshot: GuildDashboardPermissionSnapshot,
-    perm: WebPermissionKey
-): WebPermissionDecision {
-    if (snapshot.primaryPermissions.includes(perm)) {
-        return {
-            allowed: true,
-            reason: "allow:primaryPermissions",
-            memberResolved: snapshot.memberResolved,
-        }
-    }
-    if (!snapshot.memberResolved && snapshot.oauthPermissions.includes(perm)) {
-        return {
-            allowed: true,
-            reason: "allow:oauthPermissions (member not resolved by bot)",
-            memberResolved: snapshot.memberResolved,
-        }
-    }
-    if (snapshot.memberResolved) {
-        return {
-            allowed: false,
-            reason: `deny:memberResolved=true but primaryPermissions lacks "${perm}" (OAuth fallback is not used when the bot resolved a member)`,
-            memberResolved: true,
-        }
-    }
-    return {
-        allowed: false,
-        reason: `deny:neither primary nor oauth lists include "${perm}"`,
-        memberResolved: false,
-    }
-}
+import {
+    dashboardHasAllWebPermissions as sharedDashboardHasAllWebPermissions,
+    dashboardHasWebPermission as sharedDashboardHasWebPermission,
+    explainDashboardWebPermission as sharedExplainDashboardWebPermission,
+    resolveWebPermissionDecision,
+} from "@/shared/dashboard-web-permission"
 
 /**
  * Human-readable reason for {@link dashboardHasWebPermission} (for troubleshooting).
@@ -46,7 +15,7 @@ export function explainDashboardWebPermission(
     snapshot: GuildDashboardPermissionSnapshot,
     perm: WebPermissionKey
 ): string {
-    return resolveWebPermissionDecision(snapshot, perm).reason
+    return sharedExplainDashboardWebPermission(snapshot, perm)
 }
 
 /**
@@ -76,21 +45,15 @@ export function dashboardHasAllWebPermissions(
     snapshot: GuildDashboardPermissionSnapshot,
     perms: WebPermissionKey[]
 ): boolean {
-    const denied: WebPermissionKey[] = []
-    for (const perm of perms) {
-        const decision = resolveWebPermissionDecision(snapshot, perm)
-        if (!decision.allowed) {
-            denied.push(perm)
-        }
-    }
-    if (denied.length > 0) {
+    const allowed = sharedDashboardHasAllWebPermissions(snapshot, perms)
+    if (!allowed) {
+        const denied = perms.filter((perm) => !sharedDashboardHasWebPermission(snapshot, perm))
         webPlayerTrace("dashboardHasAllWebPermissions: denied", {
             denied,
             memberResolved: snapshot.memberResolved,
             primary: snapshot.primaryPermissions,
             oauth: snapshot.oauthPermissions,
         })
-        return false
     }
-    return true
+    return allowed
 }


### PR DESCRIPTION
## Summary

- Consolidates open Cursor bot/automation PRs into one review branch for CodeRabbit and human review
- Integration branch: `chore/consolidated-cursor-fixes-jul-2026-wave2` from current `main`
- Source PRs closed as superseded on create (skill override of close-after-merge)

## Supersedes

- #152 — test: cover bot API origin, dashboard URLs, and countdown embeds (https://github.com/bpeters132/DimbyBot2/pull/152)
- #153 — fix: reservation-aware trackError and alone-in-VC destroy (https://github.com/bpeters132/DimbyBot2/pull/153)
- #154 — test: cover requester id spoofing and dashboard permission merges (https://github.com/bpeters132/DimbyBot2/pull/154)
- #155 — fix: reserve guild player before create and Discord play (https://github.com/bpeters132/DimbyBot2/pull/155)
- #156 — fix: block /play hijack of local playback from another voice channel (https://github.com/bpeters132/DimbyBot2/pull/156)
- #157 — test: cover error history, API headers, origin fallback, and autoplay queries (https://github.com/bpeters132/DimbyBot2/pull/157)
- #158 — fix: preserve player session if local play join fails (https://github.com/bpeters132/DimbyBot2/pull/158)
- #159 — test: cover guild settings merge, download limits, admin gate, Lucene escape (https://github.com/bpeters132/DimbyBot2/pull/159)
- #160 — fix: flush full queue before local-play stopPlaying clears it (https://github.com/bpeters132/DimbyBot2/pull/160)

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` (126 pass)
- [ ] `npm run audit:check-imports` — skipped (not in this repo)
- [ ] Spot-check Cursor player/session/voice-channel fixes in the diff
- [ ] Confirm local-play handoff still preserves queue on failed VC join

## Version

- Current: `0.2.0`
- Recommended: `0.2.1` (`patch`) — correctness fixes for player lifecycle, voice-channel gates, and local-play session handoff; plus regression tests
- Bump not committed unless requested

## Notes

- Cherry-picked oldest-first; conflicts resolved on the integration branch:
  - #156 vs #155: kept lifecycle reservations; added occupied-voice checks before `createPlayer`
  - #160 vs #158: took flush-before-stopPlaying handoff (queue preserved across failed local join)
- Follow-up commit: narrowed `decideAdminAccess` returns for web typecheck + Prettier on conflicted paths
- Do not merge source PRs individually; this PR is the single review unit