### PR TITLE
chore: consolidate Cursor fixes Jul 2026 (waves 1+2)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,6 @@ language: "en-US"
 early_access: false
 
 reviews:
-    profile: "assertive"
     request_changes_workflow: false
     high_level_summary: false
     poem: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,9 @@ The current layout is intentional and supported: exclusion in `tsconfig.json` pl
 
 ## Testing Guidelines
 
-- No test framework is configured in `package.json`.
-- If you add tests, keep them near `src/` and document how to run them.
+- Unit tests use Node’s built-in test runner via `tsx`: `yarn test` runs `src/**/*.test.ts` next to the code under test.
+- Prefer keeping new suites under `src/` (e.g. `src/util/*.test.ts`, `src/shared/*.test.ts`).
+- Suggested manual checks: `yarn lint`, `yarn typecheck`, and `yarn test`.
 
 ## Commit & Pull Request Guidelines
 

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -16,7 +16,10 @@ import {
     restoreUpcomingQueue,
     snapshotUpcomingQueue,
 } from "../../util/playlistQueue.js"
-import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
+import {
+    acquireGuildPlayerLifecycleReservation,
+    tryDestroyOrphanGuildPlayer,
+} from "../../util/guildPlayerQueueLock.js"
 import { acquirePlayerSessionClearSuppressLease } from "../../util/playerSessionPersistence.js"
 
 export async function playerPlaylistPlayPOST(
@@ -138,77 +141,87 @@ export async function playerPlaylistPlayPOST(
         }
 
         const player = voiceSetup.player
-        const { resolved, failed } = await resolveStoredPlaylistTracks(
-            player,
-            playlist.tracks,
-            requesterPayload
-        )
+        // Cover resolve → enqueue/cleanup so queueEnd idle destroy and concurrent orphan
+        // teardown cannot kill the player while playlist tracks are still resolving.
+        const lifecycleReservation = await acquireGuildPlayerLifecycleReservation(guildId)
+        try {
+            const { resolved, failed } = await resolveStoredPlaylistTracks(
+                player,
+                playlist.tracks,
+                requesterPayload
+            )
 
-        if (resolved.length === 0) {
-            // Serialize emptiness check + destroy with enqueue so a concurrent queue add cannot
-            // land between the check and teardown.
-            await withGuildPlayerQueueLock(guildId, async () => {
-                if (playerHasQueueContent(player)) return
-                const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
-                await client.lavalink.destroyPlayer(guildId).catch(() => {
-                    // Release only this attempt's lease; clearPlayerSession consumes on success.
-                    suppressLease.release()
+            if (resolved.length === 0) {
+                await tryDestroyOrphanGuildPlayer(guildId, {
+                    hasQueueContent: () => {
+                        const live = client.lavalink.getPlayer(guildId) ?? player
+                        return playerHasQueueContent(live)
+                    },
+                    destroyPlayer: async () => {
+                        const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
+                        await client.lavalink.destroyPlayer(guildId).catch(() => {
+                            // Release only this attempt's lease; clearPlayerSession consumes on success.
+                            suppressLease.release()
+                        })
+                    },
                 })
-            })
+                return {
+                    status: 404,
+                    body: {
+                        ok: false,
+                        error: {
+                            error: "No matches found.",
+                            details: "Could not resolve any tracks from this playlist.",
+                        },
+                    },
+                }
+            }
+
+            const savedUpcoming = snapshotUpcomingQueue(player)
+            let enqueue: EnqueuePlaylistResult
+            try {
+                await clearUpcomingQueue(player)
+                enqueue = await enqueueResolvedPlaylistTracks(
+                    player,
+                    resolved,
+                    requester.requesterId,
+                    shuffle
+                )
+            } catch (enqueueErr: unknown) {
+                try {
+                    await restoreUpcomingQueue(player, savedUpcoming)
+                } catch (restoreErr: unknown) {
+                    const restoreMessage =
+                        restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
+                    console.error(
+                        "[playerPlaylistPlayPOST] failed to restore queue after enqueue error",
+                        {
+                            guildId,
+                            restoreMessage,
+                        }
+                    )
+                }
+                throw enqueueErr
+            }
+
+            const state = await toPlayerStateResponse(guildId, requester.requesterId, player)
+
             return {
-                status: 404,
+                status: 200,
                 body: {
-                    ok: false,
-                    error: {
-                        error: "No matches found.",
-                        details: "Could not resolve any tracks from this playlist.",
+                    ok: true,
+                    data: {
+                        state,
+                        playlistId: playlist.id,
+                        playlistName: playlist.name,
+                        queued: enqueue.queued,
+                        failed,
+                        shuffle,
                     },
                 },
             }
-        }
-
-        const savedUpcoming = snapshotUpcomingQueue(player)
-        let enqueue: EnqueuePlaylistResult
-        try {
-            await clearUpcomingQueue(player)
-            enqueue = await enqueueResolvedPlaylistTracks(
-                player,
-                resolved,
-                requester.requesterId,
-                shuffle
-            )
-        } catch (enqueueErr: unknown) {
-            try {
-                await restoreUpcomingQueue(player, savedUpcoming)
-            } catch (restoreErr: unknown) {
-                const restoreMessage =
-                    restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
-                console.error(
-                    "[playerPlaylistPlayPOST] failed to restore queue after enqueue error",
-                    {
-                        guildId,
-                        restoreMessage,
-                    }
-                )
-            }
-            throw enqueueErr
-        }
-
-        const state = await toPlayerStateResponse(guildId, requester.requesterId, player)
-
-        return {
-            status: 200,
-            body: {
-                ok: true,
-                data: {
-                    state,
-                    playlistId: playlist.id,
-                    playlistName: playlist.name,
-                    queued: enqueue.queued,
-                    failed,
-                    shuffle,
-                },
-            },
+        } finally {
+            lifecycleReservation.release()
         }
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -17,7 +17,7 @@ import {
     acquireGuildPlayerLifecycleReservation,
     tryDestroyOrphanGuildPlayer,
 } from "../../util/guildPlayerQueueLock.js"
-import { acquirePlayerSessionClearSuppressLease } from "../../util/playerSessionPersistence.js"
+import { destroyPlayerSuppressingSessionClear } from "../../util/playerSessionPersistence.js"
 
 export async function playerPlaylistPlayPOST(
     headers: Headers,
@@ -155,11 +155,9 @@ export async function playerPlaylistPlayPOST(
                         return playerHasQueueContent(live)
                     },
                     destroyPlayer: async () => {
-                        const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
-                        await client.lavalink.destroyPlayer(guildId).catch(() => {
-                            // Release only this attempt's lease; clearPlayerSession consumes on success.
-                            suppressLease.release()
-                        })
+                        await destroyPlayerSuppressingSessionClear(guildId, () =>
+                            client.lavalink.destroyPlayer(guildId)
+                        )
                     },
                 })
                 return {

--- a/src/botApi/handlers/playlistPlay.ts
+++ b/src/botApi/handlers/playlistPlay.ts
@@ -8,13 +8,10 @@ import { toPlayerStateResponse } from "../../shared/player-state.js"
 import { getPlaylistById } from "../../repositories/playlistRepository.js"
 import { searchAndEnqueue } from "./searchAndEnqueue.js"
 import {
-    clearUpcomingQueue,
-    enqueueResolvedPlaylistTracks,
     type EnqueuePlaylistResult,
     playerHasQueueContent,
+    replaceUpcomingWithResolvedPlaylistTracks,
     resolveStoredPlaylistTracks,
-    restoreUpcomingQueue,
-    snapshotUpcomingQueue,
 } from "../../util/playlistQueue.js"
 import {
     acquireGuildPlayerLifecycleReservation,
@@ -177,32 +174,14 @@ export async function playerPlaylistPlayPOST(
                 }
             }
 
-            const savedUpcoming = snapshotUpcomingQueue(player)
-            let enqueue: EnqueuePlaylistResult
-            try {
-                await clearUpcomingQueue(player)
-                enqueue = await enqueueResolvedPlaylistTracks(
-                    player,
-                    resolved,
-                    requester.requesterId,
-                    shuffle
-                )
-            } catch (enqueueErr: unknown) {
-                try {
-                    await restoreUpcomingQueue(player, savedUpcoming)
-                } catch (restoreErr: unknown) {
-                    const restoreMessage =
-                        restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
-                    console.error(
-                        "[playerPlaylistPlayPOST] failed to restore queue after enqueue error",
-                        {
-                            guildId,
-                            restoreMessage,
-                        }
-                    )
-                }
-                throw enqueueErr
-            }
+            // Clear + enqueue must share one guild lock so a concurrent queue POST cannot
+            // succeed then be wiped by clearUpcoming between unlocked clear and locked add.
+            const enqueue: EnqueuePlaylistResult = await replaceUpcomingWithResolvedPlaylistTracks(
+                player,
+                resolved,
+                requester.requesterId,
+                shuffle
+            )
 
             const state = await toPlayerStateResponse(guildId, requester.requesterId, player)
 

--- a/src/botApi/handlers/queue.ts
+++ b/src/botApi/handlers/queue.ts
@@ -8,6 +8,7 @@ import { toQueueResponse } from "../../shared/player-state.js"
 import { playerBroadcaster } from "../../shared/websocket/PlayerBroadcaster.js"
 import { searchAndEnqueue } from "./searchAndEnqueue.js"
 import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
 
 const MAX_QUEUE_PAGE_LIMIT = 100
 
@@ -124,8 +125,15 @@ export async function queueDELETE(
     const player = getBotClient().lavalink.getPlayer(guildId)
     try {
         if (player) {
-            await player.queue.splice(0, player.queue.tracks.length)
-            schedulePlayerSessionSave(player)
+            // Serialize with searchAndEnqueue / playlist replace / reorder so clear cannot
+            // interleave with a remove+insert reorder (resurrecting a cleared track).
+            await withGuildPlayerQueueLock(guildId, async () => {
+                const size = player.queue.tracks.length
+                if (size > 0) {
+                    await player.queue.splice(0, size)
+                }
+                schedulePlayerSessionSave(player)
+            })
             playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
         }
         return {

--- a/src/botApi/handlers/queueIndex.ts
+++ b/src/botApi/handlers/queueIndex.ts
@@ -6,6 +6,7 @@ import { getBotClient, tryGetBotClient } from "../../lib/botClientRegistry.js"
 import { toQueueResponse } from "../../shared/player-state.js"
 import { playerBroadcaster } from "../../shared/websocket/PlayerBroadcaster.js"
 import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
 
 function parseIndex(value: string): number | null {
     const index = Number(value)
@@ -41,15 +42,28 @@ export async function queueIndexDELETE(
         }
 
         const player = getBotClient().lavalink.getPlayer(guildId)
-        if (!player || queueIndex >= player.queue.tracks.length) {
+        if (!player) {
+            return {
+                status: 404,
+                body: { ok: false, error: { error: "No active player for this guild." } },
+            }
+        }
+
+        const removeResult = await withGuildPlayerQueueLock(guildId, async () => {
+            if (queueIndex >= player.queue.tracks.length) {
+                return { ok: false as const }
+            }
+            await player.queue.splice(queueIndex, 1)
+            schedulePlayerSessionSave(player)
+            return { ok: true as const }
+        })
+        if (!removeResult.ok) {
             return {
                 status: 404,
                 body: { ok: false, error: { error: "Queue index out of range." } },
             }
         }
 
-        await player.queue.splice(queueIndex, 1)
-        schedulePlayerSessionSave(player)
         playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
         return {
             status: 200,
@@ -118,53 +132,64 @@ export async function queueIndexPATCH(
             }
         }
 
-        const trackCount = player.queue.tracks.length
-        if (sourceIndex >= trackCount || destinationIndex >= trackCount) {
+        const reorderResult = await withGuildPlayerQueueLock(guildId, async () => {
+            const trackCount = player.queue.tracks.length
+            if (sourceIndex >= trackCount || destinationIndex >= trackCount) {
+                return { ok: false as const, error: "Queue index out of range." }
+            }
+
+            const [track] = await player.queue.splice(sourceIndex, 1)
+            if (!track) {
+                return { ok: false as const, error: "Queue index out of range." }
+            }
+            const insertIndexRaw = destinationIndex
+            const lenAfterRemove = player.queue.tracks.length
+            const insertIndex = Math.min(Math.max(insertIndexRaw, 0), lenAfterRemove)
+            try {
+                await player.queue.splice(insertIndex, 0, track)
+            } catch (insertErr: unknown) {
+                try {
+                    await player.queue.splice(sourceIndex, 0, track)
+                } catch (restoreErr: unknown) {
+                    const restoreMessage =
+                        restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
+                    const client = tryGetBotClient()
+                    if (client) {
+                        client.error(
+                            "[queueIndexPATCH] failed to restore track after reorder error",
+                            {
+                                guildId,
+                                sourceIndex,
+                                restoreMessage,
+                                insertErr,
+                            }
+                        )
+                    } else {
+                        console.error(
+                            "[queueIndexPATCH] failed to restore track after reorder error",
+                            {
+                                guildId,
+                                sourceIndex,
+                                restoreMessage,
+                                insertErr,
+                            }
+                        )
+                    }
+                }
+                throw insertErr
+            }
+            schedulePlayerSessionSave(player)
+            return { ok: true as const }
+        })
+
+        if (!reorderResult.ok) {
             return {
                 status: 404,
-                body: { ok: false, error: { error: "Queue index out of range." } },
+                body: { ok: false, error: { error: reorderResult.error } },
             }
         }
 
-        const [track] = await player.queue.splice(sourceIndex, 1)
-        if (!track) {
-            return {
-                status: 404,
-                body: { ok: false, error: { error: "Queue index out of range." } },
-            }
-        }
-        const insertIndexRaw = destinationIndex
-        const lenAfterRemove = player.queue.tracks.length
-        const insertIndex = Math.min(Math.max(insertIndexRaw, 0), lenAfterRemove)
-        try {
-            await player.queue.splice(insertIndex, 0, track)
-        } catch (insertErr: unknown) {
-            try {
-                await player.queue.splice(sourceIndex, 0, track)
-            } catch (restoreErr: unknown) {
-                const restoreMessage =
-                    restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
-                const client = tryGetBotClient()
-                if (client) {
-                    client.error("[queueIndexPATCH] failed to restore track after reorder error", {
-                        guildId,
-                        sourceIndex,
-                        restoreMessage,
-                        insertErr,
-                    })
-                } else {
-                    console.error("[queueIndexPATCH] failed to restore track after reorder error", {
-                        guildId,
-                        sourceIndex,
-                        restoreMessage,
-                        insertErr,
-                    })
-                }
-            }
-            throw insertErr
-        }
         playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
-        schedulePlayerSessionSave(player)
 
         return {
             status: 200,

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -7,7 +7,7 @@ import { stampRequesterUserIdOnTracks } from "../../util/rrqDisconnect.js"
 import type { PermissionGuardSuccess } from "../../shared/api-auth.js"
 import { resolveWebDashboardTextChannelId } from "../webDashboardTextChannel.js"
 import {
-    acquirePlayerSessionClearSuppressLease,
+    destroyPlayerSuppressingSessionClear,
     schedulePlayerSessionSave,
 } from "../../util/playerSessionPersistence.js"
 import {
@@ -167,11 +167,9 @@ export async function searchAndEnqueue(
                     return playerHasQueueContent(live)
                 },
                 destroyPlayer: async () => {
-                    const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
-                    await client.lavalink.destroyPlayer(guildId).catch(() => {
-                        // Release only this attempt's lease; clearPlayerSession consumes on success.
-                        suppressLease.release()
-                    })
+                    await destroyPlayerSuppressingSessionClear(guildId, () =>
+                        client.lavalink.destroyPlayer(guildId)
+                    )
                 },
             })
         }

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -16,6 +16,10 @@ import {
     withGuildPlayerQueueLock,
 } from "../../util/guildPlayerQueueLock.js"
 import { playerHasQueueContent } from "../../util/playlistQueue.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 
 export type SearchAndEnqueueGuard = Pick<PermissionGuardSuccess, "session">
 
@@ -125,6 +129,19 @@ export async function searchAndEnqueue(
             ok: false,
             status: 403,
             error: { error: "Bot lacks permission to join this voice channel." },
+        }
+    }
+
+    // Refuse takeover while bot occupies another VC (incl. local playback with no Lavalink player).
+    {
+        const existingPlayer = client.lavalink.getPlayer(guildId)
+        const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+        if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+            return {
+                ok: false,
+                status: 403,
+                error: { error: "You need to be in the same voice channel as the bot." },
+            }
         }
     }
 

--- a/src/botApi/handlers/searchAndEnqueue.ts
+++ b/src/botApi/handlers/searchAndEnqueue.ts
@@ -128,32 +128,37 @@ export async function searchAndEnqueue(
         }
     }
 
-    let player = client.lavalink.getPlayer(guildId)
-    let createdHere = false
-    if (!player) {
-        try {
-            player = await client.lavalink.createPlayer({
-                guildId,
-                voiceChannelId: voiceChannel.id,
-                textChannelId,
-                selfDeaf: true,
-                volume: 100,
-            })
-            createdHere = true
-        } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err)
-            console.error("[searchAndEnqueue] createPlayer failed", { guildId, requesterId, err })
-            return {
-                ok: false,
-                status: 503,
-                error: { error: "Could not create the player.", details: message },
-            }
-        }
-    }
-
-    // Cover acquisition → search/enqueue so concurrent orphan cleanup cannot destroy mid-use.
+    // Reserve before createPlayer so concurrent orphan/idle destroy cannot tear down a
+    // freshly created player in the window between create and the old post-create acquire.
     const lifecycleReservation = await acquireGuildPlayerLifecycleReservation(guildId)
     try {
+        let player = client.lavalink.getPlayer(guildId)
+        let createdHere = false
+        if (!player) {
+            try {
+                player = await client.lavalink.createPlayer({
+                    guildId,
+                    voiceChannelId: voiceChannel.id,
+                    textChannelId,
+                    selfDeaf: true,
+                    volume: 100,
+                })
+                createdHere = true
+            } catch (err: unknown) {
+                const message = err instanceof Error ? err.message : String(err)
+                console.error("[searchAndEnqueue] createPlayer failed", {
+                    guildId,
+                    requesterId,
+                    err,
+                })
+                return {
+                    ok: false,
+                    status: 503,
+                    error: { error: "Could not create the player.", details: message },
+                }
+            }
+        }
+
         if (textChannelId) {
             player.textChannelId = textChannelId
         }

--- a/src/botApi/httpUtil.test.ts
+++ b/src/botApi/httpUtil.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict"
+import type { IncomingMessage } from "http"
+import { describe, it } from "node:test"
+import { incomingMessageToHeaders } from "./httpUtil.js"
+
+function fakeReq(headers: IncomingMessage["headers"]): IncomingMessage {
+    return { headers } as IncomingMessage
+}
+
+describe("incomingMessageToHeaders", () => {
+    it("copies string header values with set()", () => {
+        const headers = incomingMessageToHeaders(
+            fakeReq({
+                cookie: "session=abc",
+                "content-type": "application/json",
+            })
+        )
+        assert.equal(headers.get("cookie"), "session=abc")
+        assert.equal(headers.get("content-type"), "application/json")
+    })
+
+    it("appends each value when Node supplies a string array", () => {
+        const headers = incomingMessageToHeaders(
+            fakeReq({
+                "set-cookie": ["a=1", "b=2"],
+                "x-forwarded-for": ["1.1.1.1", "2.2.2.2"],
+            })
+        )
+        assert.deepEqual(headers.getSetCookie(), ["a=1", "b=2"])
+        assert.equal(headers.get("x-forwarded-for"), "1.1.1.1, 2.2.2.2")
+    })
+
+    it("skips undefined header values without throwing", () => {
+        const headers = incomingMessageToHeaders(
+            fakeReq({
+                authorization: "Bearer tok",
+                "x-missing": undefined,
+            })
+        )
+        assert.equal(headers.get("authorization"), "Bearer tok")
+        assert.equal(headers.has("x-missing"), false)
+    })
+})

--- a/src/botApi/resolveWebRequesterId.test.ts
+++ b/src/botApi/resolveWebRequesterId.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { resolveWebRequesterDiscordId } from "./resolveWebRequesterId.js"
+
+const SESSION_ID = "123456789012345678"
+
+describe("resolveWebRequesterDiscordId", () => {
+    it("defaults to the authenticated Discord snowflake when body omits requester id", () => {
+        assert.deepEqual(resolveWebRequesterDiscordId({}, SESSION_ID), {
+            ok: true,
+            requesterId: SESSION_ID,
+        })
+        assert.deepEqual(resolveWebRequesterDiscordId(null, SESSION_ID), {
+            ok: true,
+            requesterId: SESSION_ID,
+        })
+        assert.deepEqual(resolveWebRequesterDiscordId("not-an-object", SESSION_ID), {
+            ok: true,
+            requesterId: SESSION_ID,
+        })
+    })
+
+    it("accepts a matching requesterDiscordUserId (trimmed)", () => {
+        assert.deepEqual(
+            resolveWebRequesterDiscordId(
+                { requesterDiscordUserId: `  ${SESSION_ID}  ` },
+                SESSION_ID
+            ),
+            { ok: true, requesterId: SESSION_ID }
+        )
+    })
+
+    it("rejects empty or non-string requesterDiscordUserId when provided", () => {
+        assert.deepEqual(
+            resolveWebRequesterDiscordId({ requesterDiscordUserId: "" }, SESSION_ID),
+            {
+                ok: false,
+                status: 400,
+                error: "Invalid requesterDiscordUserId.",
+                details: "Must be a non-empty string when provided.",
+            }
+        )
+        assert.deepEqual(
+            resolveWebRequesterDiscordId({ requesterDiscordUserId: "   " }, SESSION_ID),
+            {
+                ok: false,
+                status: 400,
+                error: "Invalid requesterDiscordUserId.",
+                details: "Must be a non-empty string when provided.",
+            }
+        )
+        assert.deepEqual(
+            resolveWebRequesterDiscordId({ requesterDiscordUserId: 42 }, SESSION_ID),
+            {
+                ok: false,
+                status: 400,
+                error: "Invalid requesterDiscordUserId.",
+                details: "Must be a non-empty string when provided.",
+            }
+        )
+    })
+
+    it("rejects a requesterDiscordUserId that does not match the signed-in account", () => {
+        assert.deepEqual(
+            resolveWebRequesterDiscordId(
+                { requesterDiscordUserId: "999999999999999999" },
+                SESSION_ID
+            ),
+            {
+                ok: false,
+                status: 403,
+                error: "Forbidden",
+                details: "requesterDiscordUserId does not match the signed-in account.",
+            }
+        )
+    })
+})

--- a/src/botApi/resolveWebRequesterId.test.ts
+++ b/src/botApi/resolveWebRequesterId.test.ts
@@ -31,15 +31,12 @@ describe("resolveWebRequesterDiscordId", () => {
     })
 
     it("rejects empty or non-string requesterDiscordUserId when provided", () => {
-        assert.deepEqual(
-            resolveWebRequesterDiscordId({ requesterDiscordUserId: "" }, SESSION_ID),
-            {
-                ok: false,
-                status: 400,
-                error: "Invalid requesterDiscordUserId.",
-                details: "Must be a non-empty string when provided.",
-            }
-        )
+        assert.deepEqual(resolveWebRequesterDiscordId({ requesterDiscordUserId: "" }, SESSION_ID), {
+            ok: false,
+            status: 400,
+            error: "Invalid requesterDiscordUserId.",
+            details: "Must be a non-empty string when provided.",
+        })
         assert.deepEqual(
             resolveWebRequesterDiscordId({ requesterDiscordUserId: "   " }, SESSION_ID),
             {
@@ -49,15 +46,12 @@ describe("resolveWebRequesterDiscordId", () => {
                 details: "Must be a non-empty string when provided.",
             }
         )
-        assert.deepEqual(
-            resolveWebRequesterDiscordId({ requesterDiscordUserId: 42 }, SESSION_ID),
-            {
-                ok: false,
-                status: 400,
-                error: "Invalid requesterDiscordUserId.",
-                details: "Must be a non-empty string when provided.",
-            }
-        )
+        assert.deepEqual(resolveWebRequesterDiscordId({ requesterDiscordUserId: 42 }, SESSION_ID), {
+            ok: false,
+            status: 400,
+            error: "Invalid requesterDiscordUserId.",
+            details: "Must be a non-empty string when provided.",
+        })
     })
 
     it("rejects a requesterDiscordUserId that does not match the signed-in account", () => {

--- a/src/commands/admin/Discord-Logs.ts
+++ b/src/commands/admin/Discord-Logs.ts
@@ -134,7 +134,9 @@ function formatConfig(cfg: GuildDiscordLogSettings): string {
 export default {
     data: new SlashCommandBuilder()
         .setName("discord-logs")
-        .setDescription("Configure Discord channels for bot log forwarding in this server.")
+        .setDescription(
+            "Configure Discord channels for guild-scoped bot log forwarding in this server."
+        )
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
         .setDMPermission(false)
         .addSubcommand((sub) =>

--- a/src/commands/admin/Discord-Logs.ts
+++ b/src/commands/admin/Discord-Logs.ts
@@ -82,10 +82,7 @@ function storeWithGuildRow(
 }
 
 /** Guild keys removed from the store map (explicit DB deletes — not inferred from stale snapshots). */
-function guildIdsRemovedFromStore(
-    before: GuildSettingsStore,
-    after: GuildSettingsStore
-): string[] {
+function guildIdsRemovedFromStore(before: GuildSettingsStore, after: GuildSettingsStore): string[] {
     return Object.keys(before).filter((id) => !(id in after))
 }
 

--- a/src/commands/developer/DownloadLimit.ts
+++ b/src/commands/developer/DownloadLimit.ts
@@ -3,9 +3,12 @@ import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import type { GuildSettingsStore } from "../../types/index.js"
 
+import {
+    DEFAULT_DOWNLOADS_MAX_MB,
+    isCustomDownloadsMaxMb,
+    resolveDownloadsMaxMb,
+} from "../../util/downloadsMaxMb.js"
 import { getGuildSettings, saveGuildSettings } from "../../util/saveControlChannel.js"
-
-const DEFAULT_MAX_DIR_SIZE_MB = 1000
 
 export default {
     data: new SlashCommandBuilder()
@@ -99,9 +102,8 @@ export default {
 
         if (subcommand === "show") {
             const configured = settings[targetGuildId].downloadsMaxMb
-            const parsed = Number(configured ?? Number.NaN)
-            const validCustom = Number.isFinite(parsed) && parsed >= 1
-            const limit = validCustom ? parsed : DEFAULT_MAX_DIR_SIZE_MB
+            const validCustom = isCustomDownloadsMaxMb(configured)
+            const limit = resolveDownloadsMaxMb(configured)
             const suffix = validCustom ? " (custom)" : " (default)"
             return interaction.reply({
                 content: `Download limit for guild ${targetGuildId}: ${limit}MB${suffix}.`,
@@ -148,7 +150,7 @@ export default {
                 }
             }
             return interaction.reply({
-                content: `Cleared custom download limit for guild ${targetGuildId}. Default is ${DEFAULT_MAX_DIR_SIZE_MB}MB.`,
+                content: `Cleared custom download limit for guild ${targetGuildId}. Default is ${DEFAULT_DOWNLOADS_MAX_MB}MB.`,
                 flags: [MessageFlags.Ephemeral],
             })
         }

--- a/src/commands/music/ClearQueue.ts
+++ b/src/commands/music/ClearQueue.ts
@@ -2,6 +2,8 @@ import { SlashCommandBuilder } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
+import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -80,14 +82,25 @@ export default {
         }
 
         try {
-            const queueSize = player.queue.tracks.length
-            client.debug(
-                `[ClearQueue] Clearing queue for guild ${guild.id}. Current size: ${queueSize}`
-            )
+            const cleared = await withGuildPlayerQueueLock(guild.id, async () => {
+                const queueSize = player.queue.tracks.length
+                if (queueSize === 0) return 0
+                client.debug(
+                    `[ClearQueue] Clearing queue for guild ${guild.id}. Current size: ${queueSize}`
+                )
+                await player.queue.splice(0, queueSize)
+                schedulePlayerSessionSave(player)
+                return queueSize
+            })
 
-            await player.queue.splice(0, queueSize)
+            if (cleared === 0) {
+                return interaction.reply({
+                    content: "The queue is already empty.",
+                    ephemeral: true,
+                })
+            }
 
-            await interaction.reply({ content: `Cleared ${queueSize} tracks from the queue.` })
+            await interaction.reply({ content: `Cleared ${cleared} tracks from the queue.` })
             client.debug(`[ClearQueue] Successfully cleared queue for guild ${guild.id}`)
         } catch (error) {
             client.error("[ClearQueue] Error clearing the queue:", error)

--- a/src/commands/music/Genre.ts
+++ b/src/commands/music/Genre.ts
@@ -3,6 +3,7 @@ import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction, GuildMember } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
 
+import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 import { seedAutoplayHistoryFromPlayer } from "../../util/autoplayHistory.js"
 
@@ -52,33 +53,6 @@ export default {
 
         const voiceChannel = member.voice.channel
 
-        let player = client.lavalink.getPlayer(guild.id)
-
-        if (!player) {
-            try {
-                player = await client.lavalink.createPlayer({
-                    guildId: guild.id,
-                    voiceChannelId: voiceChannel.id,
-                    textChannelId: interaction.channelId,
-                    selfDeaf: true,
-                    volume: 100,
-                })
-            } catch (err) {
-                client.error("[GenreCmd] createPlayer failed:", err)
-                return interaction.editReply({
-                    content: "Could not join voice right now. Try again in a moment.",
-                    ...noMentions,
-                })
-            }
-        }
-
-        if (player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
-            return interaction.editReply({
-                content: "You need to be in the same voice channel as the bot!",
-                ...noMentions,
-            })
-        }
-
         const textChannel = interaction.channel
         if (!textChannel?.isTextBased() || textChannel.isDMBased()) {
             return interaction.editReply({
@@ -87,16 +61,56 @@ export default {
             })
         }
 
-        const result = await handleQueryAndPlay(
-            client,
-            guild.id,
-            voiceChannel,
-            textChannel,
-            genreName,
-            interaction.user,
-            player
-        )
+        const playOutcome = await withGuildPlayerLifecycleReservation(guild.id, async () => {
+            let player = client.lavalink.getPlayer(guild.id)
 
+            if (!player) {
+                try {
+                    player = await client.lavalink.createPlayer({
+                        guildId: guild.id,
+                        voiceChannelId: voiceChannel.id,
+                        textChannelId: interaction.channelId,
+                        selfDeaf: true,
+                        volume: 100,
+                    })
+                } catch (err) {
+                    client.error("[GenreCmd] createPlayer failed:", err)
+                    return {
+                        kind: "create_failed" as const,
+                    }
+                }
+            }
+
+            if (player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
+                return { kind: "wrong_channel" as const }
+            }
+
+            const result = await handleQueryAndPlay(
+                client,
+                guild.id,
+                voiceChannel,
+                textChannel,
+                genreName,
+                interaction.user,
+                player
+            )
+            return { kind: "played" as const, player, result }
+        })
+
+        if (playOutcome.kind === "create_failed") {
+            return interaction.editReply({
+                content: "Could not join voice right now. Try again in a moment.",
+                ...noMentions,
+            })
+        }
+        if (playOutcome.kind === "wrong_channel") {
+            return interaction.editReply({
+                content: "You need to be in the same voice channel as the bot!",
+                ...noMentions,
+            })
+        }
+
+        const { player, result } = playOutcome
         if (result.success) {
             player.set("autoplay", true)
             seedAutoplayHistoryFromPlayer(player)

--- a/src/commands/music/Genre.ts
+++ b/src/commands/music/Genre.ts
@@ -6,6 +6,10 @@ import { guildMemberFromInteraction } from "../../util/guildMember.js"
 import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 import { seedAutoplayHistoryFromPlayer } from "../../util/autoplayHistory.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -52,6 +56,17 @@ export default {
         }
 
         const voiceChannel = member.voice.channel
+
+        {
+            const existingPlayer = client.lavalink.getPlayer(guild.id)
+            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+            if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                return interaction.editReply({
+                    content: "You need to be in the same voice channel as the bot!",
+                    ...noMentions,
+                })
+            }
+        }
 
         const textChannel = interaction.channel
         if (!textChannel?.isTextBased() || textChannel.isDMBased()) {

--- a/src/commands/music/Leave.ts
+++ b/src/commands/music/Leave.ts
@@ -2,6 +2,7 @@ import { SlashCommandBuilder, type Message } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import { memberMayControlPlayerVoice } from "../../util/sameVoiceChannel.js"
 
 const DELETE_REPLY_DELAY_MS = 1000 * 10
 const DELETE_REPLY_RETRY_MS = 2000
@@ -43,13 +44,13 @@ export default {
         const voiceChannel = member.voice.channel
         if (!voiceChannel) {
             client.debug("Leave command failed: User not in a voice channel")
-            return interaction.reply({ content: "Join a voice channel first!" })
+            return interaction.reply({
+                content: "Join a voice channel first!",
+                ephemeral: true,
+            })
         }
 
         client.debug(`User ${interaction.user.tag} is in voice channel ${voiceChannel.id}`)
-
-        await interaction.deferReply()
-        client.debug("Leave command deferred reply")
 
         const player = client.lavalink.players.get(guild.id)
 
@@ -61,6 +62,13 @@ export default {
             // Optional: Check if the bot *thinks* it's in a channel anyway (e.g., after a crash)
             const botVoiceState = guild.members.me?.voice
             if (botVoiceState?.channel) {
+                if (!memberMayControlPlayerVoice(botVoiceState.channel.id, voiceChannel.id)) {
+                    return interaction.reply({
+                        content: "You need to be in the same voice channel as the bot!",
+                        ephemeral: true,
+                    })
+                }
+                await interaction.deferReply()
                 client.debug(
                     `Bot is in voice channel ${botVoiceState.channel.id}. Attempting to leave.`
                 )
@@ -81,10 +89,23 @@ export default {
                 }
             } else {
                 client.debug("Bot is not in a voice channel. Replying 'nothing to leave'.")
-                await interaction.editReply("I'm not in a voice channel!")
+                await interaction.reply({
+                    content: "I'm not in a voice channel!",
+                    ephemeral: true,
+                })
             }
             return
         }
+
+        if (!memberMayControlPlayerVoice(player.voiceChannelId, voiceChannel.id)) {
+            return interaction.reply({
+                content: "You need to be in the same voice channel as the bot!",
+                ephemeral: true,
+            })
+        }
+
+        await interaction.deferReply()
+        client.debug("Leave command deferred reply")
 
         client.debug(
             `Found player for guild ${guild.id}. Connected: ${player.connected}, Playing: ${player.playing}`

--- a/src/commands/music/Play.ts
+++ b/src/commands/music/Play.ts
@@ -4,6 +4,10 @@ import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
 import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 import { webDashboardPromoAppend } from "../../util/webDashboardUrl.js"
 
 export default {
@@ -35,6 +39,18 @@ export default {
         const voiceChannel = member.voice.channel
         if (!voiceChannel) {
             return interaction.reply({ content: "Join a voice channel first!", ephemeral: true })
+        }
+
+        // Cover local @discordjs/voice playback (Lavalink player destroyed) and connected sessions.
+        {
+            const existingPlayer = client.lavalink.getPlayer(guild.id)
+            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+            if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                return interaction.reply({
+                    content: "You need to be in the same voice channel as the bot!",
+                    ephemeral: true,
+                })
+            }
         }
 
         const textChannel = interaction.channel

--- a/src/commands/music/Play.ts
+++ b/src/commands/music/Play.ts
@@ -2,6 +2,7 @@ import { SlashCommandBuilder } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 import { webDashboardPromoAppend } from "../../util/webDashboardUrl.js"
 
@@ -36,30 +37,6 @@ export default {
             return interaction.reply({ content: "Join a voice channel first!", ephemeral: true })
         }
 
-        // Use getPlayer first to potentially reuse existing player
-        let player = client.lavalink.getPlayer(guild.id)
-        let createdNewPlayer = false
-
-        if (!player) {
-            player = await client.lavalink.createPlayer({
-                guildId: guild.id,
-                voiceChannelId: voiceChannel.id,
-                textChannelId: interaction.channelId, // Bind player to interaction channel initially
-                selfDeaf: true,
-                // selfMute: false, // Default is false
-                volume: 100, // Default volume
-            })
-            createdNewPlayer = true
-        }
-
-        if (player.connected && player.voiceChannelId !== voiceChannel.id) {
-            // Optional: Handle user being in a different channel than the bot
-            return interaction.reply({
-                content: "You need to be in the same voice channel as the bot!",
-                ephemeral: true,
-            })
-        }
-
         const textChannel = interaction.channel
         if (!textChannel?.isTextBased() || textChannel.isDMBased()) {
             return interaction.reply({
@@ -70,14 +47,46 @@ export default {
 
         await interaction.deferReply()
 
-        const result = await handleQueryAndPlay(
-            client,
+        // Hold a lifecycle reservation across create + search so web orphan cleanup cannot
+        // destroy the player while Discord /play is still resolving tracks.
+        const { createdNewPlayer, result } = await withGuildPlayerLifecycleReservation(
             guild.id,
-            voiceChannel,
-            textChannel,
-            query,
-            interaction.user,
-            player
+            async () => {
+                let player = client.lavalink.getPlayer(guild.id)
+                let createdNewPlayer = false
+
+                if (!player) {
+                    player = await client.lavalink.createPlayer({
+                        guildId: guild.id,
+                        voiceChannelId: voiceChannel.id,
+                        textChannelId: interaction.channelId,
+                        selfDeaf: true,
+                        volume: 100,
+                    })
+                    createdNewPlayer = true
+                }
+
+                if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+                    return {
+                        createdNewPlayer: false,
+                        result: {
+                            success: false,
+                            feedbackText: "You need to be in the same voice channel as the bot!",
+                        },
+                    }
+                }
+
+                const result = await handleQueryAndPlay(
+                    client,
+                    guild.id,
+                    voiceChannel,
+                    textChannel,
+                    query,
+                    interaction.user,
+                    player
+                )
+                return { createdNewPlayer, result }
+            }
         )
 
         let replyText = result.feedbackText || "Something went wrong."

--- a/src/commands/music/PlayNext.ts
+++ b/src/commands/music/PlayNext.ts
@@ -4,9 +4,11 @@ import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
 import {
     isRRQActive,
-    rebalancePlayerQueueRoundRobin,
+    rebalancePlayerQueueRoundRobinAssumingLock,
     stampRequesterUserIdOnTracks,
 } from "../../util/rrqDisconnect.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
+import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -70,10 +72,13 @@ export default {
 
         const track = res.tracks[0]
         stampRequesterUserIdOnTracks([track], interaction.user.id)
-        player.queue.add(track, 0)
-        if (isRRQActive(player)) {
-            await rebalancePlayerQueueRoundRobin(player)
-        }
+        await withGuildPlayerQueueLock(guild.id, async () => {
+            player.queue.add(track, 0)
+            if (isRRQActive(player)) {
+                await rebalancePlayerQueueRoundRobinAssumingLock(player)
+            }
+            schedulePlayerSessionSave(player)
+        })
         return interaction.editReply(
             `Added [${track.info.title}](${track.info.uri}) to the top of the queue.`
         )

--- a/src/commands/music/Playlist.ts
+++ b/src/commands/music/Playlist.ts
@@ -98,7 +98,10 @@ export default {
                     opt.setName("name").setDescription("Playlist name").setRequired(true)
                 )
                 .addBooleanOption((opt) =>
-                    opt.setName("shuffle").setDescription("Shuffle before queuing").setRequired(false)
+                    opt
+                        .setName("shuffle")
+                        .setDescription("Shuffle before queuing")
+                        .setRequired(false)
                 )
         ),
 
@@ -122,269 +125,280 @@ export default {
         const subcommand = interaction.options.getSubcommand()
 
         try {
-        if (subcommand === "create") {
-            const name = interaction.options.getString("name", true)
-            const existing = await getPlaylist(userId, name)
-            if (existing) {
+            if (subcommand === "create") {
+                const name = interaction.options.getString("name", true)
+                const existing = await getPlaylist(userId, name)
+                if (existing) {
+                    return interaction.reply({
+                        content: `You already have a playlist named **${name}**.`,
+                        ephemeral: true,
+                    })
+                }
+                await createPlaylist(userId, name)
                 return interaction.reply({
-                    content: `You already have a playlist named **${name}**.`,
-                    ephemeral: true,
-                })
-            }
-            await createPlaylist(userId, name)
-            return interaction.reply({
-                content: `Created playlist **${name}**.`,
-                ephemeral: true,
-            })
-        }
-
-        if (subcommand === "delete") {
-            const name = interaction.options.getString("name", true)
-            const existing = await getPlaylist(userId, name)
-            if (!existing) {
-                return interaction.reply({
-                    content: `No playlist named **${name}** found.`,
-                    ephemeral: true,
-                })
-            }
-            await deletePlaylist(userId, name)
-            return interaction.reply({
-                content: `Deleted playlist **${name}**.`,
-                ephemeral: true,
-            })
-        }
-
-        if (subcommand === "list") {
-            const playlists = await getUserPlaylists(userId)
-            if (playlists.length === 0) {
-                return interaction.reply({
-                    content:
-                        "You don't have any playlists yet. Use `/playlist create` to make one!",
-                    ephemeral: true,
-                })
-            }
-            const embed = new EmbedBuilder()
-                .setColor(0x0099ff)
-                .setTitle("Your Playlists")
-                .setDescription(
-                    playlists
-                        .map(
-                            (p) =>
-                                `**${p.name}** — ${p.trackCount} track${p.trackCount === 1 ? "" : "s"}`
-                        )
-                        .join("\n")
-                )
-                .setTimestamp()
-            return interaction.reply({ embeds: [embed], ephemeral: true })
-        }
-
-        if (subcommand === "view") {
-            const name = interaction.options.getString("name", true)
-            const playlist = await getPlaylist(userId, name)
-            if (!playlist) {
-                return interaction.reply({
-                    content: `No playlist named **${name}** found.`,
-                    ephemeral: true,
-                })
-            }
-            return showPaginatedPlaylistView(interaction, client, playlist.name, playlist.tracks)
-        }
-
-        if (subcommand === "add") {
-            const name = interaction.options.getString("name", true)
-            const query = interaction.options.getString("query")
-            const playlist = await getPlaylist(userId, name)
-            if (!playlist) {
-                return interaction.reply({
-                    content: `No playlist named **${name}** found.`,
+                    content: `Created playlist **${name}**.`,
                     ephemeral: true,
                 })
             }
 
-            if (query) {
-                await interaction.deferReply({ ephemeral: true })
-                const player = pickPlayerForPlaylistSearch(client.lavalink, guild.id)
-                if (!player) {
-                    return interaction.editReply({
+            if (subcommand === "delete") {
+                const name = interaction.options.getString("name", true)
+                const existing = await getPlaylist(userId, name)
+                if (!existing) {
+                    return interaction.reply({
+                        content: `No playlist named **${name}** found.`,
+                        ephemeral: true,
+                    })
+                }
+                await deletePlaylist(userId, name)
+                return interaction.reply({
+                    content: `Deleted playlist **${name}**.`,
+                    ephemeral: true,
+                })
+            }
+
+            if (subcommand === "list") {
+                const playlists = await getUserPlaylists(userId)
+                if (playlists.length === 0) {
+                    return interaction.reply({
                         content:
-                            "The bot is not in a voice channel anywhere. Join voice in a server with the bot, or try again later.",
+                            "You don't have any playlists yet. Use `/playlist create` to make one!",
+                        ephemeral: true,
                     })
                 }
-                const found = await searchTracksForPlaylist(player, query, interaction.user)
-                if (found.ok === false) {
-                    return interaction.editReply({ content: found.error })
+                const embed = new EmbedBuilder()
+                    .setColor(0x0099ff)
+                    .setTitle("Your Playlists")
+                    .setDescription(
+                        playlists
+                            .map(
+                                (p) =>
+                                    `**${p.name}** — ${p.trackCount} track${p.trackCount === 1 ? "" : "s"}`
+                            )
+                            .join("\n")
+                    )
+                    .setTimestamp()
+                return interaction.reply({ embeds: [embed], ephemeral: true })
+            }
+
+            if (subcommand === "view") {
+                const name = interaction.options.getString("name", true)
+                const playlist = await getPlaylist(userId, name)
+                if (!playlist) {
+                    return interaction.reply({
+                        content: `No playlist named **${name}** found.`,
+                        ephemeral: true,
+                    })
                 }
-                const addedAt = new Date()
-                const added = await addTracksToPlaylist(
-                    playlist.id,
-                    found.tracks.map((t) => ({
-                        title: t.title,
-                        uri: t.uri,
-                        author: t.author,
-                        duration: t.duration,
-                        thumbnailUrl: t.thumbnailUrl,
-                        addedAt,
-                    }))
+                return showPaginatedPlaylistView(
+                    interaction,
+                    client,
+                    playlist.name,
+                    playlist.tracks
                 )
-                if (added.length === 1) {
-                    const t = added[0]!
-                    return interaction.editReply({
-                        content: `Added **[${t.title}](${t.uri})** to **${name}**.`,
+            }
+
+            if (subcommand === "add") {
+                const name = interaction.options.getString("name", true)
+                const query = interaction.options.getString("query")
+                const playlist = await getPlaylist(userId, name)
+                if (!playlist) {
+                    return interaction.reply({
+                        content: `No playlist named **${name}** found.`,
+                        ephemeral: true,
                     })
                 }
-                return interaction.editReply({
-                    content: `Added **${added.length}** tracks to **${name}**.`,
+
+                if (query) {
+                    await interaction.deferReply({ ephemeral: true })
+                    const player = pickPlayerForPlaylistSearch(client.lavalink, guild.id)
+                    if (!player) {
+                        return interaction.editReply({
+                            content:
+                                "The bot is not in a voice channel anywhere. Join voice in a server with the bot, or try again later.",
+                        })
+                    }
+                    const found = await searchTracksForPlaylist(player, query, interaction.user)
+                    if (found.ok === false) {
+                        return interaction.editReply({ content: found.error })
+                    }
+                    const addedAt = new Date()
+                    const added = await addTracksToPlaylist(
+                        playlist.id,
+                        found.tracks.map((t) => ({
+                            title: t.title,
+                            uri: t.uri,
+                            author: t.author,
+                            duration: t.duration,
+                            thumbnailUrl: t.thumbnailUrl,
+                            addedAt,
+                        }))
+                    )
+                    if (added.length === 1) {
+                        const t = added[0]!
+                        return interaction.editReply({
+                            content: `Added **[${t.title}](${t.uri})** to **${name}**.`,
+                        })
+                    }
+                    return interaction.editReply({
+                        content: `Added **${added.length}** tracks to **${name}**.`,
+                    })
+                }
+
+                const player = client.lavalink.players.get(guild.id)
+                const current = player?.queue.current
+                if (!current) {
+                    return interaction.reply({
+                        content: "Nothing is playing. Provide a `query` or start playback first.",
+                        ephemeral: true,
+                    })
+                }
+                const info = current.info
+                const uri = typeof info.uri === "string" ? info.uri.trim() : ""
+                if (!uri) {
+                    return interaction.reply({
+                        content: "The current track has no URL and cannot be saved to a playlist.",
+                        ephemeral: true,
+                    })
+                }
+                await addTracksToPlaylist(playlist.id, [
+                    {
+                        title: info.title ?? "Unknown",
+                        uri,
+                        author: info.author ?? "Unknown",
+                        duration: info.duration ?? 0,
+                        thumbnailUrl: thumbnailFromLavalinkTrack(current),
+                        addedAt: new Date(),
+                    },
+                ])
+                return interaction.reply({
+                    content: `Added **[${info.title}](${uri})** to **${name}**.`,
+                    ephemeral: true,
                 })
             }
 
-            const player = client.lavalink.players.get(guild.id)
-            const current = player?.queue.current
-            if (!current) {
+            if (subcommand === "remove") {
+                const name = interaction.options.getString("name", true)
+                const index = interaction.options.getInteger("index", true)
+                const playlist = await getPlaylist(userId, name)
+                if (!playlist) {
+                    return interaction.reply({
+                        content: `No playlist named **${name}** found.`,
+                        ephemeral: true,
+                    })
+                }
+                if (index < 1 || index > playlist.tracks.length) {
+                    return interaction.reply({
+                        content: `Invalid index. Choose between 1 and ${playlist.tracks.length}.`,
+                        ephemeral: true,
+                    })
+                }
+                const track = playlist.tracks[index - 1]!
+                await removeTrackFromPlaylistById(playlist.id, track.id)
                 return interaction.reply({
-                    content: "Nothing is playing. Provide a `query` or start playback first.",
+                    content: `Removed **${track.title}** from **${name}**.`,
                     ephemeral: true,
                 })
             }
-            const info = current.info
-            const uri = typeof info.uri === "string" ? info.uri.trim() : ""
-            if (!uri) {
-                return interaction.reply({
-                    content: "The current track has no URL and cannot be saved to a playlist.",
-                    ephemeral: true,
-                })
-            }
-            await addTracksToPlaylist(playlist.id, [
+
+            if (subcommand === "play") {
+                const name = interaction.options.getString("name", true)
+                const shuffle = interaction.options.getBoolean("shuffle") ?? false
+
+                const voiceChannel = member.voice.channel
+                if (!voiceChannel) {
+                    return interaction.reply({
+                        content: "Join a voice channel first!",
+                        ephemeral: true,
+                    })
+                }
+
+                await interaction.deferReply({ ephemeral: true })
+
+                const playlist = await getPlaylist(userId, name)
+                if (!playlist) {
+                    return interaction.editReply({
+                        content: `No playlist named **${name}** found.`,
+                    })
+                }
+                if (playlist.tracks.length === 0) {
+                    return interaction.editReply({
+                        content: `**${name}** has no tracks.`,
+                    })
+                }
+
                 {
-                    title: info.title ?? "Unknown",
-                    uri,
-                    author: info.author ?? "Unknown",
-                    duration: info.duration ?? 0,
-                    thumbnailUrl: thumbnailFromLavalinkTrack(current),
-                    addedAt: new Date(),
-                },
-            ])
-            return interaction.reply({
-                content: `Added **[${info.title}](${uri})** to **${name}**.`,
-                ephemeral: true,
-            })
-        }
+                    const existingPlayer = client.lavalink.getPlayer(guild.id)
+                    const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(
+                        guild,
+                        existingPlayer
+                    )
+                    if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                        return interaction.editReply({
+                            content: "You need to be in the same voice channel as the bot!",
+                        })
+                    }
+                }
 
-        if (subcommand === "remove") {
-            const name = interaction.options.getString("name", true)
-            const index = interaction.options.getInteger("index", true)
-            const playlist = await getPlaylist(userId, name)
-            if (!playlist) {
-                return interaction.reply({
-                    content: `No playlist named **${name}** found.`,
-                    ephemeral: true,
-                })
-            }
-            if (index < 1 || index > playlist.tracks.length) {
-                return interaction.reply({
-                    content: `Invalid index. Choose between 1 and ${playlist.tracks.length}.`,
-                    ephemeral: true,
-                })
-            }
-            const track = playlist.tracks[index - 1]!
-            await removeTrackFromPlaylistById(playlist.id, track.id)
-            return interaction.reply({
-                content: `Removed **${track.title}** from **${name}**.`,
-                ephemeral: true,
-            })
-        }
+                const playOutcome = await withGuildPlayerLifecycleReservation(
+                    guild.id,
+                    async () => {
+                        let player = client.lavalink.getPlayer(guild.id)
+                        if (!player) {
+                            player = await client.lavalink.createPlayer({
+                                guildId: guild.id,
+                                voiceChannelId: voiceChannel.id,
+                                textChannelId: interaction.channelId,
+                                selfDeaf: true,
+                                volume: 100,
+                            })
+                        }
 
-        if (subcommand === "play") {
-            const name = interaction.options.getString("name", true)
-            const shuffle = interaction.options.getBoolean("shuffle") ?? false
+                        if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+                            return { kind: "wrong_channel" as const }
+                        }
 
-            const voiceChannel = member.voice.channel
-            if (!voiceChannel) {
-                return interaction.reply({
-                    content: "Join a voice channel first!",
-                    ephemeral: true,
-                })
-            }
+                        const { resolved, failed } = await resolveStoredPlaylistTracks(
+                            player,
+                            playlist.tracks,
+                            interaction.user
+                        )
 
-            await interaction.deferReply({ ephemeral: true })
+                        if (resolved.length === 0) {
+                            return { kind: "no_tracks" as const, name }
+                        }
 
-            const playlist = await getPlaylist(userId, name)
-            if (!playlist) {
-                return interaction.editReply({
-                    content: `No playlist named **${name}** found.`,
-                })
-            }
-            if (playlist.tracks.length === 0) {
-                return interaction.editReply({
-                    content: `**${name}** has no tracks.`,
-                })
-            }
+                        const enqueue = await enqueueResolvedPlaylistTracks(
+                            player,
+                            resolved,
+                            interaction.user.id,
+                            shuffle
+                        )
+                        return { kind: "queued" as const, name, enqueue, failed }
+                    }
+                )
 
-            {
-                const existingPlayer = client.lavalink.getPlayer(guild.id)
-                const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
-                if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                if (playOutcome.kind === "wrong_channel") {
                     return interaction.editReply({
                         content: "You need to be in the same voice channel as the bot!",
                     })
                 }
-            }
-
-            const playOutcome = await withGuildPlayerLifecycleReservation(guild.id, async () => {
-                let player = client.lavalink.getPlayer(guild.id)
-                if (!player) {
-                    player = await client.lavalink.createPlayer({
-                        guildId: guild.id,
-                        voiceChannelId: voiceChannel.id,
-                        textChannelId: interaction.channelId,
-                        selfDeaf: true,
-                        volume: 100,
+                if (playOutcome.kind === "no_tracks") {
+                    return interaction.editReply({
+                        content: `Could not resolve any tracks from **${playOutcome.name}**.`,
                     })
                 }
 
-                if (player.connected && player.voiceChannelId !== voiceChannel.id) {
-                    return { kind: "wrong_channel" as const }
-                }
-
-                const { resolved, failed } = await resolveStoredPlaylistTracks(
-                    player,
-                    playlist.tracks,
-                    interaction.user
-                )
-
-                if (resolved.length === 0) {
-                    return { kind: "no_tracks" as const, name }
-                }
-
-                const enqueue = await enqueueResolvedPlaylistTracks(
-                    player,
-                    resolved,
-                    interaction.user.id,
-                    shuffle
-                )
-                return { kind: "queued" as const, name, enqueue, failed }
-            })
-
-            if (playOutcome.kind === "wrong_channel") {
+                const failPart =
+                    playOutcome.failed > 0
+                        ? ` ${playOutcome.failed} track${playOutcome.failed === 1 ? "" : "s"} could not be resolved.`
+                        : ""
                 return interaction.editReply({
-                    content: "You need to be in the same voice channel as the bot!",
-                })
-            }
-            if (playOutcome.kind === "no_tracks") {
-                return interaction.editReply({
-                    content: `Could not resolve any tracks from **${playOutcome.name}**.`,
+                    content: `Queued ${playOutcome.enqueue.queued} track${playOutcome.enqueue.queued === 1 ? "" : "s"} from **${playOutcome.name}**.${failPart}`,
                 })
             }
 
-            const failPart =
-                playOutcome.failed > 0
-                    ? ` ${playOutcome.failed} track${playOutcome.failed === 1 ? "" : "s"} could not be resolved.`
-                    : ""
-            return interaction.editReply({
-                content: `Queued ${playOutcome.enqueue.queued} track${playOutcome.enqueue.queued === 1 ? "" : "s"} from **${playOutcome.name}**.${failPart}`,
-            })
-        }
-
-        return interaction.reply({ content: "Unknown subcommand.", ephemeral: true })
+            return interaction.reply({ content: "Unknown subcommand.", ephemeral: true })
         } catch (err: unknown) {
             console.error("[Playlist command] execute failed", err)
             const content = "An error occurred while processing your request."

--- a/src/commands/music/Playlist.ts
+++ b/src/commands/music/Playlist.ts
@@ -25,6 +25,7 @@ import {
     resolveStoredPlaylistTracks,
     searchTracksForPlaylist,
 } from "../../util/playlistQueue.js"
+import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { thumbnailFromLavalinkTrack } from "../../util/trackThumbnail.js"
 
 export default {
@@ -314,46 +315,58 @@ export default {
                 })
             }
 
-            let player = client.lavalink.getPlayer(guild.id)
-            if (!player) {
-                player = await client.lavalink.createPlayer({
-                    guildId: guild.id,
-                    voiceChannelId: voiceChannel.id,
-                    textChannelId: interaction.channelId,
-                    selfDeaf: true,
-                    volume: 100,
-                })
-            }
+            const playOutcome = await withGuildPlayerLifecycleReservation(guild.id, async () => {
+                let player = client.lavalink.getPlayer(guild.id)
+                if (!player) {
+                    player = await client.lavalink.createPlayer({
+                        guildId: guild.id,
+                        voiceChannelId: voiceChannel.id,
+                        textChannelId: interaction.channelId,
+                        selfDeaf: true,
+                        volume: 100,
+                    })
+                }
 
-            if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+                if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+                    return { kind: "wrong_channel" as const }
+                }
+
+                const { resolved, failed } = await resolveStoredPlaylistTracks(
+                    player,
+                    playlist.tracks,
+                    interaction.user
+                )
+
+                if (resolved.length === 0) {
+                    return { kind: "no_tracks" as const, name }
+                }
+
+                const enqueue = await enqueueResolvedPlaylistTracks(
+                    player,
+                    resolved,
+                    interaction.user.id,
+                    shuffle
+                )
+                return { kind: "queued" as const, name, enqueue, failed }
+            })
+
+            if (playOutcome.kind === "wrong_channel") {
                 return interaction.editReply({
                     content: "You need to be in the same voice channel as the bot!",
                 })
             }
-
-            const { resolved, failed } = await resolveStoredPlaylistTracks(
-                player,
-                playlist.tracks,
-                interaction.user
-            )
-
-            if (resolved.length === 0) {
+            if (playOutcome.kind === "no_tracks") {
                 return interaction.editReply({
-                    content: `Could not resolve any tracks from **${name}**.`,
+                    content: `Could not resolve any tracks from **${playOutcome.name}**.`,
                 })
             }
 
-            const enqueue = await enqueueResolvedPlaylistTracks(
-                player,
-                resolved,
-                interaction.user.id,
-                shuffle
-            )
-
             const failPart =
-                failed > 0 ? ` ${failed} track${failed === 1 ? "" : "s"} could not be resolved.` : ""
+                playOutcome.failed > 0
+                    ? ` ${playOutcome.failed} track${playOutcome.failed === 1 ? "" : "s"} could not be resolved.`
+                    : ""
             return interaction.editReply({
-                content: `Queued ${enqueue.queued} track${enqueue.queued === 1 ? "" : "s"} from **${name}**.${failPart}`,
+                content: `Queued ${playOutcome.enqueue.queued} track${playOutcome.enqueue.queued === 1 ? "" : "s"} from **${playOutcome.name}**.${failPart}`,
             })
         }
 

--- a/src/commands/music/Playlist.ts
+++ b/src/commands/music/Playlist.ts
@@ -27,6 +27,10 @@ import {
 } from "../../util/playlistQueue.js"
 import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { thumbnailFromLavalinkTrack } from "../../util/trackThumbnail.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -313,6 +317,16 @@ export default {
                 return interaction.editReply({
                     content: `**${name}** has no tracks.`,
                 })
+            }
+
+            {
+                const existingPlayer = client.lavalink.getPlayer(guild.id)
+                const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+                if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                    return interaction.editReply({
+                        content: "You need to be in the same voice channel as the bot!",
+                    })
+                }
             }
 
             const playOutcome = await withGuildPlayerLifecycleReservation(guild.id, async () => {

--- a/src/commands/music/Playlist.ts
+++ b/src/commands/music/Playlist.ts
@@ -22,10 +22,14 @@ import {
 import {
     enqueueResolvedPlaylistTracks,
     pickPlayerForPlaylistSearch,
+    playerHasQueueContent,
     resolveStoredPlaylistTracks,
     searchTracksForPlaylist,
 } from "../../util/playlistQueue.js"
-import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
+import {
+    tryDestroyOrphanGuildPlayer,
+    withGuildPlayerLifecycleReservation,
+} from "../../util/guildPlayerQueueLock.js"
 import { thumbnailFromLavalinkTrack } from "../../util/trackThumbnail.js"
 import {
     memberMayJoinOccupiedVoice,
@@ -344,6 +348,7 @@ export default {
                     guild.id,
                     async () => {
                         let player = client.lavalink.getPlayer(guild.id)
+                        let createdHere = false
                         if (!player) {
                             player = await client.lavalink.createPlayer({
                                 guildId: guild.id,
@@ -352,9 +357,24 @@ export default {
                                 selfDeaf: true,
                                 volume: 100,
                             })
+                            createdHere = true
+                        }
+
+                        const cleanupCreatedPlayer = async (): Promise<void> => {
+                            if (!createdHere) return
+                            await tryDestroyOrphanGuildPlayer(guild.id, {
+                                hasQueueContent: () => {
+                                    const live = client.lavalink.getPlayer(guild.id) ?? player
+                                    return playerHasQueueContent(live)
+                                },
+                                destroyPlayer: async () => {
+                                    await client.lavalink.destroyPlayer(guild.id)
+                                },
+                            })
                         }
 
                         if (player.connected && player.voiceChannelId !== voiceChannel.id) {
+                            await cleanupCreatedPlayer()
                             return { kind: "wrong_channel" as const }
                         }
 
@@ -365,6 +385,7 @@ export default {
                         )
 
                         if (resolved.length === 0) {
+                            await cleanupCreatedPlayer()
                             return { kind: "no_tracks" as const, name }
                         }
 

--- a/src/commands/music/Seek.ts
+++ b/src/commands/music/Seek.ts
@@ -43,6 +43,13 @@ export default {
             return interaction.reply({ content: "Nothing is playing.", ephemeral: true })
         }
 
+        if (player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
+            return interaction.reply({
+                content: "You need to be in the same voice channel as the bot!",
+                ephemeral: true,
+            })
+        }
+
         const current = player.queue.current
 
         const durationMs = current.info.duration ?? 0

--- a/src/commands/music/Seek.ts
+++ b/src/commands/music/Seek.ts
@@ -2,6 +2,7 @@ import { SlashCommandBuilder } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import { memberMayControlPlayerVoice } from "../../util/sameVoiceChannel.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -43,7 +44,7 @@ export default {
             return interaction.reply({ content: "Nothing is playing.", ephemeral: true })
         }
 
-        if (player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
+        if (!memberMayControlPlayerVoice(player.voiceChannelId, voiceChannel.id)) {
             return interaction.reply({
                 content: "You need to be in the same voice channel as the bot!",
                 ephemeral: true,

--- a/src/commands/music/Shuffle.ts
+++ b/src/commands/music/Shuffle.ts
@@ -2,6 +2,8 @@ import { SlashCommandBuilder } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import { withGuildPlayerQueueLock } from "../../util/guildPlayerQueueLock.js"
+import { schedulePlayerSessionSave } from "../../util/playerSessionPersistence.js"
 
 export default {
     data: new SlashCommandBuilder().setName("shuffle").setDescription("Shuffle the current queue"),
@@ -47,7 +49,11 @@ export default {
             })
         }
 
-        await player.queue.shuffle()
+        await withGuildPlayerQueueLock(guild.id, async () => {
+            if (player.queue.tracks.length < 2) return
+            await player.queue.shuffle()
+            schedulePlayerSessionSave(player)
+        })
         await interaction.reply("Queue shuffled.")
     },
 }

--- a/src/commands/music/Stop.ts
+++ b/src/commands/music/Stop.ts
@@ -2,7 +2,9 @@ import { SlashCommandBuilder } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import type { ChatInputCommandInteraction, Message } from "discord.js"
 import { discordDeleteErrorDetails } from "../../util/discordErrorDetails.js"
+import { guildMemberFromInteraction } from "../../util/guildMember.js"
 import { stopLocalPlayer, getLocalPlayerState } from "../../util/localPlayer.js"
+import { memberMayControlPlayerVoice } from "../../util/sameVoiceChannel.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -14,6 +16,34 @@ export default {
         if (!guild) {
             return interaction.reply({
                 content: "Use this command in a server.",
+                ephemeral: true,
+            })
+        }
+
+        const member = guildMemberFromInteraction(interaction)
+        if (!member) {
+            return interaction.reply({
+                content: "Could not resolve your member profile. Try again.",
+                ephemeral: true,
+            })
+        }
+
+        const voiceChannel = member.voice.channel
+        if (!voiceChannel) {
+            return interaction.reply({
+                content: "Join a voice channel first!",
+                ephemeral: true,
+            })
+        }
+
+        // Require same VC so remote /stop cannot wipe another channel's player session.
+        const lavalinkPlayer = client.lavalink.players.get(guild.id)
+        if (
+            lavalinkPlayer &&
+            !memberMayControlPlayerVoice(lavalinkPlayer.voiceChannelId, voiceChannel.id)
+        ) {
+            return interaction.reply({
+                content: "You need to be in the same voice channel as the bot!",
                 ephemeral: true,
             })
         }
@@ -32,8 +62,6 @@ export default {
             }
         }
 
-        // Attempt to stop Lavalink player
-        const lavalinkPlayer = client.lavalink.players.get(guild.id)
         if (lavalinkPlayer) {
             // Check if it was actually doing something or had a queue
             if (

--- a/src/commands/music/Stop.ts
+++ b/src/commands/music/Stop.ts
@@ -4,7 +4,10 @@ import type { ChatInputCommandInteraction, Message } from "discord.js"
 import { discordDeleteErrorDetails } from "../../util/discordErrorDetails.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
 import { stopLocalPlayer, getLocalPlayerState } from "../../util/localPlayer.js"
-import { memberMayControlPlayerVoice } from "../../util/sameVoiceChannel.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -36,12 +39,11 @@ export default {
             })
         }
 
-        // Require same VC so remote /stop cannot wipe another channel's player session.
+        // Require same VC (incl. local playback with no Lavalink player) so remote /stop
+        // cannot wipe another channel's session.
         const lavalinkPlayer = client.lavalink.players.get(guild.id)
-        if (
-            lavalinkPlayer &&
-            !memberMayControlPlayerVoice(lavalinkPlayer.voiceChannelId, voiceChannel.id)
-        ) {
+        const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, lavalinkPlayer)
+        if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
             return interaction.reply({
                 content: "You need to be in the same voice channel as the bot!",
                 ephemeral: true,

--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -25,6 +25,15 @@ const MAX_FILE_AGE_DAYS = 7
 // Maximum total size of downloads directory in MB (default fallback)
 const DEFAULT_MAX_DIR_SIZE_MB = 1000
 
+/** Wall-clock limit for a single yt-dlp run (live / very long media). */
+const DOWNLOAD_PROCESS_TIMEOUT_MS = 10 * 60 * 1000
+
+/**
+ * Rough upper bound on WAV output (~10 MiB/min for 16-bit 44.1kHz stereo).
+ * Used only for yt-dlp duration filtering before download starts.
+ */
+const APPROX_WAV_MIB_PER_MINUTE = 10
+
 /**
  * Resolves the configured downloads size limit for a guild.
  * @param {import('../../lib/BotClient.js').default} client The bot client instance.
@@ -38,6 +47,23 @@ function getMaxDirSizeMb(client: BotClient, guildId: string) {
     const parsed = Number.parseFloat(String(configured ?? ""))
     if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_MAX_DIR_SIZE_MB
     return parsed
+}
+
+/** Max accepted on-disk size for one download (guild quota, in bytes). */
+function getMaxDownloadBytes(maxDirSizeMb: number): number {
+    return Math.max(1, maxDirSizeMb) * 1024 * 1024
+}
+
+/**
+ * yt-dlp match-filter: reject live streams and media whose estimated WAV size
+ * would exceed the guild downloads quota.
+ */
+function buildYtDlpMatchFilter(maxDirSizeMb: number): string {
+    const maxDurationSec = Math.max(
+        60,
+        Math.floor((maxDirSizeMb / APPROX_WAV_MIB_PER_MINUTE) * 60)
+    )
+    return `!is_live & duration <= ${maxDurationSec}`
 }
 
 /**
@@ -368,6 +394,8 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
 
         // Download the video
         await updateReply("Downloading audio... This can take a moment.", true)
+        const maxDownloadBytes = getMaxDownloadBytes(maxDirSizeMb)
+        const matchFilter = buildYtDlpMatchFilter(maxDirSizeMb)
         let downloadProcess: ReturnType<typeof spawn>
         try {
             downloadProcess = spawn("yt-dlp", [
@@ -382,6 +410,11 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                 "--newline",
                 "--print",
                 "after_move:filepath",
+                // Source media size cap (WAV output can still be larger; post-check below).
+                "--max-filesize",
+                `${maxDirSizeMb}M`,
+                "--match-filter",
+                matchFilter,
                 "-o",
                 `${downloadsDir}/${downloadFilePrefix}%(title)s.%(ext)s`,
             ])
@@ -400,6 +433,21 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
             )
             return
         }
+
+        let timedOut = false
+        const killTimer = setTimeout(() => {
+            timedOut = true
+            client.error(
+                `[Download] yt-dlp exceeded ${DOWNLOAD_PROCESS_TIMEOUT_MS}ms; killing process`
+            )
+            try {
+                downloadProcess.kill("SIGKILL")
+            } catch (killErr: unknown) {
+                client.error("[Download] Failed to kill timed-out yt-dlp:", killErr)
+            }
+        }, DOWNLOAD_PROCESS_TIMEOUT_MS)
+        downloadProcess.on("close", () => clearTimeout(killTimer))
+        downloadProcess.on("error", () => clearTimeout(killTimer))
 
         downloadProcess.on("error", (err: Error) => {
             client.error("[Download] Failed to start yt-dlp", err)
@@ -461,10 +509,24 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
 
         downloadProcess.on("close", async (code: number | null) => {
             try {
+                if (timedOut) {
+                    await interaction
+                        .editReply({
+                            content:
+                                "Download timed out. Try a shorter video, or contact an admin if this keeps happening.",
+                        })
+                        .catch((e: unknown) =>
+                            client.error("Failed to edit reply on download timeout", e)
+                        )
+                    return
+                }
                 if (code !== 0) {
                     client.error(`[Download] yt-dlp process exited with code ${code}`)
                     await interaction
-                        .editReply({ content: "Error downloading video. Please try again later." })
+                        .editReply({
+                            content:
+                                "Error downloading video. It may be too long, live, or otherwise rejected by size limits. Try a shorter YouTube URL.",
+                        })
                         .catch((e: unknown) =>
                             client.error("Failed to edit reply on download error", e)
                         )
@@ -522,6 +584,43 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                         )
                         .catch((e: unknown) =>
                             client.error("Failed to edit reply on file not found", e)
+                        )
+                    return
+                }
+
+                // Refuse to retain a single file larger than the guild quota. Previously the new
+                // file was "protected" during size cleanup, so an oversized WAV wiped other guild
+                // downloads while remaining on disk above the configured limit.
+                let downloadedStats: fs.Stats
+                try {
+                    downloadedStats = fs.statSync(filePath)
+                } catch (statErr: unknown) {
+                    client.error("[Download] Failed to stat downloaded file:", statErr)
+                    await interaction
+                        .editReply({
+                            content:
+                                "Download finished but the file could not be verified. Please try again.",
+                        })
+                        .catch((e: unknown) =>
+                            client.error("Failed to edit reply on download stat failure", e)
+                        )
+                    return
+                }
+                if (downloadedStats.size > maxDownloadBytes) {
+                    client.error(
+                        `[Download] Rejecting oversized file ${downloadedFile} (${downloadedStats.size} bytes > ${maxDownloadBytes} byte guild limit)`
+                    )
+                    try {
+                        fs.unlinkSync(filePath)
+                    } catch (unlinkErr: unknown) {
+                        client.error("[Download] Failed to unlink oversized download:", unlinkErr)
+                    }
+                    await interaction
+                        .editReply({
+                            content: `Download rejected: the resulting file exceeds this server's download limit (${maxDirSizeMb}MB). Try a shorter video.`,
+                        })
+                        .catch((e: unknown) =>
+                            client.error("Failed to edit reply on oversized download", e)
                         )
                     return
                 }

--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -4,6 +4,7 @@ import { spawn } from "child_process"
 import path from "path"
 import fs from "fs"
 import type BotClient from "../../lib/BotClient.js"
+import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 import { getGuildSettings } from "../../util/saveControlChannel.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
@@ -690,42 +691,39 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                         })
                         return
                     }
-                    let player = client.lavalink.getPlayer(guildId)
-                    if (!player) {
-                        player = client.lavalink.createPlayer({
-                            guildId,
-                            voiceChannelId: voiceChannel.id,
-                            textChannelId: textChannel.id,
-                            selfDeaf: true,
-                        })
-                    }
-                    if (!player) {
+                    const playResult = await withGuildPlayerLifecycleReservation(
+                        guildId,
+                        async () => {
+                            let player = client.lavalink.getPlayer(guildId)
+                            if (!player) {
+                                player = client.lavalink.createPlayer({
+                                    guildId,
+                                    voiceChannelId: voiceChannel.id,
+                                    textChannelId: textChannel.id,
+                                    selfDeaf: true,
+                                })
+                            }
+                            if (!player) {
+                                return null
+                            }
+
+                            return handleQueryAndPlay(
+                                client,
+                                guildId,
+                                voiceChannel,
+                                textChannel,
+                                filePath,
+                                interaction.user,
+                                player
+                            )
+                        }
+                    )
+                    if (!playResult) {
                         await interaction.editReply({
                             content: "Could not start the music player.",
                         })
                         return
                     }
-
-                    // Re-check after createPlayer: refuse to move an already-bound player.
-                    if (player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
-                        await interaction.editReply({
-                            content:
-                                `Saved as **${savedBaseName}**.\n` +
-                                `You need to be in the same voice channel as the bot to auto-play.\n` +
-                                `Use \`/play ${savedBaseName}\` from that channel when ready.`,
-                        })
-                        return
-                    }
-
-                    const playResult = await handleQueryAndPlay(
-                        client,
-                        guildId,
-                        voiceChannel,
-                        textChannel,
-                        filePath,
-                        interaction.user,
-                        player
-                    )
 
                     await interaction
                         .editReply({

--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -8,6 +8,10 @@ import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueue
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 import { getGuildSettings } from "../../util/saveControlChannel.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 import type { DownloadsMetadataStore } from "../../types/index.js"
 import {
     downloadMetadataEntryMatchesGuild,
@@ -667,10 +671,8 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                 // Auto-play only from the bot's current voice channel. Otherwise Play Local /
                 // ensurePlayerConnected would destroy the active session and move the bot.
                 const existingPlayer = client.lavalink.getPlayer(guildId)
-                const botVoiceChannelId = guild.members.me?.voice.channel?.id ?? null
-                const playerVoiceChannelId = existingPlayer?.voiceChannelId ?? null
-                const occupiedVoiceChannelId = playerVoiceChannelId || botVoiceChannelId
-                if (occupiedVoiceChannelId && occupiedVoiceChannelId !== voiceChannel.id) {
+                const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+                if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
                     await interaction.editReply({
                         content:
                             `Saved as **${savedBaseName}**.\n` +

--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -664,6 +664,24 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                     )
                 }
 
+                const savedBaseName = downloadedFile.replace(/\.wav$/i, "")
+
+                // Auto-play only from the bot's current voice channel. Otherwise Play Local /
+                // ensurePlayerConnected would destroy the active session and move the bot.
+                const existingPlayer = client.lavalink.getPlayer(guildId)
+                const botVoiceChannelId = guild.members.me?.voice.channel?.id ?? null
+                const playerVoiceChannelId = existingPlayer?.voiceChannelId ?? null
+                const occupiedVoiceChannelId = playerVoiceChannelId || botVoiceChannelId
+                if (occupiedVoiceChannelId && occupiedVoiceChannelId !== voiceChannel.id) {
+                    await interaction.editReply({
+                        content:
+                            `Saved as **${savedBaseName}**.\n` +
+                            `You need to be in the same voice channel as the bot to auto-play.\n` +
+                            `Use \`/play ${savedBaseName}\` from that channel when ready.`,
+                    })
+                    return
+                }
+
                 // Auto-play logic using handleQueryAndPlay
                 try {
                     await updateReply("Attempting to play the downloaded track...", true)
@@ -687,6 +705,17 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
                     if (!player) {
                         await interaction.editReply({
                             content: "Could not start the music player.",
+                        })
+                        return
+                    }
+
+                    // Re-check after createPlayer: refuse to move an already-bound player.
+                    if (player.voiceChannelId && player.voiceChannelId !== voiceChannel.id) {
+                        await interaction.editReply({
+                            content:
+                                `Saved as **${savedBaseName}**.\n` +
+                                `You need to be in the same voice channel as the bot to auto-play.\n` +
+                                `Use \`/play ${savedBaseName}\` from that channel when ready.`,
                         })
                         return
                     }

--- a/src/commands/user/download.ts
+++ b/src/commands/user/download.ts
@@ -59,10 +59,7 @@ function getMaxDownloadBytes(maxDirSizeMb: number): number {
  * would exceed the guild downloads quota.
  */
 function buildYtDlpMatchFilter(maxDirSizeMb: number): string {
-    const maxDurationSec = Math.max(
-        60,
-        Math.floor((maxDirSizeMb / APPROX_WAV_MIB_PER_MINUTE) * 60)
-    )
+    const maxDurationSec = Math.max(60, Math.floor((maxDirSizeMb / APPROX_WAV_MIB_PER_MINUTE) * 60))
     return `!is_live & duration <= ${maxDurationSec}`
 }
 

--- a/src/commands/user/downloads.ts
+++ b/src/commands/user/downloads.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder } from "discord.js"
+import { PermissionFlagsBits, SlashCommandBuilder } from "discord.js"
 import type { ChatInputCommandInteraction } from "discord.js"
 import fs from "fs"
 import { promises as fsp } from "fs"
@@ -71,7 +71,7 @@ const data = new SlashCommandBuilder()
     .addSubcommand((subcommand) =>
         subcommand
             .setName("cleanup")
-            .setDescription("Remove old downloaded files")
+            .setDescription("Remove old downloaded files (requires Manage Server)")
             .addIntegerOption((option) =>
                 option
                     .setName("days")
@@ -229,6 +229,15 @@ async function execute(interaction: ChatInputCommandInteraction, client: BotClie
         }
 
         if (subcommand === "cleanup") {
+            // Runtime check: DefaultMemberPermissions cannot be set per-subcommand, and list stays
+            // available to members. Cleanup deletes guild download files and must require Manage Guild.
+            if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+                return interaction.reply({
+                    ephemeral: true,
+                    content:
+                        "You need the **Manage Server** permission to clean up downloaded files.",
+                })
+            }
             const removeAll = interaction.options.getBoolean("all") || false
             const daysOpt = interaction.options.getInteger("days")
             const days = daysOpt === null ? 7 : daysOpt

--- a/src/events/handlers/handleControlMessages.ts
+++ b/src/events/handlers/handleControlMessages.ts
@@ -8,6 +8,10 @@ import type BotClient from "../../lib/BotClient.js"
 import { discordDeleteErrorDetails } from "../../util/discordErrorDetails.js"
 import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "../../util/sameVoiceChannel.js"
 
 export default async function handleControlMessages(client: BotClient, message: Message) {
     if (!message.member) {
@@ -67,8 +71,33 @@ export default async function handleControlMessages(client: BotClient, message: 
             `[ControlHandler] Bot has Connect/Speak permissions for VC ${voiceChannel.id}.`
         )
 
+        // 3. Refuse if bot occupies another VC (incl. local playback), then reserve + get/create.
+        const guild = message.guild
+        if (!guild) return
+        {
+            const existingPlayer = client.lavalink?.getPlayer(guildId)
+            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(guild, existingPlayer)
+            if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                client.warn(
+                    `[ControlHandler] User ${member.id} in VC ${voiceChannel.id}, but bot occupies VC ${occupiedVoiceChannelId} for guild ${guildId}.`
+                )
+                const otherVc = occupiedVoiceChannelId
+                    ? client.channels.cache.get(occupiedVoiceChannelId)
+                    : undefined
+                const otherName =
+                    otherVc &&
+                    "name" in otherVc &&
+                    typeof (otherVc as { name: string }).name === "string"
+                        ? (otherVc as { name: string }).name
+                        : "Unknown Channel"
+                feedbackMessage = await sendChannel.send(
+                    `${member}, I'm already playing in another voice channel (${otherName}).`
+                )
+                return
+            }
+        }
+
         const controlOutcome = await withGuildPlayerLifecycleReservation(guildId, async () => {
-            // 3. Get/Create player
             let player = client.lavalink?.getPlayer(guildId)
             if (!player) {
                 client.debug(

--- a/src/events/handlers/handleControlMessages.ts
+++ b/src/events/handlers/handleControlMessages.ts
@@ -6,8 +6,12 @@ import {
 } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import { discordDeleteErrorDetails } from "../../util/discordErrorDetails.js"
-import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
+import {
+    tryDestroyOrphanGuildPlayer,
+    withGuildPlayerLifecycleReservation,
+} from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
+import { playerHasQueueContent } from "../../util/playlistQueue.js"
 import {
     memberMayJoinOccupiedVoice,
     resolveOccupiedVoiceChannelId,
@@ -99,6 +103,7 @@ export default async function handleControlMessages(client: BotClient, message: 
 
         const controlOutcome = await withGuildPlayerLifecycleReservation(guildId, async () => {
             let player = client.lavalink?.getPlayer(guildId)
+            let createdHere = false
             if (!player) {
                 client.debug(
                     `[ControlHandler] No existing player for guild ${guildId}. Creating one.`
@@ -110,6 +115,7 @@ export default async function handleControlMessages(client: BotClient, message: 
                     selfDeaf: true,
                     volume: 100, // TODO: Make volume configurable?
                 })
+                createdHere = true
                 client.debug(`[ControlHandler] Created Lavalink player for guild ${guildId}.`)
             } else {
                 client.debug(
@@ -119,6 +125,19 @@ export default async function handleControlMessages(client: BotClient, message: 
 
             if (!player) {
                 return { kind: "no_player" as const }
+            }
+
+            const cleanupCreatedPlayer = async (): Promise<void> => {
+                if (!createdHere) return
+                await tryDestroyOrphanGuildPlayer(guildId, {
+                    hasQueueContent: () => {
+                        const live = client.lavalink?.getPlayer(guildId) ?? player
+                        return live ? playerHasQueueContent(live) : false
+                    },
+                    destroyPlayer: async () => {
+                        await client.lavalink?.destroyPlayer(guildId)
+                    },
+                })
             }
 
             if (!player.connected) {
@@ -137,6 +156,7 @@ export default async function handleControlMessages(client: BotClient, message: 
                         `[ControlHandler] Player failed to connect in guild ${guildId}:`,
                         connectError
                     )
+                    await cleanupCreatedPlayer()
                     return { kind: "connect_failed" as const }
                 }
             } else if (player.voiceChannelId !== voiceChannel.id) {

--- a/src/events/handlers/handleControlMessages.ts
+++ b/src/events/handlers/handleControlMessages.ts
@@ -6,6 +6,7 @@ import {
 } from "discord.js"
 import type BotClient from "../../lib/BotClient.js"
 import { discordDeleteErrorDetails } from "../../util/discordErrorDetails.js"
+import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
 import { handleQueryAndPlay } from "../../util/musicManager.js"
 
 export default async function handleControlMessages(client: BotClient, message: Message) {
@@ -66,93 +67,108 @@ export default async function handleControlMessages(client: BotClient, message: 
             `[ControlHandler] Bot has Connect/Speak permissions for VC ${voiceChannel.id}.`
         )
 
-        // 3. Get/Create player
-        let player = client.lavalink?.getPlayer(guildId)
-        if (!player) {
-            client.debug(`[ControlHandler] No existing player for guild ${guildId}. Creating one.`)
-            player = client.lavalink?.createPlayer({
-                guildId,
-                voiceChannelId: voiceChannel.id,
-                textChannelId: sendChannel.id,
-                selfDeaf: true,
-                volume: 100, // TODO: Make volume configurable?
-            })
-            client.debug(`[ControlHandler] Created Lavalink player for guild ${guildId}.`)
-        } else {
-            client.debug(
-                `[ControlHandler] Found existing player for guild ${guildId}. Connected: ${player.connected}`
-            )
-        }
+        const controlOutcome = await withGuildPlayerLifecycleReservation(guildId, async () => {
+            // 3. Get/Create player
+            let player = client.lavalink?.getPlayer(guildId)
+            if (!player) {
+                client.debug(
+                    `[ControlHandler] No existing player for guild ${guildId}. Creating one.`
+                )
+                player = client.lavalink?.createPlayer({
+                    guildId,
+                    voiceChannelId: voiceChannel.id,
+                    textChannelId: sendChannel.id,
+                    selfDeaf: true,
+                    volume: 100, // TODO: Make volume configurable?
+                })
+                client.debug(`[ControlHandler] Created Lavalink player for guild ${guildId}.`)
+            } else {
+                client.debug(
+                    `[ControlHandler] Found existing player for guild ${guildId}. Connected: ${player.connected}`
+                )
+            }
 
-        if (!player) {
+            if (!player) {
+                return { kind: "no_player" as const }
+            }
+
+            if (!player.connected) {
+                client.debug(
+                    `[ControlHandler] Player not connected for guild ${guildId}. Attempting connection to VC ${voiceChannel.id}.`
+                )
+                player.voiceChannelId = voiceChannel.id
+                player.textChannelId = sendChannel.id
+                try {
+                    await player.connect()
+                    client.debug(
+                        `[ControlHandler] Player successfully connected to VC ${voiceChannel.id} in guild ${guildId}.`
+                    )
+                } catch (connectError: unknown) {
+                    client.error(
+                        `[ControlHandler] Player failed to connect in guild ${guildId}:`,
+                        connectError
+                    )
+                    return { kind: "connect_failed" as const }
+                }
+            } else if (player.voiceChannelId !== voiceChannel.id) {
+                // If the user is in a different VC than the bot
+                client.warn(
+                    `[ControlHandler] User ${member.id} in VC ${voiceChannel.id}, but player is in VC ${player.voiceChannelId} for guild ${guildId}.`
+                )
+                const otherVc = player.voiceChannelId
+                    ? client.channels.cache.get(player.voiceChannelId)
+                    : undefined
+                const otherName =
+                    otherVc &&
+                    "name" in otherVc &&
+                    typeof (otherVc as { name: string }).name === "string"
+                        ? (otherVc as { name: string }).name
+                        : "Unknown Channel"
+                return { kind: "wrong_channel" as const, otherName }
+            }
+            client.debug(
+                `[ControlHandler] Player connected status checked/handled for guild ${guildId}.`
+            )
+
+            // 5, 6, 7: Use the centralized handler
+            const result = await handleQueryAndPlay(
+                client,
+                guildId,
+                voiceChannel,
+                sendChannel,
+                content,
+                message.author,
+                player
+            )
+            return { kind: "played" as const, result }
+        })
+
+        if (controlOutcome.kind === "no_player") {
             feedbackMessage = await sendChannel.send(
                 `${member}, Could not start the music player. Try again in a moment.`
             )
             return
         }
-
-        if (!player.connected) {
-            client.debug(
-                `[ControlHandler] Player not connected for guild ${guildId}. Attempting connection to VC ${voiceChannel.id}.`
-            )
-            player.voiceChannelId = voiceChannel.id
-            player.textChannelId = sendChannel.id
-            try {
-                await player.connect()
-                client.debug(
-                    `[ControlHandler] Player successfully connected to VC ${voiceChannel.id} in guild ${guildId}.`
-                )
-            } catch (connectError: unknown) {
-                client.error(
-                    `[ControlHandler] Player failed to connect in guild ${guildId}:`,
-                    connectError
-                )
-                feedbackMessage = await sendChannel.send(
-                    `${member}, I couldn't connect to your voice channel.`
-                )
-                return
-            }
-        } else if (player.voiceChannelId !== voiceChannel.id) {
-            // If the user is in a different VC than the bot
-            client.warn(
-                `[ControlHandler] User ${member.id} in VC ${voiceChannel.id}, but player is in VC ${player.voiceChannelId} for guild ${guildId}.`
-            )
-            const otherVc = player.voiceChannelId
-                ? client.channels.cache.get(player.voiceChannelId)
-                : undefined
-            const otherName =
-                otherVc &&
-                "name" in otherVc &&
-                typeof (otherVc as { name: string }).name === "string"
-                    ? (otherVc as { name: string }).name
-                    : "Unknown Channel"
+        if (controlOutcome.kind === "connect_failed") {
             feedbackMessage = await sendChannel.send(
-                `${member}, I'm already playing in another voice channel (${otherName}).`
+                `${member}, I couldn't connect to your voice channel.`
             )
             return
         }
-        client.debug(
-            `[ControlHandler] Player connected status checked/handled for guild ${guildId}.`
-        )
-
-        // 5, 6, 7: Use the centralized handler
-        const result = await handleQueryAndPlay(
-            client,
-            guildId,
-            voiceChannel,
-            sendChannel,
-            content,
-            message.author,
-            player
-        )
+        if (controlOutcome.kind === "wrong_channel") {
+            feedbackMessage = await sendChannel.send(
+                `${member}, I'm already playing in another voice channel (${controlOutcome.otherName}).`
+            )
+            return
+        }
 
         client.debug(
-            `[ControlHandler] handleQueryAndPlay result for guild ${guildId}: Success=${result.success}, Feedback="${result.feedbackText}"`
+            `[ControlHandler] handleQueryAndPlay result for guild ${guildId}: Success=${controlOutcome.result.success}, Feedback="${controlOutcome.result.feedbackText}"`
         )
 
         // Send feedback from the result
-        if (result.feedbackText) {
-            feedbackMessage = await sendChannel.send(result.feedbackText)
+        if (controlOutcome.result.feedbackText) {
+            feedbackMessage = await sendChannel.send(controlOutcome.result.feedbackText)
         }
         // Note: updateControlMessage is called inside handleQueryAndPlay if needed.
     } catch (error: unknown) {

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -36,7 +36,9 @@ import {
 } from "../util/rrqDisconnect.js"
 import { playerBroadcaster } from "../shared/websocket/PlayerBroadcaster.js"
 import { clearPlayerSession, schedulePlayerSessionSave } from "../util/playerSessionPersistence.js"
+import { tryDestroyOrphanGuildPlayer } from "../util/guildPlayerQueueLock.js"
 import { countHumanMembers } from "../util/voiceChannelMembers.js"
+import { playerHasQueueContent } from "../util/playlistQueue.js"
 
 /** Rate-limit `queueUpdate` websocket fan-out on Lavalink position ticks (pause/resume still immediate). */
 const lastQueueUpdateBroadcastAtMs = new Map<string, number>()
@@ -383,25 +385,42 @@ export default async (client: BotClient) => {
                     )
             }
 
-            // Standard player destroy timeout
+            // Standard player destroy timeout — reservation-aware so in-flight search/enqueue
+            // (web dashboard) is not torn down mid-request when the queue just ended.
             client.debug(
                 `[LavaMgrEvents] Setting standard timeout to destroy player ${player.guildId} after queue end.`
             )
+            const queueEndGuildId = player.guildId
             setTimeout(() => {
                 void (async () => {
                     client.debug(
-                        `[LavaMgrEvents] Executing standard queue end timeout check for player ${player.guildId}.`
+                        `[LavaMgrEvents] Executing standard queue end timeout check for player ${queueEndGuildId}.`
                     )
-                    if (player && player.queue.tracks.length === 0 && !player.queue.current) {
-                        client.debug(
-                            `[LavaMgrEvents] Player ${player.guildId} is idle, destroying after queue end timeout.`
-                        )
-                        await player.destroy()
-                    } else {
-                        client.debug(
-                            `[LavaMgrEvents] Player ${player.guildId} has new tracks or state changed, not destroying after standard timeout. Player: ${!!player}, Queue Size: ${player?.queue.tracks.length}, Current: ${!!player?.queue.current}`
-                        )
-                    }
+                    await tryDestroyOrphanGuildPlayer(
+                        queueEndGuildId,
+                        {
+                            hasQueueContent: () => {
+                                const live = client.lavalink.getPlayer(queueEndGuildId)
+                                // Already gone — treat as "has content" so we do not re-destroy.
+                                if (!live) return true
+                                return playerHasQueueContent(live)
+                            },
+                            destroyPlayer: async () => {
+                                const live = client.lavalink.getPlayer(queueEndGuildId)
+                                if (!live || playerHasQueueContent(live)) {
+                                    client.debug(
+                                        `[LavaMgrEvents] Player ${queueEndGuildId} has new tracks or state changed, not destroying after standard timeout.`
+                                    )
+                                    return
+                                }
+                                client.debug(
+                                    `[LavaMgrEvents] Player ${queueEndGuildId} is idle, destroying after queue end timeout.`
+                                )
+                                await live.destroy()
+                            },
+                        },
+                        0
+                    )
                 })()
             }, 5000)
         })

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -35,7 +35,11 @@ import {
     userHasQueuedTracks,
 } from "../util/rrqDisconnect.js"
 import { playerBroadcaster } from "../shared/websocket/PlayerBroadcaster.js"
-import { clearPlayerSession, schedulePlayerSessionSave } from "../util/playerSessionPersistence.js"
+import {
+    clearPlayerSession,
+    schedulePlayerSessionSave,
+    shouldClearPlayerSessionOnDestroy,
+} from "../util/playerSessionPersistence.js"
 import { tryDestroyOrphanGuildPlayer } from "../util/guildPlayerQueueLock.js"
 import { countHumanMembers } from "../util/voiceChannelMembers.js"
 import { playerHasQueueContent } from "../util/playlistQueue.js"
@@ -118,12 +122,18 @@ export default async (client: BotClient) => {
             )
             lastQueueUpdateBroadcastAtMs.delete(player.guildId)
             player.set(DASHBOARD_REQUESTER_KEY, undefined)
-            void clearPlayerSession(player.guildId).catch((err: unknown) => {
-                const msg = err instanceof Error ? err.message : String(err)
-                client.error(
-                    `[LavaMgrEvents] clearPlayerSession failed (guildId=${player.guildId}): ${msg}`
+            if (shouldClearPlayerSessionOnDestroy(reason)) {
+                void clearPlayerSession(player.guildId).catch((err: unknown) => {
+                    const msg = err instanceof Error ? err.message : String(err)
+                    client.error(
+                        `[LavaMgrEvents] clearPlayerSession failed (guildId=${player.guildId}): ${msg}`
+                    )
+                })
+            } else {
+                client.debug(
+                    `[LavaMgrEvents] Preserving player session for guild ${player.guildId} after destroy reason: ${String(reason)}`
                 )
-            })
+            }
             scheduleControlMessageUpdate(client, player.guildId, "playerDestroy")
             playerBroadcaster.broadcastPlayerEvent(player.guildId, null, "playerDestroy")
         })

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -43,6 +43,7 @@ import {
 import { tryDestroyOrphanGuildPlayer } from "../util/guildPlayerQueueLock.js"
 import { countHumanMembers } from "../util/voiceChannelMembers.js"
 import { playerHasQueueContent } from "../util/playlistQueue.js"
+import { skipCurrentTrack } from "../util/skipCurrentTrack.js"
 
 /** Rate-limit `queueUpdate` websocket fan-out on Lavalink position ticks (pause/resume still immediate). */
 const lastQueueUpdateBroadcastAtMs = new Map<string, number>()
@@ -275,7 +276,15 @@ export default async (client: BotClient) => {
             client.debug(
                 `[LavaMgrEvents] Attempting to skip stuck track in guild ${player.guildId}.`
             )
-            await player.skip()
+            try {
+                // Default skip() throws when upcoming queue is empty (e.g. last/autoplay track).
+                await skipCurrentTrack(player)
+            } catch (e: unknown) {
+                client.error(
+                    `[LavaMgrEvents] Failed to skip stuck track in guild ${player.guildId}:`,
+                    e
+                )
+            }
         })
         .on(
             "trackError",

--- a/src/events/lavaManagerEvents.ts
+++ b/src/events/lavaManagerEvents.ts
@@ -370,12 +370,55 @@ export default async (client: BotClient) => {
                     `[LavaMgrEvents] Attempting to skip track after error in guild ${player.guildId}.`
                 )
                 if (player.queue.tracks.length > 0) {
-                    await player.skip()
-                } else {
+                    try {
+                        await skipCurrentTrack(player)
+                    } catch (e: unknown) {
+                        client.error(
+                            `[LavaMgrEvents] Failed to skip after track error in guild ${player.guildId}:`,
+                            e
+                        )
+                    }
+                } else if (player.get("autoplay") === true) {
+                    // Library trackError does not advance to queueEnd; ending the current track
+                    // lets onEmptyQueue.autoPlayFunction run instead of wiping the session.
                     client.debug(
-                        `[LavaMgrEvents] Queue is empty, not skipping after error in guild ${player.guildId}.`
+                        `[LavaMgrEvents] Queue empty with autoplay on; ending current track for guild ${player.guildId}.`
                     )
-                    await player.destroy()
+                    try {
+                        await skipCurrentTrack(player)
+                    } catch (e: unknown) {
+                        client.error(
+                            `[LavaMgrEvents] Failed to end track for autoplay after error in guild ${player.guildId}:`,
+                            e
+                        )
+                    }
+                } else {
+                    // Reservation-aware: in-flight dashboard search/enqueue must not be destroyed.
+                    const trackErrorGuildId = player.guildId
+                    client.debug(
+                        `[LavaMgrEvents] Queue is empty after track error in guild ${trackErrorGuildId}; attempting reservation-aware destroy.`
+                    )
+                    await tryDestroyOrphanGuildPlayer(
+                        trackErrorGuildId,
+                        {
+                            hasQueueContent: () => {
+                                const live = client.lavalink.getPlayer(trackErrorGuildId)
+                                if (!live) return true
+                                return playerHasQueueContent(live)
+                            },
+                            destroyPlayer: async () => {
+                                const live = client.lavalink.getPlayer(trackErrorGuildId)
+                                if (!live || playerHasQueueContent(live)) {
+                                    client.debug(
+                                        `[LavaMgrEvents] Player ${trackErrorGuildId} regained queue content after track error; not destroying.`
+                                    )
+                                    return
+                                }
+                                await live.destroy()
+                            },
+                        },
+                        0
+                    )
                 }
             }
         )
@@ -462,53 +505,86 @@ export default async (client: BotClient) => {
             client.debug(
                 `[LavaMgrEvents] User left player's channel: Guild ${player.guildId}, User: ${userId}`
             )
+            const aloneGuildId = player.guildId
             const voiceChannel = player.voiceChannelId
                 ? client.channels.cache.get(player.voiceChannelId)
                 : undefined
             if (voiceChannel) {
                 client.debug(
-                    `[LavaMgrEvents] Setting timeout to check if bot is alone in VC ${player.voiceChannelId} for guild ${player.guildId}.`
+                    `[LavaMgrEvents] Setting timeout to check if bot is alone in VC ${player.voiceChannelId} for guild ${aloneGuildId}.`
                 )
                 setTimeout(async () => {
                     client.debug(
-                        `[LavaMgrEvents] Executing check if bot is alone for player ${player.guildId}.`
+                        `[LavaMgrEvents] Executing check if bot is alone for player ${aloneGuildId}.`
                     )
                     try {
-                        const vcId = player.voiceChannelId
-                        if (!vcId) return
+                        const livePlayer = client.lavalink.getPlayer(aloneGuildId)
+                        const vcId = livePlayer?.voiceChannelId
+                        if (!livePlayer || !vcId) return
                         const updatedVoiceChannel = await client.channels
                             .fetch(vcId)
                             .catch(() => null)
                         if (updatedVoiceChannel && updatedVoiceChannel.isVoiceBased()) {
                             const humanCount = countHumanMembers(updatedVoiceChannel)
                             client.debug(
-                                `[LavaMgrEvents] Current human member count in VC ${player.voiceChannelId}: ${humanCount}`
-                            ) // Log count
+                                `[LavaMgrEvents] Current human member count in VC ${vcId}: ${humanCount}`
+                            )
                             if (humanCount === 0) {
                                 client.info(
-                                    `[LavaMgrEvents] Destroying player in Guild ${player.guildId} as bot is alone.`
+                                    `[LavaMgrEvents] Bot alone in Guild ${aloneGuildId}; reservation-aware destroy.`
                                 )
-                                await updateControlMessage(client, player.guildId).catch(
-                                    (ctrlErr: unknown) => {
-                                        const msg =
-                                            ctrlErr instanceof Error
-                                                ? ctrlErr.message
-                                                : String(ctrlErr)
-                                        client.error(
-                                            `[LavaMgrEvents] updateControlMessage failed (beforeDestroyAlone, guildId=${player.guildId}): ${msg}`
-                                        )
-                                    }
+                                // reservedByCaller=0: in-flight search/playlist resolve must finish
+                                // (or defer teardown) instead of being killed mid-request.
+                                await tryDestroyOrphanGuildPlayer(
+                                    aloneGuildId,
+                                    {
+                                        // Alone policy destroys even with queue content; only
+                                        // lifecycle reservations should defer. destroyPlayer
+                                        // re-checks humans so a deferred run after rejoin is safe.
+                                        hasQueueContent: () => false,
+                                        destroyPlayer: async () => {
+                                            const live = client.lavalink.getPlayer(aloneGuildId)
+                                            if (!live) return
+                                            const liveVcId = live.voiceChannelId
+                                            if (!liveVcId) return
+                                            const stillAloneChannel = await client.channels
+                                                .fetch(liveVcId)
+                                                .catch(() => null)
+                                            if (
+                                                !stillAloneChannel ||
+                                                !stillAloneChannel.isVoiceBased() ||
+                                                countHumanMembers(stillAloneChannel) > 0
+                                            ) {
+                                                client.debug(
+                                                    `[LavaMgrEvents] Skipping alone destroy for ${aloneGuildId}; humans present or channel gone.`
+                                                )
+                                                return
+                                            }
+                                            await updateControlMessage(client, aloneGuildId).catch(
+                                                (ctrlErr: unknown) => {
+                                                    const msg =
+                                                        ctrlErr instanceof Error
+                                                            ? ctrlErr.message
+                                                            : String(ctrlErr)
+                                                    client.error(
+                                                        `[LavaMgrEvents] updateControlMessage failed (beforeDestroyAlone, guildId=${aloneGuildId}): ${msg}`
+                                                    )
+                                                }
+                                            )
+                                            await live.destroy()
+                                        },
+                                    },
+                                    0
                                 )
-                                await player.destroy()
                             }
                         } else {
                             client.warn(
-                                `[LavaMgrEvents] Could not verify member count for player ${player.guildId}. Channel ${player.voiceChannelId} not found or not voice-based.`
+                                `[LavaMgrEvents] Could not verify member count for player ${aloneGuildId}. Channel ${vcId} not found or not voice-based.`
                             )
                         }
                     } catch (error: unknown) {
                         client.error(
-                            `[LavaMgrEvents] Error checking channel members for player ${player.guildId}:`,
+                            `[LavaMgrEvents] Error checking channel members for player ${aloneGuildId}:`,
                             error
                         )
                     }

--- a/src/lib/LavalinkManager.ts
+++ b/src/lib/LavalinkManager.ts
@@ -408,6 +408,19 @@ export default function createLavalinkManager(client: BotClient): LavalinkManage
             fallbackSearchEngine: "youtube",
         },
         playerOptions: {
+            // Default destroyPlayer:true wipes persisted sessions on Discord voice drops
+            // (admin Disconnect, voice-server blips). Reconnect instead; failed reconnect
+            // still destroys with PlayerReconnectFail, which we preserve in playerDestroy.
+            onDisconnect: {
+                destroyPlayer: false,
+                autoReconnect: true,
+            },
+            // Default (3 errors / 35s) destroys the whole player before our trackError
+            // handler can skip — clearing the queue and session. threshold 0 disables.
+            maxErrorsPerTime: {
+                threshold: 0,
+                maxAmount: 0,
+            },
             onEmptyQueue: {
                 autoPlayFunction: async (player: Player, endedTrack: Track | undefined) => {
                     try {

--- a/src/lib/botApiPortEnv.test.ts
+++ b/src/lib/botApiPortEnv.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { resolvedBotApiPort } from "./botApiPortEnv.js"
+
+describe("resolvedBotApiPort", () => {
+    it("defaults to 3001 when unset or whitespace", () => {
+        const prev = process.env.BOT_API_PORT
+        try {
+            delete process.env.BOT_API_PORT
+            assert.equal(resolvedBotApiPort(), 3001)
+            process.env.BOT_API_PORT = "   "
+            assert.equal(resolvedBotApiPort(), 3001)
+        } finally {
+            if (prev === undefined) delete process.env.BOT_API_PORT
+            else process.env.BOT_API_PORT = prev
+        }
+    })
+
+    it("accepts integers in 1–65535 and rejects floats, zero, and out-of-range", () => {
+        const prev = process.env.BOT_API_PORT
+        try {
+            process.env.BOT_API_PORT = "1"
+            assert.equal(resolvedBotApiPort(), 1)
+            process.env.BOT_API_PORT = "65535"
+            assert.equal(resolvedBotApiPort(), 65535)
+            process.env.BOT_API_PORT = "8080"
+            assert.equal(resolvedBotApiPort(), 8080)
+
+            process.env.BOT_API_PORT = "0"
+            assert.equal(resolvedBotApiPort(), 3001)
+            process.env.BOT_API_PORT = "65536"
+            assert.equal(resolvedBotApiPort(), 3001)
+            process.env.BOT_API_PORT = "3001.5"
+            assert.equal(resolvedBotApiPort(), 3001)
+            process.env.BOT_API_PORT = "abc"
+            assert.equal(resolvedBotApiPort(), 3001)
+            process.env.BOT_API_PORT = "-1"
+            assert.equal(resolvedBotApiPort(), 3001)
+        } finally {
+            if (prev === undefined) delete process.env.BOT_API_PORT
+            else process.env.BOT_API_PORT = prev
+        }
+    })
+})

--- a/src/lib/errorHistory.test.ts
+++ b/src/lib/errorHistory.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict"
+import { afterEach, beforeEach, describe, it } from "node:test"
+import {
+    captureError,
+    clearErrorHistory,
+    getErrorsByGuild,
+    getRecentErrors,
+} from "./errorHistory.js"
+
+const GUILD_A = "123456789012345678"
+const GUILD_B = "987654321098765432"
+
+describe("errorHistory", () => {
+    beforeEach(() => {
+        clearErrorHistory()
+    })
+
+    afterEach(() => {
+        clearErrorHistory()
+    })
+
+    it("extracts the first Discord snowflake from the message as guildId", () => {
+        captureError("error", `player failed in guild ${GUILD_A} after skip`, 1_000)
+        const [entry] = getRecentErrors(1)
+        assert.equal(entry?.guildId, GUILD_A)
+        assert.equal(entry?.level, "error")
+        assert.equal(entry?.timestamp, 1_000)
+    })
+
+    it("ignores short numeric ids and leaves guildId unset when none match", () => {
+        captureError("warn", "code 404 for user 12345", 2_000)
+        const [entry] = getRecentErrors(1)
+        assert.equal(entry?.guildId, undefined)
+        assert.equal(entry?.level, "warn")
+    })
+
+    it("filters by extracted guildId and returns newest first", () => {
+        captureError("error", `guild ${GUILD_A} first`, 1)
+        captureError("error", `guild ${GUILD_B} only`, 2)
+        captureError("warn", `guild ${GUILD_A} second`, 3)
+
+        const forA = getErrorsByGuild(GUILD_A, 10)
+        assert.equal(forA.length, 2)
+        assert.equal(forA[0]?.timestamp, 3)
+        assert.equal(forA[1]?.timestamp, 1)
+
+        const forB = getErrorsByGuild(GUILD_B, 10)
+        assert.equal(forB.length, 1)
+        assert.equal(forB[0]?.timestamp, 2)
+    })
+
+    it("caps getRecentErrors / getErrorsByGuild limits and clears the buffer", () => {
+        for (let i = 0; i < 5; i++) {
+            captureError("error", `guild ${GUILD_A} n=${i}`, i)
+        }
+        assert.equal(getRecentErrors(2).length, 2)
+        assert.equal(getRecentErrors(0).length, 1)
+        assert.equal(getErrorsByGuild(GUILD_A, 3).length, 3)
+
+        clearErrorHistory()
+        assert.equal(getRecentErrors(10).length, 0)
+        assert.equal(getErrorsByGuild(GUILD_A, 10).length, 0)
+    })
+
+    it("preserves an optional stack on captured entries", () => {
+        captureError("error", "boom", 9, "Error: boom\n    at x")
+        const [entry] = getRecentErrors(1)
+        assert.equal(entry?.stack, "Error: boom\n    at x")
+    })
+})

--- a/src/shared/admin-access-decision.test.ts
+++ b/src/shared/admin-access-decision.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { decideAdminAccess } from "../shared/admin-access-decision.js"
+
+describe("decideAdminAccess", () => {
+    it("returns 503 when session load fails", () => {
+        assert.deepEqual(
+            decideAdminAccess({
+                sessionLoadFailed: true,
+                hasSessionUser: false,
+                discordUserId: null,
+                ownerId: "owner-1",
+            }),
+            {
+                ok: false,
+                status: 503,
+                error: "Service Unavailable",
+                details: "Could not load your session. Please try again later.",
+            }
+        )
+    })
+
+    it("returns 401 without a session user", () => {
+        assert.deepEqual(
+            decideAdminAccess({
+                hasSessionUser: false,
+                discordUserId: null,
+                ownerId: "owner-1",
+            }),
+            { ok: false, status: 401, error: "Unauthorized" }
+        )
+    })
+
+    it("returns 403 when Discord resolution fails or yields no snowflake", () => {
+        assert.equal(
+            decideAdminAccess({
+                hasSessionUser: true,
+                discordResolveFailed: true,
+                discordUserId: null,
+                ownerId: "owner-1",
+            }).ok,
+            false
+        )
+        const missing = decideAdminAccess({
+            hasSessionUser: true,
+            discordUserId: null,
+            ownerId: "owner-1",
+        })
+        assert.equal(missing.ok, false)
+        if (missing.ok) return
+        assert.equal(missing.status, 403)
+        assert.equal(missing.error, "Discord account required")
+    })
+
+    it("returns 403 when OWNER_ID is unset or the caller is not the owner", () => {
+        assert.deepEqual(
+            decideAdminAccess({
+                hasSessionUser: true,
+                discordUserId: "user-2",
+                ownerId: undefined,
+            }),
+            {
+                ok: false,
+                status: 403,
+                error: "Forbidden",
+                details: "Developer access required.",
+            }
+        )
+        assert.deepEqual(
+            decideAdminAccess({
+                hasSessionUser: true,
+                discordUserId: "user-2",
+                ownerId: "owner-1",
+            }),
+            {
+                ok: false,
+                status: 403,
+                error: "Forbidden",
+                details: "Developer access required.",
+            }
+        )
+    })
+
+    it("allows the owner when session and Discord id resolve", () => {
+        assert.deepEqual(
+            decideAdminAccess({
+                hasSessionUser: true,
+                discordUserId: "owner-1",
+                ownerId: "owner-1",
+            }),
+            { ok: true, discordUserId: "owner-1" }
+        )
+    })
+})

--- a/src/shared/admin-access-decision.ts
+++ b/src/shared/admin-access-decision.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure owner-gate decision for dashboard admin routes (no Next.js / Better Auth imports).
+ * Maps session + Discord snowflake + `OWNER_ID` into the same status/error shape as
+ * {@link resolveAdminAccess} in `src/web/lib/admin-access.ts`.
+ */
+export type AdminAccessDecision =
+    | { ok: true; discordUserId: string }
+    | { ok: false; status: number; error: string; details?: string }
+
+export type AdminAccessDecisionInput = {
+    /** Session lookup threw (treat as service unavailable). */
+    sessionLoadFailed?: boolean
+    /** Better Auth session has a user id. */
+    hasSessionUser: boolean
+    /** Discord account resolution threw. */
+    discordResolveFailed?: boolean
+    /** Resolved Discord snowflake, or null when missing. */
+    discordUserId: string | null
+    /** Cached `OWNER_ID` (bot developer). */
+    ownerId: string | null | undefined
+}
+
+/** Decides whether the caller may use developer admin surfaces. */
+export function decideAdminAccess(input: AdminAccessDecisionInput): AdminAccessDecision {
+    if (input.sessionLoadFailed) {
+        return {
+            ok: false,
+            status: 503,
+            error: "Service Unavailable",
+            details: "Could not load your session. Please try again later.",
+        }
+    }
+    if (!input.hasSessionUser) {
+        return { ok: false, status: 401, error: "Unauthorized" }
+    }
+    if (input.discordResolveFailed) {
+        return {
+            ok: false,
+            status: 403,
+            error: "Discord account required",
+            details: "Sign in with Discord, or sign out and sign in again.",
+        }
+    }
+    if (!input.discordUserId) {
+        return {
+            ok: false,
+            status: 403,
+            error: "Discord account required",
+            details:
+                "We could not resolve your Discord user id. Sign in with Discord, or sign out and sign in again.",
+        }
+    }
+    const ownerId = input.ownerId
+    if (!ownerId || input.discordUserId !== ownerId) {
+        return {
+            ok: false,
+            status: 403,
+            error: "Forbidden",
+            details: "Developer access required.",
+        }
+    }
+    return { ok: true, discordUserId: input.discordUserId }
+}

--- a/src/shared/api-auth.ts
+++ b/src/shared/api-auth.ts
@@ -15,6 +15,7 @@ import { auth } from "./auth-node.js"
 import { tryGetBotClient } from "../lib/botClientRegistry.js"
 import { webPlayerDebug, webPlayerWarn } from "./web-player-debug-log.js"
 import { getBotApiOrigin } from "./bot-api-origin.js"
+import { normalizeDashboardPermissionSnapshotResponse } from "./dashboard-permission-snapshot.js"
 
 export interface AuthenticatedSession {
     user: {
@@ -278,115 +279,6 @@ export async function resolveAuthenticatedGuildAccess(
 }
 
 const DASHBOARD_PERM_UPSTREAM_FETCH_MS = 10_000
-
-function snapshotErrorMessageFromPayload(body: Record<string, unknown>): string {
-    if (typeof body.error === "string") return body.error
-    const nested = body.error
-    if (nested && typeof nested === "object" && nested !== null && "error" in nested) {
-        const inner = (nested as { error?: unknown }).error
-        if (typeof inner === "string") return inner
-    }
-    return "Request failed"
-}
-
-function snapshotErrorDetailsFromPayload(body: Record<string, unknown>): string | undefined {
-    if (typeof body.details === "string") return body.details
-    const nested = body.error
-    if (nested && typeof nested === "object" && nested !== null && "details" in nested) {
-        const d = (nested as { details?: unknown }).details
-        if (typeof d === "string") return d
-    }
-    return undefined
-}
-
-/**
- * Maps bot Express JSON (including generic `{ ok: false, error: { error } }` errors) into
- * {@link GuildDashboardSnapshotResult}.
- */
-function normalizeDashboardPermissionSnapshotResponse(
-    parsed: unknown,
-    httpStatus: number
-): GuildDashboardSnapshotResult {
-    if (!parsed || typeof parsed !== "object" || !("ok" in parsed)) {
-        return {
-            ok: false,
-            status: httpStatus >= 400 ? httpStatus : 502,
-            error: "Invalid bot response",
-            details: "The bot API returned an unexpected payload for dashboard permissions.",
-        }
-    }
-    const body = parsed as Record<string, unknown>
-    if (body.ok === false) {
-        const status =
-            typeof body.status === "number" && Number.isFinite(body.status)
-                ? Math.floor(body.status)
-                : httpStatus >= 400
-                  ? httpStatus
-                  : 502
-        return {
-            ok: false,
-            status,
-            error: snapshotErrorMessageFromPayload(body),
-            details: snapshotErrorDetailsFromPayload(body),
-        }
-    }
-    if (body.ok !== true) {
-        return {
-            ok: false,
-            status: 502,
-            error: "Invalid bot response",
-            details: "The bot API returned an unexpected `ok` field for dashboard permissions.",
-        }
-    }
-
-    const discordUserId = body.discordUserId
-    if (typeof discordUserId !== "string") {
-        return {
-            ok: false,
-            status: 502,
-            error: "Invalid bot response",
-            details: "Dashboard permission snapshot is missing `discordUserId`.",
-        }
-    }
-
-    const snap = body.snapshot
-    if (!snap || typeof snap !== "object") {
-        return {
-            ok: false,
-            status: 502,
-            error: "Invalid bot response",
-            details: "Dashboard permission snapshot is missing `snapshot`.",
-        }
-    }
-    const s = snap as Record<string, unknown>
-    const primary = s.primaryPermissions
-    const oauth = s.oauthPermissions
-    const allowedWebPermissions = new Set<string>(Object.values(WebPermission))
-    const isValidPermissionList = (value: unknown): value is string[] =>
-        Array.isArray(value) &&
-        value.every((p) => typeof p === "string" && allowedWebPermissions.has(p))
-    if (!isValidPermissionList(primary) || !isValidPermissionList(oauth)) {
-        return {
-            ok: false,
-            status: 502,
-            error: "Invalid bot response",
-            details: "Dashboard permission snapshot has invalid permission arrays.",
-        }
-    }
-
-    return {
-        ok: true,
-        snapshot: {
-            memberResolved: Boolean(s.memberResolved),
-            primaryPermissions: primary,
-            oauthPermissions: oauth,
-            ...(typeof s.optimisticBotUnavailable === "boolean"
-                ? { optimisticBotUnavailable: s.optimisticBotUnavailable }
-                : {}),
-        },
-        discordUserId,
-    }
-}
 
 /**
  * Resolves primary + OAuth permission lists when a {@link BotClient} is already available (in-process

--- a/src/shared/api-auth.ts
+++ b/src/shared/api-auth.ts
@@ -16,6 +16,7 @@ import { tryGetBotClient } from "../lib/botClientRegistry.js"
 import { webPlayerDebug, webPlayerWarn } from "./web-player-debug-log.js"
 import { getBotApiOrigin } from "./bot-api-origin.js"
 import { normalizeDashboardPermissionSnapshotResponse } from "./dashboard-permission-snapshot.js"
+import { decideAdminAccess } from "./admin-access-decision.js"
 
 export interface AuthenticatedSession {
     user: {
@@ -565,6 +566,7 @@ export async function requireDeveloperAccess(
 
     const resolvedHeaders = asHeaders(headers)
     let discordUserId: string | null
+    let discordResolveFailed = false
     try {
         discordUserId = await resolveDiscordUserSnowflake(
             sessionResult.session.user.id,
@@ -573,36 +575,23 @@ export async function requireDeveloperAccess(
     } catch (error: unknown) {
         const msg = error instanceof Error ? error.message : String(error)
         console.error("[api-auth] requireDeveloperAccess resolveDiscordUserSnowflake failed:", msg)
-        return {
-            ok: false,
-            status: 403,
-            error: "Discord account required",
-            details: "Discord account required — please sign in with Discord or try again.",
-        }
-    }
-    if (!discordUserId) {
-        return {
-            ok: false,
-            status: 403,
-            error: "Discord account required",
-            details:
-                "We could not resolve your Discord user id (needed for roles and voice state). Sign in with Discord, or sign out and sign in again.",
-        }
+        discordUserId = null
+        discordResolveFailed = true
     }
 
-    const ownerId = getCachedOwnerId()
-    if (!ownerId || discordUserId !== ownerId) {
-        return {
-            ok: false,
-            status: 403,
-            error: "Forbidden",
-            details: "Developer access required.",
-        }
+    const decision = decideAdminAccess({
+        hasSessionUser: true,
+        discordResolveFailed,
+        discordUserId,
+        ownerId: getCachedOwnerId(),
+    })
+    if (decision.ok === false) {
+        return decision
     }
 
     return {
         ok: true,
         session: sessionResult.session,
-        discordUserId,
+        discordUserId: decision.discordUserId,
     }
 }

--- a/src/shared/api-auth.ts
+++ b/src/shared/api-auth.ts
@@ -577,8 +577,7 @@ export async function requireDeveloperAccess(
             ok: false,
             status: 403,
             error: "Discord account required",
-            details:
-                "Discord account required — please sign in with Discord or try again.",
+            details: "Discord account required — please sign in with Discord or try again.",
         }
     }
     if (!discordUserId) {

--- a/src/shared/bot-api-origin.test.ts
+++ b/src/shared/bot-api-origin.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { getBotApiOrigin } from "./bot-api-origin.js"
+
+function withEnv(
+    overrides: Record<string, string | undefined>,
+    fn: () => void
+): void {
+    const previous = new Map<string, string | undefined>()
+    for (const key of Object.keys(overrides)) {
+        previous.set(key, process.env[key])
+        const next = overrides[key]
+        if (next === undefined) delete process.env[key]
+        else process.env[key] = next
+    }
+    try {
+        fn()
+    } finally {
+        for (const [key, value] of previous) {
+            if (value === undefined) delete process.env[key]
+            else process.env[key] = value
+        }
+    }
+}
+
+describe("getBotApiOrigin", () => {
+    it("returns null when API_PROXY_TARGET is unset outside development", () => {
+        withEnv({ API_PROXY_TARGET: undefined, NODE_ENV: "production" }, () => {
+            assert.equal(getBotApiOrigin(), null)
+        })
+    })
+
+    it("falls back to localhost and BOT_API_PORT in development when unset", () => {
+        withEnv(
+            { API_PROXY_TARGET: undefined, NODE_ENV: "development", BOT_API_PORT: "4123" },
+            () => {
+                assert.equal(getBotApiOrigin(), "http://localhost:4123")
+            }
+        )
+        withEnv(
+            { API_PROXY_TARGET: "   ", NODE_ENV: "development", BOT_API_PORT: undefined },
+            () => {
+                assert.equal(getBotApiOrigin(), "http://localhost:3001")
+            }
+        )
+    })
+
+    it("accepts http/https origins and strips trailing slashes", () => {
+        withEnv({ API_PROXY_TARGET: "https://bot.example.com/" }, () => {
+            assert.equal(getBotApiOrigin(), "https://bot.example.com")
+        })
+        withEnv({ API_PROXY_TARGET: "http://127.0.0.1:3001///" }, () => {
+            assert.equal(getBotApiOrigin(), "http://127.0.0.1:3001")
+        })
+    })
+
+    it("rejects invalid URLs, non-http protocols, and non-origin shapes", () => {
+        withEnv({ API_PROXY_TARGET: "not a url" }, () => {
+            assert.throws(() => getBotApiOrigin(), /not a valid URL/)
+        })
+        withEnv({ API_PROXY_TARGET: "ftp://bot.example.com" }, () => {
+            assert.throws(() => getBotApiOrigin(), /protocol must be http or https/)
+        })
+        withEnv({ API_PROXY_TARGET: "https://bot.example.com/api" }, () => {
+            assert.throws(() => getBotApiOrigin(), /origin-only URL/)
+        })
+        withEnv({ API_PROXY_TARGET: "https://bot.example.com?x=1" }, () => {
+            assert.throws(() => getBotApiOrigin(), /origin-only URL/)
+        })
+        withEnv({ API_PROXY_TARGET: "https://bot.example.com#frag" }, () => {
+            assert.throws(() => getBotApiOrigin(), /origin-only URL/)
+        })
+        withEnv({ API_PROXY_TARGET: "https://user:pass@bot.example.com" }, () => {
+            assert.throws(() => getBotApiOrigin(), /origin-only URL/)
+        })
+    })
+})

--- a/src/shared/bot-api-origin.test.ts
+++ b/src/shared/bot-api-origin.test.ts
@@ -2,10 +2,7 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 import { getBotApiOrigin } from "./bot-api-origin.js"
 
-function withEnv(
-    overrides: Record<string, string | undefined>,
-    fn: () => void
-): void {
+function withEnv(overrides: Record<string, string | undefined>, fn: () => void): void {
     const previous = new Map<string, string | undefined>()
     for (const key of Object.keys(overrides)) {
         previous.set(key, process.env[key])

--- a/src/shared/bot-api-origin.test.ts
+++ b/src/shared/bot-api-origin.test.ts
@@ -45,11 +45,11 @@ describe("getBotApiOrigin", () => {
         )
     })
 
-    it("accepts http/https origins and strips trailing slashes", () => {
+    it("accepts http/https origins and strips a single trailing slash", () => {
         withEnv({ API_PROXY_TARGET: "https://bot.example.com/" }, () => {
             assert.equal(getBotApiOrigin(), "https://bot.example.com")
         })
-        withEnv({ API_PROXY_TARGET: "http://127.0.0.1:3001///" }, () => {
+        withEnv({ API_PROXY_TARGET: "http://127.0.0.1:3001" }, () => {
             assert.equal(getBotApiOrigin(), "http://127.0.0.1:3001")
         })
     })
@@ -62,6 +62,10 @@ describe("getBotApiOrigin", () => {
             assert.throws(() => getBotApiOrigin(), /protocol must be http or https/)
         })
         withEnv({ API_PROXY_TARGET: "https://bot.example.com/api" }, () => {
+            assert.throws(() => getBotApiOrigin(), /origin-only URL/)
+        })
+        // Extra path slashes parse as pathname "///", not origin-only "/".
+        withEnv({ API_PROXY_TARGET: "http://127.0.0.1:3001///" }, () => {
             assert.throws(() => getBotApiOrigin(), /origin-only URL/)
         })
         withEnv({ API_PROXY_TARGET: "https://bot.example.com?x=1" }, () => {

--- a/src/shared/dashboard-permission-snapshot.test.ts
+++ b/src/shared/dashboard-permission-snapshot.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { WebPermission } from "./permissions.js"
+import { normalizeDashboardPermissionSnapshotResponse } from "./dashboard-permission-snapshot.js"
+
+describe("normalizeDashboardPermissionSnapshotResponse", () => {
+    it("rejects non-object and missing-ok payloads", () => {
+        assert.deepEqual(normalizeDashboardPermissionSnapshotResponse(null, 200), {
+            ok: false,
+            status: 502,
+            error: "Invalid bot response",
+            details: "The bot API returned an unexpected payload for dashboard permissions.",
+        })
+        const missingOk = normalizeDashboardPermissionSnapshotResponse({}, 404)
+        assert.equal(missingOk.ok, false)
+        if (missingOk.ok === false) assert.equal(missingOk.status, 404)
+        assert.equal(normalizeDashboardPermissionSnapshotResponse({ ok: "yes" }, 200).ok, false)
+    })
+
+    it("maps ok:false with nested error shapes and status fallback", () => {
+        assert.deepEqual(
+            normalizeDashboardPermissionSnapshotResponse(
+                {
+                    ok: false,
+                    status: 403.9,
+                    error: { error: "Forbidden", details: "no access" },
+                },
+                200
+            ),
+            {
+                ok: false,
+                status: 403,
+                error: "Forbidden",
+                details: "no access",
+            }
+        )
+        const fromHttp = normalizeDashboardPermissionSnapshotResponse(
+            { ok: false, error: "boom" },
+            503
+        )
+        assert.equal(fromHttp.ok, false)
+        if (fromHttp.ok === false) assert.equal(fromHttp.status, 503)
+        const defaultStatus = normalizeDashboardPermissionSnapshotResponse({ ok: false }, 200)
+        assert.equal(defaultStatus.ok, false)
+        if (defaultStatus.ok === false) assert.equal(defaultStatus.status, 502)
+    })
+
+    it("accepts a valid success snapshot including optimisticBotUnavailable", () => {
+        const result = normalizeDashboardPermissionSnapshotResponse(
+            {
+                ok: true,
+                discordUserId: "123456789012345678",
+                snapshot: {
+                    memberResolved: 1,
+                    primaryPermissions: [WebPermission.VIEW_PLAYER],
+                    oauthPermissions: [WebPermission.MANAGE_QUEUE],
+                    optimisticBotUnavailable: true,
+                },
+            },
+            200
+        )
+        assert.deepEqual(result, {
+            ok: true,
+            discordUserId: "123456789012345678",
+            snapshot: {
+                memberResolved: true,
+                primaryPermissions: [WebPermission.VIEW_PLAYER],
+                oauthPermissions: [WebPermission.MANAGE_QUEUE],
+                optimisticBotUnavailable: true,
+            },
+        })
+    })
+
+    it("rejects missing discordUserId, snapshot, or invalid permission arrays", () => {
+        assert.match(
+            (
+                normalizeDashboardPermissionSnapshotResponse(
+                    { ok: true, snapshot: { primaryPermissions: [], oauthPermissions: [] } },
+                    200
+                ) as { details?: string }
+            ).details ?? "",
+            /discordUserId/
+        )
+        assert.match(
+            (
+                normalizeDashboardPermissionSnapshotResponse(
+                    { ok: true, discordUserId: "1" },
+                    200
+                ) as { details?: string }
+            ).details ?? "",
+            /snapshot/
+        )
+        assert.match(
+            (
+                normalizeDashboardPermissionSnapshotResponse(
+                    {
+                        ok: true,
+                        discordUserId: "1",
+                        snapshot: {
+                            memberResolved: false,
+                            primaryPermissions: ["NOT_A_REAL_PERM"],
+                            oauthPermissions: [],
+                        },
+                    },
+                    200
+                ) as { details?: string }
+            ).details ?? "",
+            /invalid permission arrays/i
+        )
+    })
+})

--- a/src/shared/dashboard-permission-snapshot.ts
+++ b/src/shared/dashboard-permission-snapshot.ts
@@ -39,12 +39,13 @@ export function normalizeDashboardPermissionSnapshotResponse(
     }
     const body = parsed as Record<string, unknown>
     if (body.ok === false) {
-        const status =
+        const statusRaw =
             typeof body.status === "number" && Number.isFinite(body.status)
                 ? Math.floor(body.status)
                 : httpStatus >= 400
                   ? httpStatus
                   : 502
+        const status = statusRaw >= 400 && statusRaw <= 599 ? statusRaw : 502
         return {
             ok: false,
             status,

--- a/src/shared/dashboard-permission-snapshot.ts
+++ b/src/shared/dashboard-permission-snapshot.ts
@@ -1,0 +1,111 @@
+import { WebPermission } from "./permissions.js"
+import type { GuildDashboardSnapshotResult } from "../types/web.js"
+
+function snapshotErrorMessageFromPayload(body: Record<string, unknown>): string {
+    if (typeof body.error === "string") return body.error
+    const nested = body.error
+    if (nested && typeof nested === "object" && nested !== null && "error" in nested) {
+        const inner = (nested as { error?: unknown }).error
+        if (typeof inner === "string") return inner
+    }
+    return "Request failed"
+}
+
+function snapshotErrorDetailsFromPayload(body: Record<string, unknown>): string | undefined {
+    if (typeof body.details === "string") return body.details
+    const nested = body.error
+    if (nested && typeof nested === "object" && nested !== null && "details" in nested) {
+        const d = (nested as { details?: unknown }).details
+        if (typeof d === "string") return d
+    }
+    return undefined
+}
+
+/**
+ * Maps bot Express JSON (including generic `{ ok: false, error: { error } }` errors) into
+ * {@link GuildDashboardSnapshotResult}.
+ */
+export function normalizeDashboardPermissionSnapshotResponse(
+    parsed: unknown,
+    httpStatus: number
+): GuildDashboardSnapshotResult {
+    if (!parsed || typeof parsed !== "object" || !("ok" in parsed)) {
+        return {
+            ok: false,
+            status: httpStatus >= 400 ? httpStatus : 502,
+            error: "Invalid bot response",
+            details: "The bot API returned an unexpected payload for dashboard permissions.",
+        }
+    }
+    const body = parsed as Record<string, unknown>
+    if (body.ok === false) {
+        const status =
+            typeof body.status === "number" && Number.isFinite(body.status)
+                ? Math.floor(body.status)
+                : httpStatus >= 400
+                  ? httpStatus
+                  : 502
+        return {
+            ok: false,
+            status,
+            error: snapshotErrorMessageFromPayload(body),
+            details: snapshotErrorDetailsFromPayload(body),
+        }
+    }
+    if (body.ok !== true) {
+        return {
+            ok: false,
+            status: 502,
+            error: "Invalid bot response",
+            details: "The bot API returned an unexpected `ok` field for dashboard permissions.",
+        }
+    }
+
+    const discordUserId = body.discordUserId
+    if (typeof discordUserId !== "string") {
+        return {
+            ok: false,
+            status: 502,
+            error: "Invalid bot response",
+            details: "Dashboard permission snapshot is missing `discordUserId`.",
+        }
+    }
+
+    const snap = body.snapshot
+    if (!snap || typeof snap !== "object") {
+        return {
+            ok: false,
+            status: 502,
+            error: "Invalid bot response",
+            details: "Dashboard permission snapshot is missing `snapshot`.",
+        }
+    }
+    const s = snap as Record<string, unknown>
+    const primary = s.primaryPermissions
+    const oauth = s.oauthPermissions
+    const allowedWebPermissions = new Set<string>(Object.values(WebPermission))
+    const isValidPermissionList = (value: unknown): value is string[] =>
+        Array.isArray(value) &&
+        value.every((p) => typeof p === "string" && allowedWebPermissions.has(p))
+    if (!isValidPermissionList(primary) || !isValidPermissionList(oauth)) {
+        return {
+            ok: false,
+            status: 502,
+            error: "Invalid bot response",
+            details: "Dashboard permission snapshot has invalid permission arrays.",
+        }
+    }
+
+    return {
+        ok: true,
+        snapshot: {
+            memberResolved: Boolean(s.memberResolved),
+            primaryPermissions: primary,
+            oauthPermissions: oauth,
+            ...(typeof s.optimisticBotUnavailable === "boolean"
+                ? { optimisticBotUnavailable: s.optimisticBotUnavailable }
+                : {}),
+        },
+        discordUserId,
+    }
+}

--- a/src/shared/dashboard-web-permission.test.ts
+++ b/src/shared/dashboard-web-permission.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { WebPermission } from "./permissions.js"
+import {
+    dashboardHasAllWebPermissions,
+    dashboardHasWebPermission,
+    explainDashboardWebPermission,
+} from "./dashboard-web-permission.js"
+
+describe("dashboard web permission merge", () => {
+    it("allows from primaryPermissions regardless of memberResolved", () => {
+        const snapshot = {
+            memberResolved: true,
+            primaryPermissions: [WebPermission.CONTROL_PLAYBACK],
+            oauthPermissions: [],
+        }
+        assert.equal(
+            dashboardHasWebPermission(snapshot, WebPermission.CONTROL_PLAYBACK),
+            true
+        )
+        assert.equal(
+            explainDashboardWebPermission(snapshot, WebPermission.CONTROL_PLAYBACK),
+            "allow:primaryPermissions"
+        )
+    })
+
+    it("allows OAuth fallback only when the bot has not resolved a member", () => {
+        const unresolved = {
+            memberResolved: false,
+            primaryPermissions: [],
+            oauthPermissions: [WebPermission.MANAGE_QUEUE],
+        }
+        assert.equal(dashboardHasWebPermission(unresolved, WebPermission.MANAGE_QUEUE), true)
+        assert.match(
+            explainDashboardWebPermission(unresolved, WebPermission.MANAGE_QUEUE),
+            /oauthPermissions/
+        )
+
+        const resolved = {
+            memberResolved: true,
+            primaryPermissions: [],
+            oauthPermissions: [WebPermission.MANAGE_QUEUE],
+        }
+        assert.equal(dashboardHasWebPermission(resolved, WebPermission.MANAGE_QUEUE), false)
+        assert.match(
+            explainDashboardWebPermission(resolved, WebPermission.MANAGE_QUEUE),
+            /memberResolved=true/
+        )
+    })
+
+    it("denies when neither list includes the permission", () => {
+        const snapshot = {
+            memberResolved: false,
+            primaryPermissions: [WebPermission.VIEW_PLAYER],
+            oauthPermissions: [],
+        }
+        assert.equal(dashboardHasWebPermission(snapshot, WebPermission.MANAGE_QUEUE), false)
+        assert.match(
+            explainDashboardWebPermission(snapshot, WebPermission.MANAGE_QUEUE),
+            /neither primary nor oauth/
+        )
+    })
+
+    it("requires every permission for dashboardHasAllWebPermissions", () => {
+        const snapshot = {
+            memberResolved: false,
+            primaryPermissions: [WebPermission.VIEW_PLAYER],
+            oauthPermissions: [WebPermission.MANAGE_QUEUE],
+        }
+        assert.equal(
+            dashboardHasAllWebPermissions(snapshot, [
+                WebPermission.VIEW_PLAYER,
+                WebPermission.MANAGE_QUEUE,
+            ]),
+            true
+        )
+        assert.equal(
+            dashboardHasAllWebPermissions(snapshot, [
+                WebPermission.VIEW_PLAYER,
+                WebPermission.CONTROL_PLAYBACK,
+            ]),
+            false
+        )
+    })
+})

--- a/src/shared/dashboard-web-permission.test.ts
+++ b/src/shared/dashboard-web-permission.test.ts
@@ -14,10 +14,7 @@ describe("dashboard web permission merge", () => {
             primaryPermissions: [WebPermission.CONTROL_PLAYBACK],
             oauthPermissions: [],
         }
-        assert.equal(
-            dashboardHasWebPermission(snapshot, WebPermission.CONTROL_PLAYBACK),
-            true
-        )
+        assert.equal(dashboardHasWebPermission(snapshot, WebPermission.CONTROL_PLAYBACK), true)
         assert.equal(
             explainDashboardWebPermission(snapshot, WebPermission.CONTROL_PLAYBACK),
             "allow:primaryPermissions"

--- a/src/shared/dashboard-web-permission.ts
+++ b/src/shared/dashboard-web-permission.ts
@@ -1,0 +1,68 @@
+import type { GuildDashboardPermissionSnapshot } from "../types/web.js"
+
+type WebPermissionDecision =
+    | { allowed: true; reason: string; memberResolved: boolean }
+    | { allowed: false; reason: string; memberResolved: boolean }
+
+/**
+ * Shared primary vs OAuth-fallback rules for dashboard gating (matches {@link requirePermissions}).
+ * Pure helper — callers may add tracing around denials.
+ */
+export function resolveWebPermissionDecision(
+    snapshot: GuildDashboardPermissionSnapshot,
+    perm: string
+): WebPermissionDecision {
+    if (snapshot.primaryPermissions.includes(perm)) {
+        return {
+            allowed: true,
+            reason: "allow:primaryPermissions",
+            memberResolved: snapshot.memberResolved,
+        }
+    }
+    if (!snapshot.memberResolved && snapshot.oauthPermissions.includes(perm)) {
+        return {
+            allowed: true,
+            reason: "allow:oauthPermissions (member not resolved by bot)",
+            memberResolved: snapshot.memberResolved,
+        }
+    }
+    if (snapshot.memberResolved) {
+        return {
+            allowed: false,
+            reason: `deny:memberResolved=true but primaryPermissions lacks "${perm}" (OAuth fallback is not used when the bot resolved a member)`,
+            memberResolved: true,
+        }
+    }
+    return {
+        allowed: false,
+        reason: `deny:neither primary nor oauth lists include "${perm}"`,
+        memberResolved: false,
+    }
+}
+
+/** Human-readable reason for {@link dashboardHasWebPermission} (for troubleshooting). */
+export function explainDashboardWebPermission(
+    snapshot: GuildDashboardPermissionSnapshot,
+    perm: string
+): string {
+    return resolveWebPermissionDecision(snapshot, perm).reason
+}
+
+/**
+ * Whether the user may perform an action that the bot API would allow, using the same primary vs
+ * OAuth-fallback merge as {@link requirePermissions}.
+ */
+export function dashboardHasWebPermission(
+    snapshot: GuildDashboardPermissionSnapshot,
+    perm: string
+): boolean {
+    return resolveWebPermissionDecision(snapshot, perm).allowed
+}
+
+/** True if every listed permission is satisfied (AND). */
+export function dashboardHasAllWebPermissions(
+    snapshot: GuildDashboardPermissionSnapshot,
+    perms: string[]
+): boolean {
+    return perms.every((perm) => dashboardHasWebPermission(snapshot, perm))
+}

--- a/src/shared/discord-user-id.test.ts
+++ b/src/shared/discord-user-id.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { isDiscordSnowflake } from "./discord-user-id.js"
+
+describe("isDiscordSnowflake", () => {
+    it("accepts typical Discord snowflakes after trim", () => {
+        assert.equal(isDiscordSnowflake("12345678901234567"), true) // 17
+        assert.equal(isDiscordSnowflake("123456789012345678"), true) // 18
+        assert.equal(isDiscordSnowflake("1234567890123456789"), true) // 19
+        assert.equal(isDiscordSnowflake("1234567890123456789012"), true) // 22
+        assert.equal(isDiscordSnowflake("  123456789012345678  "), true)
+    })
+
+    it("rejects too-short, too-long, non-digit, and empty values", () => {
+        assert.equal(isDiscordSnowflake("1234567890123456"), false) // 16
+        assert.equal(isDiscordSnowflake("12345678901234567890123"), false) // 23
+        assert.equal(isDiscordSnowflake("12345678901234567a"), false)
+        assert.equal(isDiscordSnowflake("not-a-snowflake"), false)
+        assert.equal(isDiscordSnowflake(""), false)
+        assert.equal(isDiscordSnowflake("   "), false)
+    })
+})

--- a/src/shared/permissions.test.ts
+++ b/src/shared/permissions.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict"
+import { afterEach, describe, it } from "node:test"
+import {
+    WebPermission,
+    hasRequiredPermissions,
+    invalidatePermissionCache,
+    resolveOauthGuildPermissionFallback,
+    resolveUserPermissions,
+} from "./permissions.js"
+
+type MockVoiceState = { channelId?: string | null; member?: unknown }
+
+/** Minimal Lavalink player shape accepted by `isPlayer` / voice summary. */
+function mockLavalinkPlayer(voiceChannelId: string | null, guildId = "guild-1") {
+    return {
+        guildId,
+        voiceChannelId,
+        playing: false,
+        queue: { tracks: [] as unknown[] },
+        get: () => undefined,
+    }
+}
+
+function mockPermissionClient(opts: {
+    guildId: string
+    ownerId?: string
+    voiceStates?: Map<string, MockVoiceState>
+    /** When set (including null), returned from lavalink.getPlayer as an isPlayer-shaped object. */
+    playerVoiceChannelId?: string | null
+    meVoiceChannelId?: string | null
+    memberFetch?: (userId: string) => Promise<unknown>
+}) {
+    const voiceStates = opts.voiceStates ?? new Map<string, MockVoiceState>()
+    return {
+        guilds: {
+            cache: new Map([
+                [
+                    opts.guildId,
+                    {
+                        ownerId: opts.ownerId ?? "owner-1",
+                        voiceStates: { cache: voiceStates },
+                        members: {
+                            me:
+                                opts.meVoiceChannelId !== undefined
+                                    ? { voice: { channelId: opts.meVoiceChannelId } }
+                                    : undefined,
+                            fetch:
+                                opts.memberFetch ??
+                                (async () => {
+                                    return null
+                                }),
+                        },
+                    },
+                ],
+            ]),
+        },
+        lavalink: {
+            getPlayer: (guildId: string) => {
+                if (guildId !== opts.guildId) return null
+                if (opts.playerVoiceChannelId === undefined) return null
+                return mockLavalinkPlayer(opts.playerVoiceChannelId, opts.guildId)
+            },
+        },
+    }
+}
+
+afterEach(() => {
+    invalidatePermissionCache()
+})
+
+describe("hasRequiredPermissions", () => {
+    it("allows empty required lists and rejects missing capabilities", () => {
+        assert.equal(hasRequiredPermissions([], []), true)
+        assert.equal(hasRequiredPermissions([WebPermission.VIEW_PLAYER], []), true)
+        assert.equal(
+            hasRequiredPermissions(
+                [WebPermission.VIEW_PLAYER, WebPermission.MANAGE_QUEUE],
+                [WebPermission.VIEW_PLAYER]
+            ),
+            true
+        )
+        assert.equal(
+            hasRequiredPermissions([WebPermission.VIEW_PLAYER], [WebPermission.CONTROL_PLAYBACK]),
+            false
+        )
+        assert.equal(
+            hasRequiredPermissions(
+                [WebPermission.VIEW_PLAYER],
+                [WebPermission.VIEW_PLAYER, WebPermission.MANAGE_QUEUE]
+            ),
+            false
+        )
+    })
+})
+
+describe("resolveOauthGuildPermissionFallback", () => {
+    const guildId = "guild-1"
+    const userId = "user-1"
+
+    it("grants VIEW_PLAYER only when client or guild is missing", () => {
+        assert.deepEqual(resolveOauthGuildPermissionFallback(null, guildId, userId), {
+            permissions: [WebPermission.VIEW_PLAYER],
+            inVoiceWithBot: false,
+        })
+
+        const client = mockPermissionClient({ guildId: "other-guild" })
+        assert.deepEqual(resolveOauthGuildPermissionFallback(client, guildId, userId), {
+            permissions: [WebPermission.VIEW_PLAYER],
+            inVoiceWithBot: false,
+        })
+    })
+
+    it("keeps queue ability when user is in voice and bot is not", () => {
+        const client = mockPermissionClient({
+            guildId,
+            voiceStates: new Map([[userId, { channelId: "vc-user" }]]),
+            playerVoiceChannelId: null,
+        })
+        const result = resolveOauthGuildPermissionFallback(client, guildId, userId)
+        assert.equal(result.inVoiceWithBot, false)
+        assert.deepEqual(result.permissions, [
+            WebPermission.VIEW_PLAYER,
+            WebPermission.MANAGE_QUEUE,
+        ])
+        assert.equal(result.permissions.includes(WebPermission.CONTROL_PLAYBACK), false)
+        assert.equal(result.permissions.includes(WebPermission.MANAGE_GUILD_SETTINGS), false)
+    })
+
+    it("grants playback and queue when user shares the bot voice channel", () => {
+        const client = mockPermissionClient({
+            guildId,
+            voiceStates: new Map([[userId, { channelId: "vc-1" }]]),
+            playerVoiceChannelId: "vc-1",
+        })
+        const result = resolveOauthGuildPermissionFallback(client, guildId, userId)
+        assert.equal(result.inVoiceWithBot, true)
+        assert.deepEqual(result.permissions, [
+            WebPermission.VIEW_PLAYER,
+            WebPermission.CONTROL_PLAYBACK,
+            WebPermission.MANAGE_QUEUE,
+        ])
+    })
+
+    it("strips voice-gated perms when user is in a different voice channel", () => {
+        const client = mockPermissionClient({
+            guildId,
+            voiceStates: new Map([[userId, { channelId: "vc-other" }]]),
+            playerVoiceChannelId: "vc-1",
+        })
+        const result = resolveOauthGuildPermissionFallback(client, guildId, userId)
+        assert.equal(result.inVoiceWithBot, false)
+        assert.deepEqual(result.permissions, [WebPermission.VIEW_PLAYER])
+    })
+
+    it("strips voice-gated perms when user is not in voice", () => {
+        const client = mockPermissionClient({
+            guildId,
+            voiceStates: new Map(),
+            playerVoiceChannelId: "vc-1",
+        })
+        const result = resolveOauthGuildPermissionFallback(client, guildId, userId)
+        assert.equal(result.inVoiceWithBot, false)
+        assert.deepEqual(result.permissions, [WebPermission.VIEW_PLAYER])
+    })
+})
+
+describe("resolveUserPermissions", () => {
+    const guildId = "guild-1"
+    const ownerId = "owner-1"
+
+    it("returns empty permissions when the guild is not cached", async () => {
+        const client = mockPermissionClient({ guildId: "other" })
+        const result = await resolveUserPermissions(client, guildId, ownerId)
+        assert.deepEqual(result, { permissions: [], inVoiceWithBot: false })
+    })
+
+    it("grants guild-owner capabilities without member fetch", async () => {
+        const client = mockPermissionClient({
+            guildId,
+            ownerId,
+            voiceStates: new Map([[ownerId, { channelId: "vc-1" }]]),
+            playerVoiceChannelId: "vc-1",
+        })
+        const result = await resolveUserPermissions(client, guildId, ownerId)
+        assert.equal(result.inVoiceWithBot, true)
+        assert.deepEqual(result.permissions, [
+            WebPermission.VIEW_PLAYER,
+            WebPermission.CONTROL_PLAYBACK,
+            WebPermission.MANAGE_QUEUE,
+            WebPermission.MANAGE_GUILD_SETTINGS,
+            WebPermission.MANAGE_MESSAGES,
+        ])
+        assert.equal(result.permissions.includes(WebPermission.DEVELOPER_ACCESS), false)
+    })
+
+    it("skips voice gating for dashboard entitlement reads", async () => {
+        const client = mockPermissionClient({
+            guildId,
+            ownerId,
+            voiceStates: new Map(),
+            playerVoiceChannelId: "vc-1",
+        })
+        const result = await resolveUserPermissions(client, guildId, ownerId, {
+            applyVoiceGating: false,
+        })
+        assert.equal(result.inVoiceWithBot, false)
+        assert.deepEqual(result.permissions, [
+            WebPermission.VIEW_PLAYER,
+            WebPermission.CONTROL_PLAYBACK,
+            WebPermission.MANAGE_QUEUE,
+            WebPermission.MANAGE_GUILD_SETTINGS,
+            WebPermission.MANAGE_MESSAGES,
+        ])
+    })
+
+    it("returns empty when non-owner member cannot be resolved", async () => {
+        const client = mockPermissionClient({
+            guildId,
+            ownerId,
+            memberFetch: async () => null,
+        })
+        const result = await resolveUserPermissions(client, guildId, "member-2")
+        assert.deepEqual(result, { permissions: [], inVoiceWithBot: false })
+    })
+})
+
+describe("invalidatePermissionCache", () => {
+    it("clears cached voice-gated resolutions so later reads recompute", async () => {
+        const guildId = "guild-cache"
+        const ownerId = "owner-cache"
+        const voiceStates = new Map<string, MockVoiceState>([
+            [ownerId, { channelId: "vc-1" }],
+        ])
+        const client = mockPermissionClient({
+            guildId,
+            ownerId,
+            voiceStates,
+            playerVoiceChannelId: "vc-1",
+        })
+
+        const first = await resolveUserPermissions(client, guildId, ownerId)
+        assert.equal(first.inVoiceWithBot, true)
+        assert.equal(first.permissions.includes(WebPermission.CONTROL_PLAYBACK), true)
+
+        voiceStates.set(ownerId, { channelId: "vc-other" })
+        const stale = await resolveUserPermissions(client, guildId, ownerId)
+        assert.equal(stale.inVoiceWithBot, true, "TTL cache should still serve pre-move voice state")
+
+        invalidatePermissionCache(guildId)
+        const refreshed = await resolveUserPermissions(client, guildId, ownerId)
+        assert.equal(refreshed.inVoiceWithBot, false)
+        assert.equal(refreshed.permissions.includes(WebPermission.CONTROL_PLAYBACK), false)
+    })
+})

--- a/src/shared/permissions.test.ts
+++ b/src/shared/permissions.test.ts
@@ -231,9 +231,7 @@ describe("invalidatePermissionCache", () => {
     it("clears cached voice-gated resolutions so later reads recompute", async () => {
         const guildId = "guild-cache"
         const ownerId = "owner-cache"
-        const voiceStates = new Map<string, MockVoiceState>([
-            [ownerId, { channelId: "vc-1" }],
-        ])
+        const voiceStates = new Map<string, MockVoiceState>([[ownerId, { channelId: "vc-1" }]])
         const client = mockPermissionClient({
             guildId,
             ownerId,
@@ -247,7 +245,11 @@ describe("invalidatePermissionCache", () => {
 
         voiceStates.set(ownerId, { channelId: "vc-other" })
         const stale = await resolveUserPermissions(client, guildId, ownerId)
-        assert.equal(stale.inVoiceWithBot, true, "TTL cache should still serve pre-move voice state")
+        assert.equal(
+            stale.inVoiceWithBot,
+            true,
+            "TTL cache should still serve pre-move voice state"
+        )
 
         invalidatePermissionCache(guildId)
         const refreshed = await resolveUserPermissions(client, guildId, ownerId)

--- a/src/shared/permissions.test.ts
+++ b/src/shared/permissions.test.ts
@@ -21,6 +21,9 @@ function mockLavalinkPlayer(voiceChannelId: string | null, guildId = "guild-1") 
     }
 }
 
+/** Duck-typed client accepted by permission helpers (avoids full discord.js GuildMemberManager). */
+type MockPermissionClient = NonNullable<Parameters<typeof resolveOauthGuildPermissionFallback>[0]>
+
 function mockPermissionClient(opts: {
     guildId: string
     ownerId?: string
@@ -29,7 +32,7 @@ function mockPermissionClient(opts: {
     playerVoiceChannelId?: string | null
     meVoiceChannelId?: string | null
     memberFetch?: (userId: string) => Promise<unknown>
-}) {
+}): MockPermissionClient {
     const voiceStates = opts.voiceStates ?? new Map<string, MockVoiceState>()
     return {
         guilds: {
@@ -61,7 +64,7 @@ function mockPermissionClient(opts: {
                 return mockLavalinkPlayer(opts.playerVoiceChannelId, opts.guildId)
             },
         },
-    }
+    } as unknown as MockPermissionClient
 }
 
 afterEach(() => {

--- a/src/shared/player-state.test.ts
+++ b/src/shared/player-state.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    isPlayer,
+    resolveBotVoiceChannelId,
+    snapshotGuildListPlayer,
+    summarizeVoiceForWeb,
+} from "./player-state.js"
+
+function mockPlayer(opts: {
+    guildId?: string
+    voiceChannelId?: string | null
+    playing?: boolean
+    paused?: boolean
+    tracks?: unknown[]
+    current?: { info?: { title?: string; author?: string } } | null
+}) {
+    return {
+        get: () => undefined,
+        guildId: opts.guildId ?? "guild-1",
+        voiceChannelId: opts.voiceChannelId === undefined ? "vc-bot" : opts.voiceChannelId,
+        playing: opts.playing ?? false,
+        paused: opts.paused ?? false,
+        queue: {
+            tracks: opts.tracks ?? [],
+            current: opts.current ?? null,
+        },
+    }
+}
+
+function mockClient(opts: {
+    guildId?: string
+    botChannelId?: string | null
+    userId?: string
+    userChannelId?: string | null
+}) {
+    const guildId = opts.guildId ?? "guild-1"
+    const voiceStates = new Map<string, { channelId?: string | null }>()
+    if (opts.userId) {
+        voiceStates.set(opts.userId, { channelId: opts.userChannelId ?? null })
+    }
+    const guild = {
+        members: {
+            me: { voice: { channelId: opts.botChannelId ?? null } },
+        },
+        voiceStates: { cache: voiceStates },
+    }
+    return {
+        guilds: {
+            cache: new Map([[guildId, guild]]),
+        },
+    }
+}
+
+describe("isPlayer", () => {
+    it("accepts a minimal Lavalink-shaped player", () => {
+        assert.equal(isPlayer(mockPlayer({})), true)
+    })
+
+    it("rejects missing get, queue.tracks, playing, or guildId", () => {
+        assert.equal(isPlayer(null), false)
+        assert.equal(isPlayer({ queue: { tracks: [] }, playing: false, guildId: "g" }), false)
+        assert.equal(
+            isPlayer({ get: () => undefined, queue: {}, playing: false, guildId: "g" }),
+            false
+        )
+        assert.equal(
+            isPlayer({
+                get: () => undefined,
+                queue: { tracks: [] },
+                playing: "yes",
+                guildId: "g",
+            }),
+            false
+        )
+        assert.equal(
+            isPlayer({
+                get: () => undefined,
+                queue: { tracks: [] },
+                playing: false,
+                guildId: 1,
+            }),
+            false
+        )
+        assert.equal(
+            isPlayer({
+                get: () => undefined,
+                queue: { tracks: [] },
+                playing: false,
+                guildId: "g",
+                node: null,
+            }),
+            false
+        )
+    })
+})
+
+describe("resolveBotVoiceChannelId", () => {
+    it("prefers Lavalink player.voiceChannelId when set", () => {
+        const client = mockClient({ botChannelId: "vc-discord" })
+        assert.equal(
+            resolveBotVoiceChannelId(
+                "guild-1",
+                mockPlayer({ voiceChannelId: "vc-lava" }) as never,
+                client
+            ),
+            "vc-lava"
+        )
+    })
+
+    it("falls back to Discord members.me.voice when player VC is empty", () => {
+        const client = mockClient({ botChannelId: "vc-discord" })
+        assert.equal(
+            resolveBotVoiceChannelId(
+                "guild-1",
+                mockPlayer({ voiceChannelId: null }) as never,
+                client
+            ),
+            "vc-discord"
+        )
+        assert.equal(resolveBotVoiceChannelId("guild-1", null, client), "vc-discord")
+    })
+
+    it("returns null when neither player nor Discord has a bot VC", () => {
+        const client = mockClient({ botChannelId: null })
+        assert.equal(resolveBotVoiceChannelId("guild-1", null, client), null)
+        assert.equal(resolveBotVoiceChannelId("missing-guild", null, client), null)
+    })
+})
+
+describe("summarizeVoiceForWeb", () => {
+    it("marks inVoiceWithBot only when user and bot share the same VC", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-same",
+            botChannelId: "vc-other",
+        })
+        const player = mockPlayer({ voiceChannelId: "vc-same" })
+        assert.deepEqual(summarizeVoiceForWeb("guild-1", "user-1", player, client), {
+            inVoiceWithBot: true,
+            botInVoiceChannel: true,
+            canQueueTracks: true,
+        })
+    })
+
+    it("allows canQueueTracks when user is in voice and bot is not", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-user",
+            botChannelId: null,
+        })
+        assert.deepEqual(summarizeVoiceForWeb("guild-1", "user-1", null, client), {
+            inVoiceWithBot: false,
+            botInVoiceChannel: false,
+            canQueueTracks: true,
+        })
+    })
+
+    it("blocks canQueueTracks when user is in a different VC than the bot", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-user",
+            botChannelId: "vc-bot",
+        })
+        const player = mockPlayer({ voiceChannelId: "vc-bot" })
+        assert.deepEqual(summarizeVoiceForWeb("guild-1", "user-1", player, client), {
+            inVoiceWithBot: false,
+            botInVoiceChannel: true,
+            canQueueTracks: false,
+        })
+    })
+
+    it("blocks queueing when the user is not in any voice channel", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: null,
+            botChannelId: "vc-bot",
+        })
+        const player = mockPlayer({ voiceChannelId: "vc-bot" })
+        assert.deepEqual(summarizeVoiceForWeb("guild-1", "user-1", player, client), {
+            inVoiceWithBot: false,
+            botInVoiceChannel: true,
+            canQueueTracks: false,
+        })
+    })
+
+    it("ignores non-player shapes for bot VC and falls back to Discord", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-discord",
+            botChannelId: "vc-discord",
+        })
+        assert.deepEqual(
+            summarizeVoiceForWeb("guild-1", "user-1", { voiceChannelId: "vc-ignored" }, client),
+            {
+                inVoiceWithBot: true,
+                botInVoiceChannel: true,
+                canQueueTracks: true,
+            }
+        )
+    })
+})
+
+describe("snapshotGuildListPlayer", () => {
+    it("returns null when there is no player and the bot is not in voice", () => {
+        const client = mockClient({ botChannelId: null })
+        assert.equal(snapshotGuildListPlayer("guild-1", "user-1", null, client), null)
+    })
+
+    it("reports idle bot-in-voice without a player, and clears inVoiceWithBot without discordUserId", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-bot",
+            botChannelId: "vc-bot",
+        })
+        assert.deepEqual(snapshotGuildListPlayer("guild-1", undefined, null, client), {
+            status: "idle",
+            botInVoiceChannel: true,
+            inVoiceWithBot: false,
+            currentTrackTitle: null,
+            currentTrackAuthor: null,
+            queueCount: 0,
+        })
+    })
+
+    it("surfaces playing status and current track fields from a valid player", () => {
+        const client = mockClient({
+            userId: "user-1",
+            userChannelId: "vc-bot",
+            botChannelId: "vc-bot",
+        })
+        const player = mockPlayer({
+            voiceChannelId: "vc-bot",
+            playing: true,
+            tracks: [{}, {}],
+            current: { info: { title: "Song", author: "Artist" } },
+        })
+        assert.deepEqual(snapshotGuildListPlayer("guild-1", "user-1", player, client), {
+            status: "playing",
+            botInVoiceChannel: true,
+            inVoiceWithBot: true,
+            currentTrackTitle: "Song",
+            currentTrackAuthor: "Artist",
+            queueCount: 2,
+        })
+    })
+})

--- a/src/util/autoplayHistory.test.ts
+++ b/src/util/autoplayHistory.test.ts
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player, Track, TrackInfo } from "lavalink-client"
+import {
+    AUTOPLAY_RECENT_SONG_CAP,
+    autoplaySameComposition,
+    autoplayTrackFingerprint,
+    clearAutoplayRecent,
+    isAutoplayRecentlyPlayed,
+    isDuplicateAutoplayCandidate,
+    isPlausibleAutoplayMusicTrack,
+    isSamePrimaryArtist,
+    orderLavalinkTracksForAutoplay,
+    orderSimilarByArtistVariety,
+    primaryArtistKey,
+    rememberAutoplayPlayed,
+    songIdentityKey,
+    youtubeVideoIdFromUri,
+    canonicalSongCore,
+    coreTrackTitle,
+} from "./autoplayHistory.js"
+
+function info(overrides: Partial<TrackInfo> = {}): TrackInfo {
+    return {
+        title: "Song Title",
+        author: "Artist",
+        uri: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        duration: 180_000,
+        isStream: false,
+        identifier: "dQw4w9WgXcQ",
+        isSeekable: true,
+        sourceName: "youtube",
+        artworkUrl: null,
+        isrc: null,
+        ...overrides,
+    } as TrackInfo
+}
+
+function mockPlayer(): Player {
+    const store = new Map<string, unknown>()
+    return {
+        get: (key: string) => store.get(key),
+        set: (key: string, value: unknown) => {
+            store.set(key, value)
+        },
+        queue: { current: null, tracks: [], previous: [] },
+    } as unknown as Player
+}
+
+function trackFromInfo(trackInfo: TrackInfo): Track {
+    return { info: trackInfo, encoded: "enc", requester: null } as unknown as Track
+}
+
+describe("youtubeVideoIdFromUri", () => {
+    it("parses watch, short, embed, shorts, and live URLs", () => {
+        assert.equal(
+            youtubeVideoIdFromUri("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+            "dQw4w9WgXcQ"
+        )
+        assert.equal(youtubeVideoIdFromUri("https://youtu.be/dQw4w9WgXcQ"), "dQw4w9WgXcQ")
+        assert.equal(
+            youtubeVideoIdFromUri("https://www.youtube.com/embed/dQw4w9WgXcQ"),
+            "dQw4w9WgXcQ"
+        )
+        assert.equal(
+            youtubeVideoIdFromUri("https://www.youtube.com/shorts/dQw4w9WgXcQ"),
+            "dQw4w9WgXcQ"
+        )
+        assert.equal(
+            youtubeVideoIdFromUri("https://music.youtube.com/watch?v=abc123XYZ01"),
+            "abc123XYZ01"
+        )
+    })
+
+    it("returns null for missing, non-YouTube, or malformed URIs", () => {
+        assert.equal(youtubeVideoIdFromUri(undefined), null)
+        assert.equal(youtubeVideoIdFromUri("https://open.spotify.com/track/x"), null)
+        assert.equal(youtubeVideoIdFromUri("not a url"), null)
+    })
+})
+
+describe("title and artist normalization", () => {
+    it("strips promo trailers and feat. tails for comparable cores", () => {
+        assert.equal(coreTrackTitle("Hello (Official Music Video)"), "hello")
+        assert.equal(primaryArtistKey("Adele feat. Someone"), "adele")
+        assert.equal(canonicalSongCore("Adele", "Adele - Hello (Lyrics)"), "hello")
+        assert.equal(isSamePrimaryArtist("Adele ft. X", "Adele"), true)
+        assert.equal(isSamePrimaryArtist("Adele", "Beyonce"), false)
+    })
+})
+
+describe("isPlausibleAutoplayMusicTrack", () => {
+    it("rejects reaction/interview junk and very short non-stream clips", () => {
+        assert.equal(
+            isPlausibleAutoplayMusicTrack(info({ title: "Producer Reacts to New Song" })),
+            false
+        )
+        assert.equal(
+            isPlausibleAutoplayMusicTrack(info({ title: "Exclusive Interview with the Band" })),
+            false
+        )
+        assert.equal(
+            isPlausibleAutoplayMusicTrack(info({ title: "Real Song", duration: 15_000 })),
+            false
+        )
+        assert.equal(isPlausibleAutoplayMusicTrack(info({ title: "Real Song" })), true)
+        assert.equal(isPlausibleAutoplayMusicTrack(undefined), false)
+    })
+})
+
+describe("autoplaySameComposition / duplicates", () => {
+    it("matches covers and lyric uploads of the same work", () => {
+        assert.equal(
+            autoplaySameComposition("Radiohead", "Creep", "Radiohead", "Creep Lyrics"),
+            true
+        )
+        assert.equal(
+            autoplaySameComposition(
+                "Radiohead",
+                "Creep",
+                "Some Cover Channel",
+                "Radiohead - Creep (Cover)"
+            ),
+            false
+        )
+    })
+
+    it("does not treat unrelated short titles as the same song across artists", () => {
+        assert.equal(autoplaySameComposition("Artist A", "Run", "Artist B", "Run"), false)
+        assert.equal(autoplaySameComposition("Artist A", "Run", "Artist A", "Run"), true)
+    })
+
+    it("detects duplicates by URI, YouTube id, and composition", () => {
+        const ended = info({
+            uri: "https://www.youtube.com/watch?v=abc123XYZ01",
+            identifier: "abc123XYZ01",
+            author: "Adele",
+            title: "Hello",
+        })
+        assert.equal(
+            isDuplicateAutoplayCandidate(
+                info({
+                    uri: "https://youtu.be/abc123XYZ01",
+                    identifier: "other",
+                    author: "Adele",
+                    title: "Hello Official Video",
+                }),
+                ended
+            ),
+            true
+        )
+        assert.equal(
+            isDuplicateAutoplayCandidate(
+                info({
+                    uri: "https://www.youtube.com/watch?v=zzzzzzzzzzz",
+                    identifier: "zzzzzzzzzzz",
+                    author: "Other",
+                    title: "Totally Different Song Name Here",
+                }),
+                ended
+            ),
+            false
+        )
+    })
+})
+
+describe("fingerprints and recent history", () => {
+    it("prefers YouTube id fingerprints and falls back to song identity", () => {
+        assert.equal(
+            autoplayTrackFingerprint(info({ uri: "https://youtu.be/dQw4w9WgXcQ" })),
+            "yt:dQw4w9WgXcQ"
+        )
+        assert.equal(
+            autoplayTrackFingerprint(
+                info({
+                    uri: "https://open.spotify.com/track/x",
+                    identifier: "",
+                    author: "Adele",
+                    title: "Hello",
+                })
+            ),
+            songIdentityKey("Adele", "Hello")
+        )
+    })
+
+    it("remembers distinct songs, caps history, and matches fuzzy recent plays", () => {
+        const player = mockPlayer()
+        rememberAutoplayPlayed(player, info({ author: "Adele", title: "Hello" }))
+        rememberAutoplayPlayed(player, info({ author: "Adele", title: "Hello (Lyrics)" }))
+        assert.equal(
+            isAutoplayRecentlyPlayed(player, info({ author: "Adele", title: "Hello Official Audio" })),
+            true
+        )
+        assert.equal(
+            isAutoplayRecentlyPlayed(player, info({ author: "Beyonce", title: "Halo" })),
+            false
+        )
+
+        for (let i = 0; i < AUTOPLAY_RECENT_SONG_CAP + 5; i++) {
+            rememberAutoplayPlayed(player, info({ author: `Artist${i}`, title: `Song ${i}` }))
+        }
+        const recent = player.get("autoplayRecentSongs") as string[]
+        assert.equal(recent.length, AUTOPLAY_RECENT_SONG_CAP)
+        assert.equal(isAutoplayRecentlyPlayed(player, info({ author: "Adele", title: "Hello" })), false)
+
+        clearAutoplayRecent(player)
+        assert.equal(
+            isAutoplayRecentlyPlayed(player, info({ author: `Artist${AUTOPLAY_RECENT_SONG_CAP + 4}`, title: `Song ${AUTOPLAY_RECENT_SONG_CAP + 4}` })),
+            false
+        )
+    })
+})
+
+describe("ordering helpers", () => {
+    it("orders similar recommendations with other artists first", () => {
+        const ordered = orderSimilarByArtistVariety(
+            [
+                { artist: "Adele", title: "Someone Like You" },
+                { artist: "Sam Smith", title: "Stay With Me" },
+                { artist: "Adele ft. X", title: "Rumour Has It" },
+            ],
+            "Adele"
+        )
+        assert.deepEqual(
+            ordered.map((s) => s.artist),
+            ["Sam Smith", "Adele", "Adele ft. X"]
+        )
+    })
+
+    it("filters junk, duplicates, and recent plays when ordering Lavalink hits", () => {
+        const player = mockPlayer()
+        const ended = info({
+            author: "Seed",
+            title: "Ended Track",
+            identifier: "ended1",
+            uri: "https://www.youtube.com/watch?v=endedTrack01",
+        })
+        rememberAutoplayPlayed(
+            player,
+            info({
+                author: "Recent",
+                title: "Already Heard",
+                identifier: "recent1",
+                uri: "https://www.youtube.com/watch?v=recentHeard01",
+            })
+        )
+
+        const tracks = [
+            trackFromInfo(
+                info({
+                    author: "Other Band",
+                    title: "Fresh Cut",
+                    identifier: "a1",
+                    uri: "https://www.youtube.com/watch?v=freshCutAAAA",
+                })
+            ),
+            trackFromInfo(
+                info({
+                    author: "Seed",
+                    title: "Ended Track",
+                    identifier: "ended1",
+                    uri: ended.uri,
+                })
+            ),
+            trackFromInfo(
+                info({
+                    author: "Recent",
+                    title: "Already Heard",
+                    identifier: "r1",
+                    uri: "https://www.youtube.com/watch?v=recentHeard02",
+                })
+            ),
+            trackFromInfo(
+                info({
+                    author: "Clip Channel",
+                    title: "Producer Reacts to Hit",
+                    identifier: "j1",
+                    uri: "https://www.youtube.com/watch?v=junkReact0001",
+                })
+            ),
+            trackFromInfo(
+                info({
+                    author: "Seed",
+                    title: "Same Artist B-Side",
+                    identifier: "s1",
+                    uri: "https://www.youtube.com/watch?v=sameArtistB01",
+                })
+            ),
+        ]
+
+        const ordered = orderLavalinkTracksForAutoplay(tracks, "Seed", ended, player)
+        assert.deepEqual(
+            ordered.map((t) => t.info?.identifier),
+            ["a1", "s1"]
+        )
+    })
+})

--- a/src/util/autoplayHistory.test.ts
+++ b/src/util/autoplayHistory.test.ts
@@ -188,7 +188,10 @@ describe("fingerprints and recent history", () => {
         rememberAutoplayPlayed(player, info({ author: "Adele", title: "Hello" }))
         rememberAutoplayPlayed(player, info({ author: "Adele", title: "Hello (Lyrics)" }))
         assert.equal(
-            isAutoplayRecentlyPlayed(player, info({ author: "Adele", title: "Hello Official Audio" })),
+            isAutoplayRecentlyPlayed(
+                player,
+                info({ author: "Adele", title: "Hello Official Audio" })
+            ),
             true
         )
         assert.equal(
@@ -201,11 +204,20 @@ describe("fingerprints and recent history", () => {
         }
         const recent = player.get("autoplayRecentSongs") as string[]
         assert.equal(recent.length, AUTOPLAY_RECENT_SONG_CAP)
-        assert.equal(isAutoplayRecentlyPlayed(player, info({ author: "Adele", title: "Hello" })), false)
+        assert.equal(
+            isAutoplayRecentlyPlayed(player, info({ author: "Adele", title: "Hello" })),
+            false
+        )
 
         clearAutoplayRecent(player)
         assert.equal(
-            isAutoplayRecentlyPlayed(player, info({ author: `Artist${AUTOPLAY_RECENT_SONG_CAP + 4}`, title: `Song ${AUTOPLAY_RECENT_SONG_CAP + 4}` })),
+            isAutoplayRecentlyPlayed(
+                player,
+                info({
+                    author: `Artist${AUTOPLAY_RECENT_SONG_CAP + 4}`,
+                    title: `Song ${AUTOPLAY_RECENT_SONG_CAP + 4}`,
+                })
+            ),
             false
         )
     })

--- a/src/util/botApiVerboseEnv.test.ts
+++ b/src/util/botApiVerboseEnv.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { isBotApiVerbose } from "./botApiVerboseEnv.js"
+
+describe("isBotApiVerbose", () => {
+    it("treats BOT_API_VERBOSE / WEB_BOT_API_VERBOSE truthy flags as enabled", () => {
+        const prevBot = process.env.BOT_API_VERBOSE
+        const prevWeb = process.env.WEB_BOT_API_VERBOSE
+        try {
+            delete process.env.BOT_API_VERBOSE
+            delete process.env.WEB_BOT_API_VERBOSE
+            assert.equal(isBotApiVerbose(), false)
+
+            process.env.BOT_API_VERBOSE = "1"
+            assert.equal(isBotApiVerbose(), true)
+
+            // Non-empty BOT_API_VERBOSE wins over WEB (including falsy-looking "0").
+            process.env.BOT_API_VERBOSE = "0"
+            process.env.WEB_BOT_API_VERBOSE = "yes"
+            assert.equal(isBotApiVerbose(), false)
+
+            delete process.env.BOT_API_VERBOSE
+            process.env.WEB_BOT_API_VERBOSE = "yes"
+            assert.equal(isBotApiVerbose(), true)
+
+            process.env.WEB_BOT_API_VERBOSE = " off "
+            assert.equal(isBotApiVerbose(), false)
+
+            process.env.BOT_API_VERBOSE = "TRUE"
+            assert.equal(isBotApiVerbose(), true)
+        } finally {
+            if (prevBot === undefined) delete process.env.BOT_API_VERBOSE
+            else process.env.BOT_API_VERBOSE = prevBot
+            if (prevWeb === undefined) delete process.env.WEB_BOT_API_VERBOSE
+            else process.env.WEB_BOT_API_VERBOSE = prevWeb
+        }
+    })
+})

--- a/src/util/countdownEmbed.test.ts
+++ b/src/util/countdownEmbed.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { CountdownEntry } from "../types/index.js"
+import {
+    DEFAULT_COUNTDOWN_COLOR,
+    buildCountdownEmbed,
+    buildCountdownFinishEmbed,
+} from "./countdownEmbed.js"
+
+function entry(overrides: Partial<CountdownEntry> = {}): CountdownEntry {
+    return {
+        id: 7,
+        guildId: "g1",
+        channelId: "c1",
+        messageId: "m1",
+        eventName: "Launch Party",
+        description: null,
+        imageUrl: null,
+        color: null,
+        footer: null,
+        finishMessage: null,
+        mentionRoleId: null,
+        targetTime: new Date("2030-01-01T00:00:00.000Z"),
+        createdBy: "u1",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        ...overrides,
+    }
+}
+
+describe("buildCountdownEmbed", () => {
+    it("shows remaining time, default color/footer, and optional description/image", () => {
+        const target = new Date("2030-01-01T00:00:00.000Z")
+        const now = target.getTime() - 90 * 60 * 1000
+        const embed = buildCountdownEmbed(
+            entry({
+                description: "Bring snacks",
+                imageUrl: "https://cdn.example.com/party.png",
+                targetTime: target,
+            }),
+            now
+        )
+        const data = embed.toJSON()
+        assert.equal(data.title, "Launch Party")
+        assert.equal(data.color, DEFAULT_COUNTDOWN_COLOR)
+        assert.equal(data.footer?.text, "Countdown #7")
+        assert.equal(data.image?.url, "https://cdn.example.com/party.png")
+        assert.match(String(data.description), /Bring snacks/)
+        assert.match(String(data.description), /\*\*Starts:\*\* <t:1893456000:F>/)
+        assert.match(String(data.description), /\*\*Time remaining:\*\* 1 hour, 30 minutes/)
+    })
+
+    it("marks the event as started and honors custom color/footer", () => {
+        const target = new Date("2030-01-01T00:00:00.000Z")
+        const embed = buildCountdownEmbed(
+            entry({
+                color: 0xff0000,
+                footer: "Custom footer",
+                targetTime: target,
+            }),
+            target.getTime() + 1
+        )
+        const data = embed.toJSON()
+        assert.equal(data.color, 0xff0000)
+        assert.equal(data.footer?.text, "Custom footer")
+        assert.match(String(data.description), /\*\*Time remaining:\*\* Event started!/)
+        assert.equal(data.image, undefined)
+    })
+})
+
+describe("buildCountdownFinishEmbed", () => {
+    it("returns null when there is no image to re-post", () => {
+        assert.equal(buildCountdownFinishEmbed(entry({ imageUrl: null })), null)
+    })
+
+    it("builds a title+image finish embed with default or custom color", () => {
+        const withDefault = buildCountdownFinishEmbed(
+            entry({ imageUrl: "https://cdn.example.com/done.png" })
+        )
+        assert.ok(withDefault)
+        const defaultData = withDefault.toJSON()
+        assert.equal(defaultData.title, "Launch Party")
+        assert.equal(defaultData.color, DEFAULT_COUNTDOWN_COLOR)
+        assert.equal(defaultData.image?.url, "https://cdn.example.com/done.png")
+
+        const withColor = buildCountdownFinishEmbed(
+            entry({ imageUrl: "https://cdn.example.com/done.png", color: 0x00ff00 })
+        )
+        assert.ok(withColor)
+        assert.equal(withColor.toJSON().color, 0x00ff00)
+    })
+})

--- a/src/util/countdownUpdater.test.ts
+++ b/src/util/countdownUpdater.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { isUnrecoverableCountdownDiscordError } from "./countdownUpdater.js"
+
+describe("isUnrecoverableCountdownDiscordError", () => {
+    it("deletes countdowns only for unknown channel/message", () => {
+        assert.equal(isUnrecoverableCountdownDiscordError({ code: 10003 }), true)
+        assert.equal(isUnrecoverableCountdownDiscordError({ code: 10008 }), true)
+    })
+
+    it("retries permission and non-numeric failures instead of wiping countdown rows", () => {
+        assert.equal(isUnrecoverableCountdownDiscordError({ code: 50001 }), false)
+        assert.equal(isUnrecoverableCountdownDiscordError({ code: 50013 }), false)
+        assert.equal(isUnrecoverableCountdownDiscordError({ code: "10003" }), false)
+        assert.equal(isUnrecoverableCountdownDiscordError(new Error("timeout")), false)
+        assert.equal(isUnrecoverableCountdownDiscordError(null), false)
+    })
+})

--- a/src/util/countdownUpdater.ts
+++ b/src/util/countdownUpdater.ts
@@ -14,7 +14,11 @@ const UNRECOVERABLE_CODES = new Set([
     10008, // Unknown Message
 ])
 
-function isUnrecoverableError(error: unknown): boolean {
+/**
+ * True when a Discord fetch/edit failure should delete the countdown row.
+ * Permission and transient errors must return false so the next interval can retry.
+ */
+export function isUnrecoverableCountdownDiscordError(error: unknown): boolean {
     if (typeof error === "object" && error !== null && "code" in error) {
         const code = (error as { code: unknown }).code
         return typeof code === "number" && UNRECOVERABLE_CODES.has(code)
@@ -74,7 +78,7 @@ export async function updateAllCountdowns(client: BotClient): Promise<void> {
                 }
                 channel = fetched
             } catch (error: unknown) {
-                if (isUnrecoverableError(error)) {
+                if (isUnrecoverableCountdownDiscordError(error)) {
                     await removeCountdown(entry.id)
                 } else {
                     client.warn(
@@ -89,7 +93,7 @@ export async function updateAllCountdowns(client: BotClient): Promise<void> {
             try {
                 message = await channel.messages.fetch(entry.messageId)
             } catch (error: unknown) {
-                if (isUnrecoverableError(error)) {
+                if (isUnrecoverableCountdownDiscordError(error)) {
                     await removeCountdown(entry.id)
                 } else {
                     client.warn(
@@ -114,7 +118,7 @@ export async function updateAllCountdowns(client: BotClient): Promise<void> {
                 }
             }
         } catch (error: unknown) {
-            if (isUnrecoverableError(error)) {
+            if (isUnrecoverableCountdownDiscordError(error)) {
                 await removeCountdown(entry.id).catch((removeErr: unknown) =>
                     client.warn(
                         `[countdown] Failed to remove unrecoverable countdown #${entry.id}:`,

--- a/src/util/dashboardRequesterSnapshot.test.ts
+++ b/src/util/dashboardRequesterSnapshot.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { snapshotFromRequester } from "./dashboardRequesterSnapshot.js"
+
+describe("snapshotFromRequester", () => {
+    it("returns null for missing or unusable requesters", () => {
+        assert.equal(snapshotFromRequester(null), null)
+        assert.equal(snapshotFromRequester(undefined), null)
+        assert.equal(snapshotFromRequester({}), null)
+        assert.equal(snapshotFromRequester({ username: "no-id" }), null)
+        assert.equal(snapshotFromRequester(42), null)
+    })
+
+    it("accepts stamped string ids and numeric/bigint object ids", () => {
+        assert.deepEqual(snapshotFromRequester("123456789012345678"), {
+            id: "123456789012345678",
+        })
+        assert.deepEqual(snapshotFromRequester({ id: 42 }), { id: "42" })
+        assert.deepEqual(snapshotFromRequester({ id: 99n }), { id: "99" })
+    })
+
+    it("prefers globalName, then username, then displayName (trimmed)", () => {
+        assert.deepEqual(
+            snapshotFromRequester({
+                id: "1",
+                globalName: "  Display  ",
+                username: "login",
+                displayName: "nick",
+            }),
+            { id: "1", username: "Display" }
+        )
+        assert.deepEqual(
+            snapshotFromRequester({ id: "2", globalName: "   ", username: " login ", displayName: "nick" }),
+            { id: "2", username: "login" }
+        )
+        assert.deepEqual(
+            snapshotFromRequester({ id: "3", username: "", displayName: "  Nick  " }),
+            { id: "3", username: "Nick" }
+        )
+        assert.deepEqual(
+            snapshotFromRequester({ id: "4", globalName: "", username: "  ", displayName: "  " }),
+            { id: "4" }
+        )
+    })
+})

--- a/src/util/dashboardRequesterSnapshot.test.ts
+++ b/src/util/dashboardRequesterSnapshot.test.ts
@@ -30,7 +30,12 @@ describe("snapshotFromRequester", () => {
             { id: "1", username: "Display" }
         )
         assert.deepEqual(
-            snapshotFromRequester({ id: "2", globalName: "   ", username: " login ", displayName: "nick" }),
+            snapshotFromRequester({
+                id: "2",
+                globalName: "   ",
+                username: " login ",
+                displayName: "nick",
+            }),
             { id: "2", username: "login" }
         )
         assert.deepEqual(

--- a/src/util/discordBotInvite.test.ts
+++ b/src/util/discordBotInvite.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { DISCORD_BOT_INVITE_PERMISSIONS } from "../shared/discordBotPermissions.js"
+import { getDiscordBotInviteUrl } from "../web/lib/discord-bot-invite.js"
+
+describe("getDiscordBotInviteUrl", () => {
+    it("builds an authorize URL with encoded client id, shared permissions, and bot scopes", () => {
+        const prev = process.env.CLIENT_ID
+        try {
+            process.env.CLIENT_ID = "123456789012345678"
+            const url = getDiscordBotInviteUrl()
+            assert.ok(url)
+            const parsed = new URL(url!)
+            assert.equal(parsed.origin + parsed.pathname, "https://discord.com/oauth2/authorize")
+            assert.equal(parsed.searchParams.get("client_id"), "123456789012345678")
+            assert.equal(parsed.searchParams.get("permissions"), DISCORD_BOT_INVITE_PERMISSIONS)
+            assert.equal(parsed.searchParams.get("scope"), "bot applications.commands")
+        } finally {
+            if (prev === undefined) delete process.env.CLIENT_ID
+            else process.env.CLIENT_ID = prev
+        }
+    })
+
+    it("returns null when CLIENT_ID is missing or blank", () => {
+        const prev = process.env.CLIENT_ID
+        try {
+            delete process.env.CLIENT_ID
+            assert.equal(getDiscordBotInviteUrl(), null)
+            process.env.CLIENT_ID = "   "
+            assert.equal(getDiscordBotInviteUrl(), null)
+        } finally {
+            if (prev === undefined) delete process.env.CLIENT_ID
+            else process.env.CLIENT_ID = prev
+        }
+    })
+})

--- a/src/util/discordErrorDetails.test.ts
+++ b/src/util/discordErrorDetails.test.ts
@@ -19,7 +19,7 @@ describe("getDiscordErrorCode", () => {
         assert.equal(getDiscordErrorCode({}), undefined)
         assert.equal(getDiscordErrorCode({ code: "EAI_AGAIN" }), undefined)
         assert.equal(getDiscordErrorCode({ code: Number.NaN }), undefined)
-        assert.equal(getDiscordErrorCode({ code: 12.5 }), undefined)
+        assert.equal(getDiscordErrorCode({ code: Number.POSITIVE_INFINITY }), undefined)
     })
 })
 

--- a/src/util/discordErrorDetails.test.ts
+++ b/src/util/discordErrorDetails.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { discordDeleteErrorDetails, getDiscordErrorCode } from "./discordErrorDetails.js"
+
+describe("getDiscordErrorCode", () => {
+    it("reads finite numeric codes from thrown Discord-like errors", () => {
+        assert.equal(getDiscordErrorCode({ code: 10003 }), 10003)
+        assert.equal(getDiscordErrorCode({ code: 0 }), 0)
+    })
+
+    it("parses digit-only string codes used by some discord.js surfaces", () => {
+        assert.equal(getDiscordErrorCode({ code: "10004" }), 10004)
+    })
+
+    it("rejects non-codes so callers do not misclassify network failures as Discord API errors", () => {
+        assert.equal(getDiscordErrorCode(null), undefined)
+        assert.equal(getDiscordErrorCode(undefined), undefined)
+        assert.equal(getDiscordErrorCode("boom"), undefined)
+        assert.equal(getDiscordErrorCode({}), undefined)
+        assert.equal(getDiscordErrorCode({ code: "EAI_AGAIN" }), undefined)
+        assert.equal(getDiscordErrorCode({ code: Number.NaN }), undefined)
+        assert.equal(getDiscordErrorCode({ code: 12.5 }), undefined)
+    })
+})
+
+describe("discordDeleteErrorDetails", () => {
+    it("normalizes Error and non-Error throws for logging", () => {
+        assert.deepEqual(discordDeleteErrorDetails(new Error("gone")), {
+            code: undefined,
+            message: "gone",
+        })
+        assert.deepEqual(discordDeleteErrorDetails({ code: "EAI_AGAIN", message: "dns" }), {
+            code: "EAI_AGAIN",
+            message: "[object Object]",
+        })
+        assert.deepEqual(discordDeleteErrorDetails({ code: 500 }), {
+            code: "500",
+            message: "[object Object]",
+        })
+    })
+})

--- a/src/util/discordLogForward.test.ts
+++ b/src/util/discordLogForward.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { GuildDiscordLogSettings } from "../types/index.js"
+import { discordLogLevelAllowed, resolveDiscordLogChannelId } from "./discordLogForward.js"
+
+describe("resolveDiscordLogChannelId", () => {
+    it("prefers per-level overrides over allChannelId", () => {
+        const cfg: GuildDiscordLogSettings = {
+            allChannelId: "all-chan",
+            byLevel: { error: "error-chan", warn: "warn-chan" },
+        }
+        assert.equal(resolveDiscordLogChannelId(cfg, "error"), "error-chan")
+        assert.equal(resolveDiscordLogChannelId(cfg, "warn"), "warn-chan")
+        assert.equal(resolveDiscordLogChannelId(cfg, "info"), "all-chan")
+        assert.equal(resolveDiscordLogChannelId(cfg, "debug"), "all-chan")
+    })
+
+    it("returns null when neither per-level nor allChannelId is set", () => {
+        assert.equal(resolveDiscordLogChannelId({}, "error"), null)
+        assert.equal(resolveDiscordLogChannelId({ byLevel: {} }, "info"), null)
+    })
+})
+
+describe("discordLogLevelAllowed", () => {
+    it("defaults minLevel to debug (all levels allowed)", () => {
+        const cfg: GuildDiscordLogSettings = {}
+        assert.equal(discordLogLevelAllowed(cfg, "debug"), true)
+        assert.equal(discordLogLevelAllowed(cfg, "error"), true)
+    })
+
+    it("filters below the configured threshold and allows equal/higher", () => {
+        const cfg: GuildDiscordLogSettings = { minLevel: "warn" }
+        assert.equal(discordLogLevelAllowed(cfg, "debug"), false)
+        assert.equal(discordLogLevelAllowed(cfg, "info"), false)
+        assert.equal(discordLogLevelAllowed(cfg, "warn"), true)
+        assert.equal(discordLogLevelAllowed(cfg, "error"), true)
+    })
+
+    it("allows only error when minLevel is error", () => {
+        const cfg: GuildDiscordLogSettings = { minLevel: "error" }
+        assert.equal(discordLogLevelAllowed(cfg, "warn"), false)
+        assert.equal(discordLogLevelAllowed(cfg, "error"), true)
+    })
+})

--- a/src/util/discordLogForward.test.ts
+++ b/src/util/discordLogForward.test.ts
@@ -47,7 +47,10 @@ describe("logMessageBelongsToGuild", () => {
     })
 
     it("rejects process-wide logs with no guild id (prevents cross-tenant fan-out)", () => {
-        assert.equal(logMessageBelongsToGuild("[Database] Database connection verified.", guildA), false)
+        assert.equal(
+            logMessageBelongsToGuild("[Database] Database connection verified.", guildA),
+            false
+        )
         assert.equal(logMessageBelongsToGuild("Lavalink Node main CONNECTED", guildA), false)
     })
 

--- a/src/util/discordLogForward.test.ts
+++ b/src/util/discordLogForward.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 import type { GuildDiscordLogSettings } from "../types/index.js"
-import { discordLogLevelAllowed, resolveDiscordLogChannelId } from "./discordLogForward.js"
+import {
+    discordLogLevelAllowed,
+    logMessageBelongsToGuild,
+    resolveDiscordLogChannelId,
+} from "./discordLogForward.js"
 
 describe("resolveDiscordLogChannelId", () => {
     it("prefers per-level overrides over allChannelId", () => {
@@ -18,6 +22,39 @@ describe("resolveDiscordLogChannelId", () => {
     it("returns null when neither per-level nor allChannelId is set", () => {
         assert.equal(resolveDiscordLogChannelId({}, "error"), null)
         assert.equal(resolveDiscordLogChannelId({ byLevel: {} }, "info"), null)
+    })
+})
+
+describe("logMessageBelongsToGuild", () => {
+    const guildA = "123456789012345678"
+    const guildB = "987654321098765432"
+
+    it("requires the guild snowflake to appear as its own digit run", () => {
+        assert.equal(
+            logMessageBelongsToGuild(
+                `[MusicManager] handleQueryAndPlay called for guild ${guildA}. Query: "song"`,
+                guildA
+            ),
+            true
+        )
+        assert.equal(
+            logMessageBelongsToGuild(
+                `[MusicManager] handleQueryAndPlay called for guild ${guildA}. Query: "song"`,
+                guildB
+            ),
+            false
+        )
+    })
+
+    it("rejects process-wide logs with no guild id (prevents cross-tenant fan-out)", () => {
+        assert.equal(logMessageBelongsToGuild("[Database] Database connection verified.", guildA), false)
+        assert.equal(logMessageBelongsToGuild("Lavalink Node main CONNECTED", guildA), false)
+    })
+
+    it("rejects invalid guild ids and substring digit matches", () => {
+        assert.equal(logMessageBelongsToGuild(`guild ${guildA}`, ""), false)
+        assert.equal(logMessageBelongsToGuild(`guild ${guildA}`, "not-a-snowflake"), false)
+        assert.equal(logMessageBelongsToGuild(`id ${guildA}9`, guildA), false)
     })
 })
 

--- a/src/util/discordLogForward.ts
+++ b/src/util/discordLogForward.ts
@@ -21,6 +21,9 @@ const MAX_EMBED_DESC = 3900
 
 const TRUNCATE_SUFFIX = "\n… (truncated)"
 
+/** Discord snowflake shape used to scope forwarded log lines to a guild. */
+const DISCORD_SNOWFLAKE_RE = /^\d{17,19}$/
+
 /** Max queued Discord forwards; oldest entries are dropped when full. */
 const DISCORD_LOG_FORWARD_QUEUE_CAP = 200
 
@@ -105,8 +108,23 @@ function truncateForDiscord(text: string): string {
 }
 
 /**
+ * Whether a process log line should be forwarded to a guild's Discord log channel.
+ * Requires an explicit guild snowflake in the message so one server cannot receive
+ * other tenants' operational logs (queries, URLs, paths, user tags, error stacks).
+ */
+export function logMessageBelongsToGuild(message: string, guildId: string): boolean {
+    if (!guildId || !DISCORD_SNOWFLAKE_RE.test(guildId)) {
+        return false
+    }
+    // Word-ish boundary: snowflakes are digits; avoid matching a longer digit run.
+    const re = new RegExp(`(?<!\\d)${guildId}(?!\\d)`)
+    return re.test(message)
+}
+
+/**
  * Sends a log line to every guild that configured Discord logging for this level.
  * Skips guilds where the channel is missing or the bot lacks permission.
+ * Only forwards lines that reference that guild's id (cross-tenant isolation).
  */
 export async function forwardLogToDiscordChannels(
     client: BotClient,
@@ -119,6 +137,9 @@ export async function forwardLogToDiscordChannels(
     for (const [guildId, guildSettings] of Object.entries(settings)) {
         const cfg = guildSettings.discordLog
         if (!cfg) {
+            continue
+        }
+        if (!logMessageBelongsToGuild(message, guildId)) {
             continue
         }
         if (!discordLogLevelAllowed(cfg, level)) {

--- a/src/util/downloadMetadataKeys.test.ts
+++ b/src/util/downloadMetadataKeys.test.ts
@@ -96,6 +96,9 @@ describe("downloadMetadataFileBelongsToGuild / entryMatchesGuild / keysForFile",
             composite,
             fileName,
         ])
-        assert.deepEqual(downloadMetadataKeysForFile({ [fileName]: { guildId: "x" } }, fileName, guildId), [])
+        assert.deepEqual(
+            downloadMetadataKeysForFile({ [fileName]: { guildId: "x" } }, fileName, guildId),
+            []
+        )
     })
 })

--- a/src/util/downloadMetadataKeys.test.ts
+++ b/src/util/downloadMetadataKeys.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    DOWNLOAD_METADATA_KEY_SEP,
+    DOWNLOAD_METADATA_UNKNOWN_GUILD_ID,
+    downloadMetadataEntryMatchesGuild,
+    downloadMetadataFileBelongsToGuild,
+    downloadMetadataKeysForFile,
+    downloadMetadataStoreKey,
+    effectiveDownloadMetadataGuildId,
+    parseDownloadMetadataStoreKey,
+} from "./downloadMetadataKeys.js"
+
+describe("downloadMetadataStoreKey / parseDownloadMetadataStoreKey", () => {
+    it("round-trips composite guild+file keys", () => {
+        const key = downloadMetadataStoreKey("guild-a", "track.wav")
+        assert.equal(key, `guild-a${DOWNLOAD_METADATA_KEY_SEP}track.wav`)
+        assert.deepEqual(parseDownloadMetadataStoreKey(key), {
+            guildId: "guild-a",
+            fileName: "track.wav",
+        })
+    })
+
+    it("treats legacy plain file names as guild-less keys", () => {
+        assert.deepEqual(parseDownloadMetadataStoreKey("legacy.wav"), {
+            guildId: null,
+            fileName: "legacy.wav",
+        })
+    })
+})
+
+describe("effectiveDownloadMetadataGuildId", () => {
+    it("prefers composite key guild id and ignores UNKNOWN sentinel", () => {
+        const composite = downloadMetadataStoreKey("guild-a", "a.wav")
+        assert.equal(effectiveDownloadMetadataGuildId(composite, { guildId: "other" }), "guild-a")
+        assert.equal(
+            effectiveDownloadMetadataGuildId(
+                downloadMetadataStoreKey(DOWNLOAD_METADATA_UNKNOWN_GUILD_ID, "a.wav"),
+                undefined
+            ),
+            null
+        )
+        assert.equal(
+            effectiveDownloadMetadataGuildId("legacy.wav", {
+                guildId: DOWNLOAD_METADATA_UNKNOWN_GUILD_ID,
+            }),
+            null
+        )
+        assert.equal(
+            effectiveDownloadMetadataGuildId("legacy.wav", { guildId: " guild-b " }),
+            "guild-b"
+        )
+    })
+})
+
+describe("downloadMetadataFileBelongsToGuild / entryMatchesGuild / keysForFile", () => {
+    it("matches composite keys strictly and legacy keys by guildId rules", () => {
+        const guildId = "guild-1"
+        const fileName = "song.wav"
+        const composite = downloadMetadataStoreKey(guildId, fileName)
+        const metadata = {
+            [composite]: { guildId },
+            "other.wav": { guildId: "guild-2" },
+            "orphan.wav": { guildId: "" },
+        }
+
+        assert.equal(downloadMetadataFileBelongsToGuild(metadata, fileName, guildId), true)
+        assert.equal(downloadMetadataFileBelongsToGuild(metadata, "other.wav", guildId), false)
+        assert.equal(downloadMetadataFileBelongsToGuild(metadata, "orphan.wav", guildId), true)
+        assert.equal(downloadMetadataFileBelongsToGuild(metadata, "missing.wav", guildId), false)
+
+        assert.equal(
+            downloadMetadataEntryMatchesGuild(composite, metadata[composite], guildId),
+            true
+        )
+        assert.equal(
+            downloadMetadataEntryMatchesGuild("other.wav", metadata["other.wav"], guildId),
+            false
+        )
+        assert.equal(
+            downloadMetadataEntryMatchesGuild("orphan.wav", metadata["orphan.wav"], guildId),
+            true
+        )
+    })
+
+    it("collects composite and matching legacy keys for cleanup", () => {
+        const guildId = "guild-1"
+        const fileName = "song.wav"
+        const composite = downloadMetadataStoreKey(guildId, fileName)
+        const metadata = {
+            [composite]: { guildId },
+            [fileName]: { guildId },
+            "song.wav-other": { guildId: "guild-2" },
+        }
+        assert.deepEqual(downloadMetadataKeysForFile(metadata, fileName, guildId), [
+            composite,
+            fileName,
+        ])
+        assert.deepEqual(downloadMetadataKeysForFile({ [fileName]: { guildId: "x" } }, fileName, guildId), [])
+    })
+})

--- a/src/util/downloadsMaxMb.test.ts
+++ b/src/util/downloadsMaxMb.test.ts
@@ -34,9 +34,17 @@ describe("isCustomDownloadsMaxMb", () => {
     it("is true only for finite limits ≥ 1", () => {
         assert.equal(isCustomDownloadsMaxMb(1), true)
         assert.equal(isCustomDownloadsMaxMb(500), true)
+        assert.equal(isCustomDownloadsMaxMb("12.5"), true)
+        assert.equal(isCustomDownloadsMaxMb("12.5abc"), true)
         assert.equal(isCustomDownloadsMaxMb(0), false)
         assert.equal(isCustomDownloadsMaxMb(-1), false)
         assert.equal(isCustomDownloadsMaxMb(undefined), false)
         assert.equal(isCustomDownloadsMaxMb("abc"), false)
+    })
+
+    it("agrees with resolveDownloadsMaxMb on trailing-junk numbers", () => {
+        const raw = "12.5abc"
+        assert.equal(isCustomDownloadsMaxMb(raw), true)
+        assert.equal(resolveDownloadsMaxMb(raw), 12.5)
     })
 })

--- a/src/util/downloadsMaxMb.test.ts
+++ b/src/util/downloadsMaxMb.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    DEFAULT_DOWNLOADS_MAX_MB,
+    isCustomDownloadsMaxMb,
+    resolveDownloadsMaxMb,
+} from "./downloadsMaxMb.js"
+
+describe("resolveDownloadsMaxMb", () => {
+    it("returns a finite custom limit of at least 1 MB", () => {
+        assert.equal(resolveDownloadsMaxMb(250), 250)
+        assert.equal(resolveDownloadsMaxMb("1000"), 1000)
+        assert.equal(resolveDownloadsMaxMb(1), 1)
+        assert.equal(resolveDownloadsMaxMb("12.5"), 12.5)
+    })
+
+    it("falls back for missing, non-finite, zero, and negative values", () => {
+        assert.equal(resolveDownloadsMaxMb(undefined), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(null), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(""), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb("nope"), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(Number.NaN), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(0), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(-5), DEFAULT_DOWNLOADS_MAX_MB)
+        assert.equal(resolveDownloadsMaxMb(Number.POSITIVE_INFINITY), DEFAULT_DOWNLOADS_MAX_MB)
+    })
+
+    it("honors an explicit default override", () => {
+        assert.equal(resolveDownloadsMaxMb(0, 42), 42)
+    })
+})
+
+describe("isCustomDownloadsMaxMb", () => {
+    it("is true only for finite limits ≥ 1", () => {
+        assert.equal(isCustomDownloadsMaxMb(1), true)
+        assert.equal(isCustomDownloadsMaxMb(500), true)
+        assert.equal(isCustomDownloadsMaxMb(0), false)
+        assert.equal(isCustomDownloadsMaxMb(-1), false)
+        assert.equal(isCustomDownloadsMaxMb(undefined), false)
+        assert.equal(isCustomDownloadsMaxMb("abc"), false)
+    })
+})

--- a/src/util/downloadsMaxMb.ts
+++ b/src/util/downloadsMaxMb.ts
@@ -1,0 +1,24 @@
+/** Default guild download directory cap when no valid custom limit is configured. */
+export const DEFAULT_DOWNLOADS_MAX_MB = 1000
+
+/**
+ * Resolves a guild downloads size limit in MB.
+ * Invalid, non-finite, or sub-1 values fall back to {@link DEFAULT_DOWNLOADS_MAX_MB}
+ * (or `defaultMb`) so a corrupt settings row cannot enforce a zero/negative quota.
+ */
+export function resolveDownloadsMaxMb(
+    configured: unknown,
+    defaultMb: number = DEFAULT_DOWNLOADS_MAX_MB
+): number {
+    const parsed = Number.parseFloat(String(configured ?? ""))
+    if (!Number.isFinite(parsed) || parsed < 1) {
+        return defaultMb
+    }
+    return parsed
+}
+
+/** True when `configured` is a usable custom downloads limit (≥ 1 MB). */
+export function isCustomDownloadsMaxMb(configured: unknown): boolean {
+    const parsed = Number(configured ?? Number.NaN)
+    return Number.isFinite(parsed) && parsed >= 1
+}

--- a/src/util/downloadsMaxMb.ts
+++ b/src/util/downloadsMaxMb.ts
@@ -19,6 +19,6 @@ export function resolveDownloadsMaxMb(
 
 /** True when `configured` is a usable custom downloads limit (≥ 1 MB). */
 export function isCustomDownloadsMaxMb(configured: unknown): boolean {
-    const parsed = Number(configured ?? Number.NaN)
+    const parsed = Number.parseFloat(String(configured ?? ""))
     return Number.isFinite(parsed) && parsed >= 1
 }

--- a/src/util/escapeLucenePhrase.test.ts
+++ b/src/util/escapeLucenePhrase.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { escapeLucenePhrase } from "./escapeLucenePhrase.js"
+
+describe("escapeLucenePhrase", () => {
+    it("trims and escapes backslashes and quotes for Lucene phrases", () => {
+        assert.equal(escapeLucenePhrase('  AC/DC "Live"  '), 'AC/DC \\"Live\\"')
+        assert.equal(escapeLucenePhrase("path\\name"), "path\\\\name")
+        assert.equal(escapeLucenePhrase('both\\"ends'), 'both\\\\\\"ends')
+    })
+
+    it("returns an empty string for blank or missing input", () => {
+        assert.equal(escapeLucenePhrase(""), "")
+        assert.equal(escapeLucenePhrase("   "), "")
+        assert.equal(escapeLucenePhrase(undefined as unknown as string), "")
+    })
+})

--- a/src/util/escapeLucenePhrase.ts
+++ b/src/util/escapeLucenePhrase.ts
@@ -1,0 +1,7 @@
+/** Escapes `\` and `"` so artist names are safe inside Lucene phrase queries. */
+export function escapeLucenePhrase(s: string): string {
+    return String(s || "")
+        .trim()
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+}

--- a/src/util/formatCountdownDuration.test.ts
+++ b/src/util/formatCountdownDuration.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { formatCountdownDuration } from "./formatCountdownDuration.js"
+
+describe("formatCountdownDuration", () => {
+    it("returns Event started! for non-positive or non-finite input", () => {
+        assert.equal(formatCountdownDuration(0), "Event started!")
+        assert.equal(formatCountdownDuration(-1), "Event started!")
+        assert.equal(formatCountdownDuration(Number.NaN), "Event started!")
+        assert.equal(formatCountdownDuration(Number.POSITIVE_INFINITY), "Event started!")
+    })
+
+    it("uses Less than a minute for sub-minute remainders", () => {
+        assert.equal(formatCountdownDuration(1), "Less than a minute")
+        assert.equal(formatCountdownDuration(59_999), "Less than a minute")
+    })
+
+    it("formats days, hours, and minutes without zero units or seconds", () => {
+        assert.equal(formatCountdownDuration(60_000), "1 minute")
+        assert.equal(formatCountdownDuration(2 * 60_000), "2 minutes")
+        assert.equal(formatCountdownDuration(60 * 60_000), "1 hour")
+        assert.equal(formatCountdownDuration(2 * 60 * 60_000 + 3 * 60_000), "2 hours, 3 minutes")
+        assert.equal(
+            formatCountdownDuration(3 * 24 * 60 * 60_000 + 4 * 60 * 60_000 + 20 * 60_000),
+            "3 days, 4 hours, 20 minutes"
+        )
+        assert.equal(formatCountdownDuration(24 * 60 * 60_000), "1 day")
+        // Sub-minute remainder after whole minutes is dropped (no seconds).
+        assert.equal(formatCountdownDuration(90_000), "1 minute")
+    })
+})

--- a/src/util/guildPlayerLifecycle.test.ts
+++ b/src/util/guildPlayerLifecycle.test.ts
@@ -118,4 +118,30 @@ describe("deferred orphan player cleanup", () => {
         holder.release()
         await waitForPendingOrphanDestroyForTests(guildId)
     })
+
+    it("defers idle destroy when reservedByCaller is 0 and a reservation is held", async () => {
+        const guildId = "guild-orphan-idle-timer"
+        let destroyed = false
+
+        const inFlight = await acquireGuildPlayerLifecycleReservation(guildId)
+
+        // queueEnd-style idle teardown does not itself hold a reservation.
+        await tryDestroyOrphanGuildPlayer(
+            guildId,
+            {
+                hasQueueContent: () => false,
+                destroyPlayer: async () => {
+                    destroyed = true
+                },
+            },
+            0
+        )
+        assert.equal(destroyed, false)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), true)
+
+        inFlight.release()
+        await waitForPendingOrphanDestroyForTests(guildId)
+        assert.equal(destroyed, true)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), false)
+    })
 })

--- a/src/util/guildPlayerLifecycle.test.ts
+++ b/src/util/guildPlayerLifecycle.test.ts
@@ -125,7 +125,7 @@ describe("deferred orphan player cleanup", () => {
 
         const inFlight = await acquireGuildPlayerLifecycleReservation(guildId)
 
-        // queueEnd-style idle teardown does not itself hold a reservation.
+        // Idle teardown (queueEnd / trackError / alone-in-VC) does not itself hold a reservation.
         await tryDestroyOrphanGuildPlayer(
             guildId,
             {

--- a/src/util/guildPlayerLifecycle.test.ts
+++ b/src/util/guildPlayerLifecycle.test.ts
@@ -6,6 +6,7 @@ import {
     hasPendingOrphanDestroyForTests,
     tryDestroyOrphanGuildPlayer,
     waitForPendingOrphanDestroyForTests,
+    withGuildPlayerLifecycleReservation,
 } from "./guildPlayerQueueLock.js"
 
 describe("guild player lifecycle reservation", () => {
@@ -18,6 +19,53 @@ describe("guild player lifecycle reservation", () => {
         assert.ok(getGuildPlayerLifecycleReservationCount("guild-life") > 0)
         b.release()
         assert.equal(getGuildPlayerLifecycleReservationCount("guild-life"), 0)
+    })
+
+    it("withGuildPlayerLifecycleReservation always releases after work", async () => {
+        const guildId = "guild-with-reserve"
+        await withGuildPlayerLifecycleReservation(guildId, async () => {
+            assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 1)
+        })
+        assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 0)
+    })
+
+    it("withGuildPlayerLifecycleReservation releases when work throws", async () => {
+        const guildId = "guild-with-reserve-throw"
+        await assert.rejects(
+            () =>
+                withGuildPlayerLifecycleReservation(guildId, async () => {
+                    assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 1)
+                    throw new Error("boom")
+                }),
+            /boom/
+        )
+        assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 0)
+    })
+
+    it("defers orphan destroy while a Discord-style reservation is held without createdHere", async () => {
+        // Models Discord /play (or restore) holding a reservation while web search cleanup runs.
+        const guildId = "guild-discord-vs-web-orphan"
+        let destroyed = false
+
+        const discordPlay = await acquireGuildPlayerLifecycleReservation(guildId)
+        const webSearch = await acquireGuildPlayerLifecycleReservation(guildId)
+
+        await tryDestroyOrphanGuildPlayer(guildId, {
+            hasQueueContent: () => false,
+            destroyPlayer: async () => {
+                destroyed = true
+            },
+        })
+        assert.equal(destroyed, false)
+        assert.equal(hasPendingOrphanDestroyForTests(guildId), true)
+
+        webSearch.release()
+        assert.equal(destroyed, false)
+        assert.equal(getGuildPlayerLifecycleReservationCount(guildId), 1)
+
+        discordPlay.release()
+        await waitForPendingOrphanDestroyForTests(guildId)
+        assert.equal(destroyed, true)
     })
 })
 

--- a/src/util/guildPlayerQueueLock.ts
+++ b/src/util/guildPlayerQueueLock.ts
@@ -65,21 +65,26 @@ export function getGuildPlayerLifecycleReservationCount(guildId: string): number
 }
 
 /**
- * Destroys an empty orphan player when safe. If other lifecycle reservations are held,
+ * Destroys an empty orphan player when safe. If conflicting lifecycle reservations are held,
  * records a pending cleanup and retries under the queue lock when the count reaches zero.
  * Destroy runs under the same lock as reservation grants, so acquire waits until it finishes.
+ *
+ * @param reservedByCaller How many of the current reservation count belong to this caller
+ *   (1 for search/enqueue cleanup that still holds a lease; 0 for idle timers / non-reserved paths).
  */
 export async function tryDestroyOrphanGuildPlayer(
     guildId: string,
-    hooks: PendingOrphanDestroy
+    hooks: PendingOrphanDestroy,
+    reservedByCaller = 1
 ): Promise<void> {
+    const selfReservations = reservedByCaller > 0 ? reservedByCaller : 0
     await withGuildPlayerQueueLock(guildId, async () => {
         if (hooks.hasQueueContent()) {
             pendingOrphanDestroyByGuild.delete(guildId)
             return
         }
-        // Count includes the caller; >1 means another in-flight request still needs the player.
-        if (getGuildPlayerLifecycleReservationCount(guildId) > 1) {
+        // Defer while other in-flight requests still need this player.
+        if (getGuildPlayerLifecycleReservationCount(guildId) > selfReservations) {
             pendingOrphanDestroyByGuild.set(guildId, hooks)
             return
         }

--- a/src/util/guildPlayerQueueLock.ts
+++ b/src/util/guildPlayerQueueLock.ts
@@ -59,6 +59,19 @@ export async function acquireGuildPlayerLifecycleReservation(
     })
 }
 
+/** Acquires a lifecycle reservation, runs `work`, then always releases. */
+export async function withGuildPlayerLifecycleReservation<T>(
+    guildId: string,
+    work: () => Promise<T>
+): Promise<T> {
+    const lease = await acquireGuildPlayerLifecycleReservation(guildId)
+    try {
+        return await work()
+    } finally {
+        lease.release()
+    }
+}
+
 /** Active lifecycle reservations for a guild (includes the calling request while it holds one). */
 export function getGuildPlayerLifecycleReservationCount(guildId: string): number {
     return guildPlayerLifecycleReservations.get(guildId) ?? 0

--- a/src/util/guildSettingsMerge.test.ts
+++ b/src/util/guildSettingsMerge.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { GUILD_SETTING_FIELD_KEYS, mergeGuildSettingsRow } from "./guildSettingsMerge.js"
+
+describe("mergeGuildSettingsRow", () => {
+    it("keeps DB fields omitted from the snapshot (no cross-field clobber)", () => {
+        const merged = mergeGuildSettingsRow(
+            {
+                controlChannelId: "c1",
+                controlMessageId: "m1",
+                downloadsMaxMb: 500,
+            },
+            { controlChannelId: "c2" }
+        )
+        assert.deepEqual(merged, {
+            controlChannelId: "c2",
+            controlMessageId: "m1",
+            downloadsMaxMb: 500,
+        })
+    })
+
+    it("applies clearedFields even when the snapshot still lists those keys", () => {
+        const merged = mergeGuildSettingsRow(
+            { controlChannelId: "c1", downloadsMaxMb: 200 },
+            { controlChannelId: "c1", downloadsMaxMb: 200 },
+            ["downloadsMaxMb"]
+        )
+        assert.deepEqual(merged, { controlChannelId: "c1" })
+        assert.equal("downloadsMaxMb" in merged, false)
+    })
+
+    it("builds a row from snapshot alone when the DB row is missing", () => {
+        const merged = mergeGuildSettingsRow(undefined, {
+            discordLog: { channelId: "log1" },
+            downloadsMaxMb: 100,
+        })
+        assert.deepEqual(merged, {
+            discordLog: { channelId: "log1" },
+            downloadsMaxMb: 100,
+        })
+    })
+
+    it("ignores undefined snapshot values and unknown cleared keys leave other fields", () => {
+        const merged = mergeGuildSettingsRow(
+            { controlChannelId: "c1", controlMessageId: "m1" },
+            { controlChannelId: undefined as unknown as string, controlMessageId: "m2" },
+            []
+        )
+        assert.deepEqual(merged, { controlChannelId: "c1", controlMessageId: "m2" })
+    })
+
+    it("returns an empty object when clearing every known field", () => {
+        const merged = mergeGuildSettingsRow(
+            {
+                controlChannelId: "c1",
+                controlMessageId: "m1",
+                downloadsMaxMb: 50,
+                discordLog: { channelId: "d1" },
+            },
+            {},
+            [...GUILD_SETTING_FIELD_KEYS]
+        )
+        assert.deepEqual(merged, {})
+    })
+
+    it("does not mutate the input DB row", () => {
+        const db = { controlChannelId: "c1", downloadsMaxMb: 10 }
+        const merged = mergeGuildSettingsRow(db, { downloadsMaxMb: 20 })
+        assert.equal(db.downloadsMaxMb, 10)
+        assert.equal(merged.downloadsMaxMb, 20)
+        assert.notEqual(merged, db)
+    })
+})

--- a/src/util/guildSettingsMerge.test.ts
+++ b/src/util/guildSettingsMerge.test.ts
@@ -31,11 +31,11 @@ describe("mergeGuildSettingsRow", () => {
 
     it("builds a row from snapshot alone when the DB row is missing", () => {
         const merged = mergeGuildSettingsRow(undefined, {
-            discordLog: { channelId: "log1" },
+            discordLog: { allChannelId: "log1" },
             downloadsMaxMb: 100,
         })
         assert.deepEqual(merged, {
-            discordLog: { channelId: "log1" },
+            discordLog: { allChannelId: "log1" },
             downloadsMaxMb: 100,
         })
     })
@@ -55,7 +55,7 @@ describe("mergeGuildSettingsRow", () => {
                 controlChannelId: "c1",
                 controlMessageId: "m1",
                 downloadsMaxMb: 50,
-                discordLog: { channelId: "d1" },
+                discordLog: { allChannelId: "d1" },
             },
             {},
             [...GUILD_SETTING_FIELD_KEYS]

--- a/src/util/guildSettingsMerge.ts
+++ b/src/util/guildSettingsMerge.ts
@@ -1,0 +1,52 @@
+import type { GuildSettings } from "../types/index.js"
+
+/** Fields that may be written or cleared on a guild settings row. */
+export const GUILD_SETTING_FIELD_KEYS: (keyof GuildSettings)[] = [
+    "controlChannelId",
+    "controlMessageId",
+    "downloadsMaxMb",
+    "discordLog",
+]
+
+function cloneGuildSettingsRow(row: GuildSettings): GuildSettings {
+    return typeof structuredClone === "function"
+        ? structuredClone(row)
+        : (JSON.parse(JSON.stringify(row)) as GuildSettings)
+}
+
+/**
+ * Merges only fields present in `snapshotRow` onto `dbRow`, then removes `clearedFields`.
+ * Omitted snapshot fields keep their latest database values (prevents cross-field clobber races).
+ */
+export function mergeGuildSettingsRow(
+    dbRow: GuildSettings | undefined,
+    snapshotRow: GuildSettings | undefined,
+    clearedFields: (keyof GuildSettings)[] = []
+): GuildSettings {
+    const merged: GuildSettings = dbRow ? cloneGuildSettingsRow(dbRow) : {}
+    if (snapshotRow) {
+        for (const key of GUILD_SETTING_FIELD_KEYS) {
+            if (key in snapshotRow) {
+                const value = snapshotRow[key]
+                if (value !== undefined) {
+                    switch (key) {
+                        case "controlChannelId":
+                        case "controlMessageId":
+                            merged[key] = value as string
+                            break
+                        case "downloadsMaxMb":
+                            merged.downloadsMaxMb = value as number
+                            break
+                        case "discordLog":
+                            merged.discordLog = value as GuildSettings["discordLog"]
+                            break
+                    }
+                }
+            }
+        }
+    }
+    for (const key of clearedFields) {
+        delete merged[key]
+    }
+    return merged
+}

--- a/src/util/localPlaySessionHandoff.test.ts
+++ b/src/util/localPlaySessionHandoff.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { afterEach, describe, it } from "node:test"
 import type { Player, Track } from "lavalink-client"
+import type { PlayerSessionSnapshotV1 } from "../types/index.js"
 import {
     acquirePlayerSessionClearSuppressLease,
     clearPlayerSession,
@@ -9,16 +10,16 @@ import {
 } from "./playerSessionPersistence.js"
 import { beginLocalPlaySessionHandoff } from "./localPlaySessionHandoff.js"
 
-function mockTrack(): Track {
+function mockTrack(title = "Song"): Track {
     return {
-        encoded: "enc",
+        encoded: `enc-${title}`,
         info: {
-            title: "Song",
+            title,
             author: "Artist",
-            uri: "https://example.com/t",
+            uri: `https://example.com/${title}`,
             duration: 1000,
             isStream: false,
-            identifier: "id",
+            identifier: title,
             isSeekable: true,
             sourceName: "http",
             artworkUrl: null,
@@ -28,7 +29,10 @@ function mockTrack(): Track {
     } as unknown as Track
 }
 
-function mockPlayer(guildId: string): Player {
+function mockPlayer(
+    guildId: string,
+    opts: { current?: Track | null; tracks?: Track[] } = {}
+): Player {
     const store = new Map<string, unknown>()
     return {
         guildId,
@@ -39,8 +43,8 @@ function mockPlayer(guildId: string): Player {
         paused: false,
         playing: true,
         queue: {
-            current: mockTrack(),
-            tracks: [],
+            current: opts.current === undefined ? mockTrack("Current") : opts.current,
+            tracks: opts.tracks ?? [],
         },
         get: (key: string) => store.get(key),
         set: (key: string, value: unknown) => {
@@ -52,6 +56,44 @@ function mockPlayer(guildId: string): Player {
 describe("beginLocalPlaySessionHandoff", () => {
     afterEach(() => {
         setPlayerSessionPersistenceDbForTests(null)
+    })
+
+    it("flushes upcoming queue before destroy callback clears tracks (join-fail restore)", async () => {
+        const guildId = "guild-local-handoff-queue-order"
+        const upsertedQueues: PlayerSessionSnapshotV1["queue"][] = []
+        const deletes: string[] = []
+
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async (_id, _vc, _text, snapshot) => {
+                upsertedQueues.push(snapshot.queue)
+            },
+            deletePlayerSession: async (id) => {
+                deletes.push(id)
+            },
+        })
+
+        const upcoming = [mockTrack("Next-1"), mockTrack("Next-2")]
+        const player = mockPlayer(guildId, { tracks: upcoming })
+
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            // Simulate stopPlaying(true) + destroy after the flush must already have run.
+            player.queue.tracks.length = 0
+            player.queue.current = null
+            assert.equal(shouldSkipPlayerSessionClear(guildId), true)
+            await clearPlayerSession(guildId)
+        })
+        handoff.markDestroyEventSeen()
+
+        assert.equal(handoff.destroyedLavalink, true)
+        assert.equal(upsertedQueues.length, 1)
+        assert.equal(upsertedQueues[0].length, 2)
+        assert.equal(upsertedQueues[0][0]?.info.title, "Next-1")
+        assert.equal(upsertedQueues[0][1]?.info.title, "Next-2")
+        assert.deepEqual(deletes, [])
+
+        // Failed local VC join: preserved row still has the full upcoming queue.
+        handoff.releaseLeftoverSuppressLease()
+        assert.deepEqual(deletes, [])
     })
 
     it("keeps the session row when local join fails after Lavalink destroy", async () => {

--- a/src/util/localPlaySessionHandoff.test.ts
+++ b/src/util/localPlaySessionHandoff.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict"
+import { afterEach, describe, it } from "node:test"
+import type { Player, Track } from "lavalink-client"
+import {
+    acquirePlayerSessionClearSuppressLease,
+    clearPlayerSession,
+    setPlayerSessionPersistenceDbForTests,
+    shouldSkipPlayerSessionClear,
+} from "./playerSessionPersistence.js"
+import { beginLocalPlaySessionHandoff } from "./localPlaySessionHandoff.js"
+
+function mockTrack(): Track {
+    return {
+        encoded: "enc",
+        info: {
+            title: "Song",
+            author: "Artist",
+            uri: "https://example.com/t",
+            duration: 1000,
+            isStream: false,
+            identifier: "id",
+            isSeekable: true,
+            sourceName: "http",
+            artworkUrl: null,
+            isrc: null,
+        },
+        requester: "user-1",
+    } as unknown as Track
+}
+
+function mockPlayer(guildId: string): Player {
+    const store = new Map<string, unknown>()
+    return {
+        guildId,
+        voiceChannelId: "vc-1",
+        textChannelId: "text-1",
+        volume: 80,
+        repeatMode: "off",
+        paused: false,
+        playing: true,
+        queue: {
+            current: mockTrack(),
+            tracks: [],
+        },
+        get: (key: string) => store.get(key),
+        set: (key: string, value: unknown) => {
+            store.set(key, value)
+        },
+    } as unknown as Player
+}
+
+describe("beginLocalPlaySessionHandoff", () => {
+    afterEach(() => {
+        setPlayerSessionPersistenceDbForTests(null)
+    })
+
+    it("keeps the session row when local join fails after Lavalink destroy", async () => {
+        const guildId = "guild-local-handoff-keep"
+        const deletes: string[] = []
+        const upserts: string[] = []
+
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async (id) => {
+                upserts.push(id)
+            },
+            deletePlayerSession: async (id) => {
+                deletes.push(id)
+            },
+        })
+
+        const player = mockPlayer(guildId)
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            // Simulate playerDestroy → clearPlayerSession while lease is held.
+            assert.equal(shouldSkipPlayerSessionClear(guildId), true)
+            await clearPlayerSession(guildId)
+        })
+        handoff.markDestroyEventSeen()
+
+        assert.equal(handoff.destroyedLavalink, true)
+        assert.deepEqual(deletes, [])
+        assert.ok(upserts.includes(guildId), "flush should persist snapshot before destroy")
+
+        // Failed local VC join: leave the row; leftover release is a no-op after consume.
+        handoff.releaseLeftoverSuppressLease()
+        assert.deepEqual(deletes, [])
+        assert.equal(shouldSkipPlayerSessionClear(guildId), false)
+
+        // Later intentional clear (e.g. user stops) can still delete.
+        await clearPlayerSession(guildId)
+        assert.deepEqual(deletes, [guildId])
+    })
+
+    it("clears the session only after local Ready succeeds", async () => {
+        const guildId = "guild-local-handoff-clear"
+        const deletes: string[] = []
+
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => undefined,
+            deletePlayerSession: async (id) => {
+                deletes.push(id)
+            },
+        })
+
+        const player = mockPlayer(guildId)
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            await clearPlayerSession(guildId)
+        })
+        handoff.markDestroyEventSeen()
+
+        assert.deepEqual(deletes, [])
+        await handoff.clearSessionAfterLocalReady()
+        assert.deepEqual(deletes, [guildId])
+    })
+
+    it("releases leftover suppress lease when playerDestroy never fires", async () => {
+        const guildId = "guild-local-handoff-timeout"
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => undefined,
+            deletePlayerSession: async () => undefined,
+        })
+
+        const player = mockPlayer(guildId)
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            // Destroy "succeeds" but no playerDestroy / clear ran (timeout path).
+        })
+
+        assert.equal(shouldSkipPlayerSessionClear(guildId), true)
+        handoff.releaseLeftoverSuppressLease()
+        assert.equal(shouldSkipPlayerSessionClear(guildId), false)
+    })
+
+    it("releases the lease immediately when destroy throws", async () => {
+        const guildId = "guild-local-handoff-destroy-fail"
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => undefined,
+            deletePlayerSession: async () => undefined,
+        })
+
+        const player = mockPlayer(guildId)
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            throw new Error("destroy failed")
+        })
+
+        assert.equal(handoff.destroyedLavalink, false)
+        assert.equal(shouldSkipPlayerSessionClear(guildId), false)
+    })
+
+    it("does not double-release after playerDestroy consumed the lease", async () => {
+        const guildId = "guild-local-handoff-no-double"
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => undefined,
+            deletePlayerSession: async () => undefined,
+        })
+
+        // Extra concurrent lease must survive releaseLeftover when destroy already consumed ours.
+        const other = acquirePlayerSessionClearSuppressLease(guildId)
+        const player = mockPlayer(guildId)
+        const handoff = await beginLocalPlaySessionHandoff(player, async () => {
+            await clearPlayerSession(guildId)
+        })
+        handoff.markDestroyEventSeen()
+
+        handoff.releaseLeftoverSuppressLease()
+        assert.equal(shouldSkipPlayerSessionClear(guildId), true)
+        other.release()
+        assert.equal(shouldSkipPlayerSessionClear(guildId), false)
+    })
+})

--- a/src/util/localPlaySessionHandoff.test.ts
+++ b/src/util/localPlaySessionHandoff.test.ts
@@ -87,8 +87,8 @@ describe("beginLocalPlaySessionHandoff", () => {
         assert.equal(handoff.destroyedLavalink, true)
         assert.equal(upsertedQueues.length, 1)
         assert.equal(upsertedQueues[0].length, 2)
-        assert.equal(upsertedQueues[0][0]?.info.title, "Next-1")
-        assert.equal(upsertedQueues[0][1]?.info.title, "Next-2")
+        assert.equal(upsertedQueues[0][0]?.title, "Next-1")
+        assert.equal(upsertedQueues[0][1]?.title, "Next-2")
         assert.deepEqual(deletes, [])
 
         // Failed local VC join: preserved row still has the full upcoming queue.

--- a/src/util/localPlaySessionHandoff.ts
+++ b/src/util/localPlaySessionHandoff.ts
@@ -13,6 +13,9 @@ import {
  * Destroying Lavalink fires `playerDestroy` → `clearPlayerSession`. Without a suppress
  * lease, a failed local VC join after destroy permanently deletes the persisted queue.
  * Hold a suppress lease across destroy, then clear only after local Ready succeeds.
+ *
+ * Callers must not mutate the live queue (e.g. `stopPlaying(true)`) before this runs —
+ * the flush below captures `player.queue` as-is.
  */
 export type LocalPlaySessionHandoff = {
     /** True when Lavalink destroy was attempted successfully (player torn down). */
@@ -31,6 +34,9 @@ export type LocalPlaySessionHandoff = {
 /**
  * Flushes the live snapshot, acquires a suppress lease, then runs `destroyLavalink`.
  * On destroy failure the lease is released immediately.
+ *
+ * `destroyLavalink` may clear/stop the player — do that only inside the callback so the
+ * flushed snapshot still includes upcoming tracks.
  */
 export async function beginLocalPlaySessionHandoff(
     player: Player,

--- a/src/util/localPlaySessionHandoff.ts
+++ b/src/util/localPlaySessionHandoff.ts
@@ -1,0 +1,78 @@
+import type { Player } from "lavalink-client"
+import {
+    acquirePlayerSessionClearSuppressLease,
+    clearPlayerSession,
+    flushPlayerSessionSave,
+    schedulePlayerSessionSave,
+    type PlayerSessionClearSuppressLease,
+} from "./playerSessionPersistence.js"
+
+/**
+ * Session policy for Lavalink → @discordjs/voice local playback handoff.
+ *
+ * Destroying Lavalink fires `playerDestroy` → `clearPlayerSession`. Without a suppress
+ * lease, a failed local VC join after destroy permanently deletes the persisted queue.
+ * Hold a suppress lease across destroy, then clear only after local Ready succeeds.
+ */
+export type LocalPlaySessionHandoff = {
+    /** True when Lavalink destroy was attempted successfully (player torn down). */
+    readonly destroyedLavalink: boolean
+    /**
+     * Call after `playerDestroy` is observed (or known to have run). When true, the
+     * suppress lease was consumed by the skipped clear; do not release again.
+     */
+    markDestroyEventSeen(): void
+    /** Release a leftover lease if destroy never emitted `playerDestroy` (avoid leak). */
+    releaseLeftoverSuppressLease(): void
+    /** Intentional clear after local playback has started successfully. */
+    clearSessionAfterLocalReady(): Promise<void>
+}
+
+/**
+ * Flushes the live snapshot, acquires a suppress lease, then runs `destroyLavalink`.
+ * On destroy failure the lease is released immediately.
+ */
+export async function beginLocalPlaySessionHandoff(
+    player: Player,
+    destroyLavalink: () => Promise<void>
+): Promise<LocalPlaySessionHandoff> {
+    const guildId = player.guildId
+    schedulePlayerSessionSave(player)
+    await flushPlayerSessionSave(guildId)
+
+    let lease: PlayerSessionClearSuppressLease | null =
+        acquirePlayerSessionClearSuppressLease(guildId)
+    let destroyEventSeen = false
+    let destroyedLavalink = false
+
+    try {
+        await destroyLavalink()
+        destroyedLavalink = true
+    } catch {
+        lease.release()
+        lease = null
+    }
+
+    return {
+        get destroyedLavalink() {
+            return destroyedLavalink
+        },
+        markDestroyEventSeen() {
+            destroyEventSeen = true
+        },
+        releaseLeftoverSuppressLease() {
+            if (!lease || destroyEventSeen) return
+            lease.release()
+            lease = null
+        },
+        async clearSessionAfterLocalReady() {
+            // If playerDestroy never consumed the lease, release so clear can delete.
+            if (lease && !destroyEventSeen) {
+                lease.release()
+                lease = null
+            }
+            if (!destroyedLavalink) return
+            await clearPlayerSession(guildId)
+        },
+    }
+}

--- a/src/util/localPlayer.ts
+++ b/src/util/localPlayer.ts
@@ -17,30 +17,37 @@ import type {
     LocalPlayerState,
     QueryPlayResult,
 } from "../types/index.js"
+import {
+    beginLocalPlaySessionHandoff,
+    type LocalPlaySessionHandoff,
+} from "./localPlaySessionHandoff.js"
 
 const activeLocalPlayers = new Map<string, ActiveLocalPlayer>()
 const pendingLocalPlayGuildIds = new Set<string>()
 
-/** Resolves when Lavalink emits `playerDestroy` for the guild or after `timeoutMs` (teardown handoff). */
+/**
+ * Resolves when Lavalink emits `playerDestroy` for the guild or after `timeoutMs`.
+ * Returns whether the destroy event was observed (vs timeout).
+ */
 function waitForLavalinkPlayerDestroy(
     client: BotClient,
     guildId: string,
     timeoutMs: number
-): Promise<void> {
+): Promise<boolean> {
     return new Promise((resolve) => {
         let settled = false
-        const finish = () => {
+        const finish = (eventSeen: boolean) => {
             if (settled) return
             settled = true
             clearTimeout(timer)
             client.lavalink.off("playerDestroy", onDestroy)
-            resolve()
+            resolve(eventSeen)
         }
         const onDestroy = (p: Player) => {
             if (p.guildId !== guildId) return
-            finish()
+            finish(true)
         }
-        const timer = setTimeout(finish, timeoutMs)
+        const timer = setTimeout(() => finish(false), timeoutMs)
         client.lavalink.on("playerDestroy", onDestroy)
     })
 }
@@ -81,6 +88,7 @@ export async function playLocalFile(
     pendingLocalPlayGuildIds.add(guildId)
 
     let postLavalinkHandoff: Promise<void> = new Promise((r) => queueMicrotask(r))
+    let sessionHandoff: LocalPlaySessionHandoff | null = null
 
     if (lavalinkPlayer) {
         client.debug(
@@ -98,8 +106,11 @@ export async function playLocalFile(
             }
         }
         if (client.lavalink.players.has(guildId)) {
-            postLavalinkHandoff = waitForLavalinkPlayerDestroy(client, guildId, 2000)
-            try {
+            // Preserve the DB session across destroy until local Ready succeeds.
+            // Otherwise playerDestroy → clearPlayerSession wipes the queue on a failed join.
+            let destroyEventWait: Promise<boolean> = Promise.resolve(false)
+            sessionHandoff = await beginLocalPlaySessionHandoff(lavalinkPlayer, async () => {
+                destroyEventWait = waitForLavalinkPlayerDestroy(client, guildId, 2000)
                 client.debug(
                     `[LocalPlayer] Attempting to destroy existing Lavalink player for guild ${guildId}.`
                 )
@@ -116,12 +127,15 @@ export async function playLocalFile(
                         `[LocalPlayer] Attempted to delete player from Lavalink manager for guild ${guildId}, but it was not found (or delete returned false).`
                     )
                 }
-            } catch (e: unknown) {
-                const msg = e instanceof Error ? e.message : String(e)
+            })
+            if (!sessionHandoff.destroyedLavalink) {
                 client.warn(
-                    `[LocalPlayer] Failed to destroy or delete Lavalink player in guild ${guildId}: ${msg}. Proceeding with @discordjs/voice connection attempt.`
+                    `[LocalPlayer] Failed to destroy Lavalink player in guild ${guildId}. Proceeding with @discordjs/voice connection attempt.`
                 )
             }
+            postLavalinkHandoff = destroyEventWait.then((eventSeen) => {
+                if (eventSeen) sessionHandoff?.markDestroyEventSeen()
+            })
         } else {
             client.debug(
                 `[LocalPlayer] No Lavalink player found in manager for guild ${guildId} prior to local play.`
@@ -171,6 +185,9 @@ export async function playLocalFile(
                 `[LocalPlayer] Failed to join or get ready in voice channel ${voiceChannel.id} for guild ${guildId}:`,
                 error
             )
+            // Keep the persisted Lavalink session so a restart (or later restore) can recover
+            // the queue that was torn down before this failed local join.
+            sessionHandoff?.releaseLeftoverSuppressLease()
             if (connection && connection.state.status !== VoiceConnectionStatus.Destroyed) {
                 connection.destroy()
             }
@@ -179,6 +196,15 @@ export async function playLocalFile(
                 feedbackText: "I couldn't connect to your voice channel to play the local file.",
                 error: error instanceof Error ? error : new Error(String(error)),
             }
+        }
+
+        try {
+            await sessionHandoff?.clearSessionAfterLocalReady()
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e)
+            client.warn(
+                `[LocalPlayer] clearPlayerSession after local Ready failed for guild ${guildId}: ${msg}`
+            )
         }
 
         const conn = connection!

--- a/src/util/localPlayer.ts
+++ b/src/util/localPlayer.ts
@@ -94,22 +94,22 @@ export async function playLocalFile(
         client.debug(
             `[LocalPlayer] Checking Lavalink player state for guild ${guildId}. Connected: ${lavalinkPlayer.connected}, Playing: ${lavalinkPlayer.playing}`
         )
-        if (lavalinkPlayer.playing) {
-            try {
-                await lavalinkPlayer.stopPlaying(true, false)
-                client.debug(`[LocalPlayer] Stopped Lavalink player in guild ${guildId}.`)
-            } catch (e: unknown) {
-                const msg = e instanceof Error ? e.message : String(e)
-                client.warn(
-                    `[LocalPlayer] Failed to stop Lavalink player in guild ${guildId}: ${msg}`
-                )
-            }
-        }
         if (client.lavalink.players.has(guildId)) {
-            // Preserve the DB session across destroy until local Ready succeeds.
-            // Otherwise playerDestroy → clearPlayerSession wipes the queue on a failed join.
+            // Flush the full queue *before* stopPlaying(true) clears upcoming tracks, then
+            // suppress clearPlayerSession across destroy so a failed local join can restore.
             let destroyEventWait: Promise<boolean> = Promise.resolve(false)
             sessionHandoff = await beginLocalPlaySessionHandoff(lavalinkPlayer, async () => {
+                if (lavalinkPlayer.playing) {
+                    try {
+                        await lavalinkPlayer.stopPlaying(true, false)
+                        client.debug(`[LocalPlayer] Stopped Lavalink player in guild ${guildId}.`)
+                    } catch (e: unknown) {
+                        const msg = e instanceof Error ? e.message : String(e)
+                        client.warn(
+                            `[LocalPlayer] Failed to stop Lavalink player in guild ${guildId}: ${msg}`
+                        )
+                    }
+                }
                 destroyEventWait = waitForLavalinkPlayerDestroy(client, guildId, 2000)
                 client.debug(
                     `[LocalPlayer] Attempting to destroy existing Lavalink player for guild ${guildId}.`
@@ -140,6 +140,17 @@ export async function playLocalFile(
             client.debug(
                 `[LocalPlayer] No Lavalink player found in manager for guild ${guildId} prior to local play.`
             )
+            if (lavalinkPlayer.playing) {
+                try {
+                    await lavalinkPlayer.stopPlaying(true, false)
+                    client.debug(`[LocalPlayer] Stopped Lavalink player in guild ${guildId}.`)
+                } catch (e: unknown) {
+                    const msg = e instanceof Error ? e.message : String(e)
+                    client.warn(
+                        `[LocalPlayer] Failed to stop Lavalink player in guild ${guildId}: ${msg}`
+                    )
+                }
+            }
         }
     }
 
@@ -185,8 +196,7 @@ export async function playLocalFile(
                 `[LocalPlayer] Failed to join or get ready in voice channel ${voiceChannel.id} for guild ${guildId}:`,
                 error
             )
-            // Keep the persisted Lavalink session so a restart (or later restore) can recover
-            // the queue that was torn down before this failed local join.
+            // Keep the persisted Lavalink session (full queue flushed before stop/destroy).
             sessionHandoff?.releaseLeftoverSuppressLease()
             if (connection && connection.state.status !== VoiceConnectionStatus.Destroyed) {
                 connection.destroy()

--- a/src/util/musicBrainzSimilarService.ts
+++ b/src/util/musicBrainzSimilarService.ts
@@ -3,6 +3,8 @@
  * @see https://musicbrainz.org/doc/MusicBrainz_API — rate limit ~1 req/s; User-Agent required.
  */
 
+import { escapeLucenePhrase } from "./escapeLucenePhrase.js"
+
 const MB_ROOT = "https://musicbrainz.org/ws/2"
 
 let lastMbRequestAt = 0
@@ -46,16 +48,6 @@ async function mbFetch(pathQuery: string): Promise<Response> {
         },
     })
     return res
-}
-
-/**
- * @param {string} s
- */
-function escapeLucenePhrase(s: string) {
-    return String(s || "")
-        .trim()
-        .replace(/\\/g, "\\\\")
-        .replace(/"/g, '\\"')
 }
 
 /**

--- a/src/util/musicManager.ts
+++ b/src/util/musicManager.ts
@@ -22,6 +22,10 @@ import {
 import { downloadMetadataFileBelongsToGuild } from "./downloadMetadataKeys.js"
 import { getDownloadMetadataStore } from "./downloadMetadataStore.js"
 import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
+import {
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "./sameVoiceChannel.js"
 
 type SearchAttempt =
     | { source: string; success: true; loadType?: string }
@@ -432,6 +436,17 @@ export async function handleQueryAndPlay(
 
         const currentLocalPlayerState = getLocalPlayerState(guildId)
         if (currentLocalPlayerState && currentLocalPlayerState.isPlaying) {
+            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(
+                voiceChannel.guild,
+                player
+            )
+            if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
+                return {
+                    success: false,
+                    feedbackText: `${requester}, You need to be in the same voice channel as the bot!`,
+                    error: new Error("other voice channel during local playback"),
+                }
+            }
             client.debug(
                 `[MusicManager] Active local player found in guild ${guildId}. Stopping it before Lavalink playback.`
             )

--- a/src/util/musicManager.ts
+++ b/src/util/musicManager.ts
@@ -22,10 +22,7 @@ import {
 import { downloadMetadataFileBelongsToGuild } from "./downloadMetadataKeys.js"
 import { getDownloadMetadataStore } from "./downloadMetadataStore.js"
 import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
-import {
-    memberMayJoinOccupiedVoice,
-    resolveOccupiedVoiceChannelId,
-} from "./sameVoiceChannel.js"
+import { memberMayJoinOccupiedVoice, resolveOccupiedVoiceChannelId } from "./sameVoiceChannel.js"
 
 type SearchAttempt =
     | { source: string; success: true; loadType?: string }
@@ -436,10 +433,7 @@ export async function handleQueryAndPlay(
 
         const currentLocalPlayerState = getLocalPlayerState(guildId)
         if (currentLocalPlayerState && currentLocalPlayerState.isPlaying) {
-            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(
-                voiceChannel.guild,
-                player
-            )
+            const occupiedVoiceChannelId = resolveOccupiedVoiceChannelId(voiceChannel.guild, player)
             if (!memberMayJoinOccupiedVoice(occupiedVoiceChannelId, voiceChannel.id)) {
                 return {
                     success: false,

--- a/src/util/originFallback.test.ts
+++ b/src/util/originFallback.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { getOriginFallback } from "../web/server/origin-fallback.js"
+
+describe("getOriginFallback", () => {
+    it("returns the BETTER_AUTH_URL origin when set to a valid http(s) URL", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            process.env.BETTER_AUTH_URL = "https://dashboard.example/app"
+            assert.equal(getOriginFallback(), "https://dashboard.example")
+
+            process.env.BETTER_AUTH_URL = " http://localhost:3000/ "
+            assert.equal(getOriginFallback(), "http://localhost:3000")
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+
+    it("returns null when unset or not a valid URL", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            delete process.env.BETTER_AUTH_URL
+            assert.equal(getOriginFallback(), null)
+
+            process.env.BETTER_AUTH_URL = "   "
+            assert.equal(getOriginFallback(), null)
+
+            process.env.BETTER_AUTH_URL = "not a url"
+            assert.equal(getOriginFallback(), null)
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+})

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -121,6 +121,44 @@ describe("snapshotFromPlayer", () => {
     })
 })
 
+describe("shouldClearPlayerSessionOnDestroy", () => {
+    it("clears for intentional app destroys (undefined / empty reason)", () => {
+        assert.equal(shouldClearPlayerSessionOnDestroy(undefined), true)
+        assert.equal(shouldClearPlayerSessionOnDestroy(null), true)
+        assert.equal(shouldClearPlayerSessionOnDestroy(""), true)
+        assert.equal(shouldClearPlayerSessionOnDestroy("custom leave"), true)
+    })
+
+    it("preserves sessions for Discord disconnect and reconnect failure", () => {
+        assert.equal(shouldClearPlayerSessionOnDestroy("Disconnected"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("PlayerReconnectFail"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("LavalinkNoVoice"), false)
+    })
+
+    it("preserves sessions for node / infra teardown reasons", () => {
+        assert.equal(shouldClearPlayerSessionOnDestroy("NodeDestroy"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("NodeDeleted"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("NodeReconnectFail"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("DisconnectAllNodes"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("ReconnectAllNodes"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("PlayerChangeNodeFail"), false)
+        assert.equal(
+            shouldClearPlayerSessionOnDestroy("PlayerChangeNodeFailNoEligibleNode"),
+            false
+        )
+    })
+
+    it("preserves sessions for library max-errors auto-destroy", () => {
+        assert.equal(shouldClearPlayerSessionOnDestroy("TrackErrorMaxTracksErroredPerTime"), false)
+        assert.equal(shouldClearPlayerSessionOnDestroy("TrackStuckMaxTracksErroredPerTime"), false)
+    })
+
+    it("still clears when the voice channel itself is deleted", () => {
+        assert.equal(shouldClearPlayerSessionOnDestroy("ChannelDeleted"), true)
+        assert.equal(shouldClearPlayerSessionOnDestroy("QueueEmpty"), true)
+    })
+})
+
 describe("shouldSkipPlayerSessionClear", () => {
     afterEach(() => {
         clearPlayerSessionRestoreInProgress("guild-restore")

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -10,6 +10,7 @@ import {
     setPlayerSessionPersistenceDbForTests,
     shouldSkipPlayerSessionClear,
     shouldSkipPlayerSessionClearForState,
+    shouldClearPlayerSessionOnDestroy,
     shouldUndoStaleSessionUpsert,
     snapshotFromPlayer,
     writePlayerSessionForTests,

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -160,6 +160,37 @@ describe("shouldSkipPlayerSessionClear", () => {
     })
 })
 
+describe("clearPlayerSession suppress lease consumption", () => {
+    afterEach(() => {
+        setPlayerSessionPersistenceDbForTests(null)
+    })
+
+    it("consumes one suppress lease without deleting or bumping the clear epoch", async () => {
+        const guildId = "guild-suppress-consume"
+        const events: string[] = []
+        setPlayerSessionPersistenceDbForTests({
+            upsertPlayerSession: async () => {
+                events.push("upsert")
+            },
+            deletePlayerSession: async () => {
+                events.push("delete")
+            },
+        })
+
+        const epochBefore = getSessionClearEpochForTests(guildId)
+        acquirePlayerSessionClearSuppressLease(guildId)
+        await clearPlayerSession(guildId)
+
+        assert.deepEqual(events, [])
+        assert.equal(getSessionClearEpochForTests(guildId), epochBefore)
+        assert.equal(shouldSkipPlayerSessionClear(guildId), false)
+
+        await clearPlayerSession(guildId)
+        assert.deepEqual(events, ["delete"])
+        assert.equal(getSessionClearEpochForTests(guildId), epochBefore + 1)
+    })
+})
+
 describe("shouldUndoStaleSessionUpsert", () => {
     it("undoes when clear invalidated the write and no newer persist claimed generation", () => {
         // saveEpoch 1, clear bumped to 2, write still owns generation 5

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -5,6 +5,7 @@ import {
     acquirePlayerSessionClearSuppressLease,
     clearPlayerSession,
     clearPlayerSessionRestoreInProgress,
+    destroyPlayerSuppressingSessionClear,
     getSessionClearEpochForTests,
     markPlayerSessionRestoreInProgress,
     setPlayerSessionPersistenceDbForTests,
@@ -193,6 +194,28 @@ describe("shouldSkipPlayerSessionClear", () => {
         assert.equal(shouldSkipPlayerSessionClear("guild-lease"), true)
         leaseB.release()
         assert.equal(shouldSkipPlayerSessionClear("guild-lease"), false)
+    })
+
+    it("releases suppress lease when destroyPlayer returns undefined (already gone)", async () => {
+        // Mirrors LavalinkManager.destroyPlayer: sync undefined when no player exists.
+        // The old `.catch` pattern threw TypeError and leaked the lease forever.
+        await destroyPlayerSuppressingSessionClear("guild-gone", () => undefined)
+        assert.equal(shouldSkipPlayerSessionClear("guild-gone"), false)
+    })
+
+    it("releases suppress lease when destroyPlayer rejects", async () => {
+        await destroyPlayerSuppressingSessionClear("guild-reject", () =>
+            Promise.reject(new Error("destroy failed"))
+        )
+        assert.equal(shouldSkipPlayerSessionClear("guild-reject"), false)
+    })
+
+    it("keeps suppress lease when destroyPlayer resolves (clear consumes it)", async () => {
+        await destroyPlayerSuppressingSessionClear("guild-ok", () => Promise.resolve())
+        assert.equal(shouldSkipPlayerSessionClear("guild-ok"), true)
+        // Simulate playerDestroy → clearPlayerSession consuming the lease.
+        await clearPlayerSession("guild-ok")
+        assert.equal(shouldSkipPlayerSessionClear("guild-ok"), false)
     })
 })
 

--- a/src/util/playerSessionPersistence.test.ts
+++ b/src/util/playerSessionPersistence.test.ts
@@ -142,10 +142,7 @@ describe("shouldClearPlayerSessionOnDestroy", () => {
         assert.equal(shouldClearPlayerSessionOnDestroy("DisconnectAllNodes"), false)
         assert.equal(shouldClearPlayerSessionOnDestroy("ReconnectAllNodes"), false)
         assert.equal(shouldClearPlayerSessionOnDestroy("PlayerChangeNodeFail"), false)
-        assert.equal(
-            shouldClearPlayerSessionOnDestroy("PlayerChangeNodeFailNoEligibleNode"),
-            false
-        )
+        assert.equal(shouldClearPlayerSessionOnDestroy("PlayerChangeNodeFailNoEligibleNode"), false)
     })
 
     it("preserves sessions for library max-errors auto-destroy", () => {

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -327,6 +327,35 @@ export async function flushAllPlayerSessionSaves(): Promise<void> {
     }
 }
 
+/**
+ * Library / infrastructure destroy reasons that must not wipe persisted sessions.
+ * Intentional app destroys (`player.destroy()` with no reason, alone-in-VC, /stop, etc.)
+ * still clear so queues do not resurrect after an explicit teardown.
+ */
+const PRESERVE_SESSION_DESTROY_REASONS = new Set([
+    "Disconnected",
+    "PlayerReconnectFail",
+    "LavalinkNoVoice",
+    "NodeDestroy",
+    "NodeDeleted",
+    "NodeReconnectFail",
+    "DisconnectAllNodes",
+    "ReconnectAllNodes",
+    "PlayerChangeNodeFail",
+    "PlayerChangeNodeFailNoEligibleNode",
+    "TrackErrorMaxTracksErroredPerTime",
+    "TrackStuckMaxTracksErroredPerTime",
+])
+
+/**
+ * Whether `playerDestroy` should delete the DB session for this destroy reason.
+ * Non-string reasons (typical app `player.destroy()`) clear; known infra reasons preserve.
+ */
+export function shouldClearPlayerSessionOnDestroy(reason: unknown): boolean {
+    if (typeof reason !== "string" || reason.length === 0) return true
+    return !PRESERVE_SESSION_DESTROY_REASONS.has(reason)
+}
+
 /** Removes a persisted session row (intentional destroy or stale cleanup). */
 export async function clearPlayerSession(guildId: string): Promise<void> {
     // Evaluate preserve/skip before bumping the clear epoch or cancelling pending saves.

--- a/src/util/playerSessionPersistence.ts
+++ b/src/util/playerSessionPersistence.ts
@@ -142,6 +142,33 @@ export function acquirePlayerSessionClearSuppressLease(
     }
 }
 
+/**
+ * Runs an ephemeral destroy under a suppress lease.
+ * LavalinkManager.destroyPlayer returns `undefined` (not a Promise) when no player exists —
+ * calling `.catch` on that throws and would leak the lease. Release when destroy does not run
+ * or rejects; a successful destroy leaves the lease for playerDestroy → clearPlayerSession.
+ */
+export async function destroyPlayerSuppressingSessionClear(
+    guildId: string,
+    destroyPlayer: () => Promise<unknown> | void | undefined
+): Promise<void> {
+    const suppressLease = acquirePlayerSessionClearSuppressLease(guildId)
+    let result: Promise<unknown> | void | undefined
+    try {
+        result = destroyPlayer()
+    } catch {
+        suppressLease.release()
+        return
+    }
+    if (result == null || typeof (result as Promise<unknown>).then !== "function") {
+        suppressLease.release()
+        return
+    }
+    await (result as Promise<unknown>).catch(() => {
+        suppressLease.release()
+    })
+}
+
 /** Set during SIGINT/SIGTERM so playerDestroy does not wipe flushed session rows. */
 export function markPlayerSessionPersistenceShuttingDown(): void {
     persistenceShuttingDown = true

--- a/src/util/playerSessionTracks.test.ts
+++ b/src/util/playerSessionTracks.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player } from "lavalink-client"
+import type { PersistedQueueTrack } from "../types/index.js"
+import { resolvePersistedTracks } from "./playerSessionTracks.js"
+
+function stored(overrides: Partial<PersistedQueueTrack> = {}): PersistedQueueTrack {
+    return {
+        title: "Song",
+        author: "Artist",
+        uri: "https://example.com/track",
+        duration: 1000,
+        encoded: null,
+        requesterId: "user-1",
+        thumbnailUrl: null,
+        isStream: false,
+        ...overrides,
+    }
+}
+
+function mockPlayer(hooks: {
+    search?: (uri: string) => Promise<{ tracks: unknown[] }>
+    decode?: (encoded: string) => Promise<unknown>
+}): Player {
+    return {
+        search: async (uri: string) => {
+            if (!hooks.search) throw new Error("search not stubbed")
+            return hooks.search(uri)
+        },
+        node: {
+            decode: {
+                singleTrack: async (encoded: string) => {
+                    if (!hooks.decode) throw new Error("decode not stubbed")
+                    return hooks.decode(encoded)
+                },
+            },
+        },
+    } as unknown as Player
+}
+
+describe("resolvePersistedTracks transient vs permanent failures", () => {
+    it("reports transientFailures when URI search throws", async () => {
+        const player = mockPlayer({
+            search: async () => {
+                throw new Error("lavalink down")
+            },
+        })
+        const result = await resolvePersistedTracks(player, [stored()])
+        assert.equal(result.resolved.length, 0)
+        assert.equal(result.failed, 1)
+        assert.equal(result.transientFailures, 1)
+    })
+
+    it("treats empty search results as permanent failures", async () => {
+        const player = mockPlayer({
+            search: async () => ({ tracks: [] }),
+        })
+        const result = await resolvePersistedTracks(player, [stored()])
+        assert.equal(result.resolved.length, 0)
+        assert.equal(result.failed, 1)
+        assert.equal(result.transientFailures, 0)
+    })
+
+    it("reports transientFailures when encoded-only decode throws", async () => {
+        const player = mockPlayer({
+            decode: async () => {
+                throw new Error("decode failed")
+            },
+        })
+        const result = await resolvePersistedTracks(player, [
+            stored({ uri: "", encoded: "encoded-track" }),
+        ])
+        assert.equal(result.resolved.length, 0)
+        assert.equal(result.failed, 1)
+        assert.equal(result.transientFailures, 1)
+    })
+})

--- a/src/util/playerSessionTracks.ts
+++ b/src/util/playerSessionTracks.ts
@@ -57,8 +57,9 @@ function trackMatchesStored(track: Track, stored: PersistedQueueTrack): boolean 
 async function resolvePersistedTrackAtIndex(
     player: Player,
     stored: PersistedQueueTrack
-): Promise<Track | null> {
+): Promise<{ track: Track | null; transientFailure: boolean }> {
     const requester = stored.requesterId ?? "session-restore"
+    let sawTransientFailure = false
 
     if (stored.encoded) {
         try {
@@ -67,9 +68,10 @@ async function resolvePersistedTrackAtIndex(
                 if (stored.requesterId) {
                     stampRequesterUserIdOnTracks([decoded], stored.requesterId)
                 }
-                return decoded
+                return { track: decoded, transientFailure: false }
             }
         } catch {
+            sawTransientFailure = true
             /* fall through to URI search */
         }
     }
@@ -82,32 +84,41 @@ async function resolvePersistedTrackAtIndex(
                 if (stored.requesterId) {
                     stampRequesterUserIdOnTracks([first], stored.requesterId)
                 }
-                return first
+                return { track: first, transientFailure: false }
             }
+            // Search completed but no usable match — permanent for this snapshot.
+            return { track: null, transientFailure: false }
         } catch {
-            /* unresolved */
+            return { track: null, transientFailure: true }
         }
     }
-    return null
+
+    // Encoded-only track whose decode threw, with no URI fallback.
+    return { track: null, transientFailure: sawTransientFailure }
 }
 
 /** Resolves persisted tracks via Lavalink (parallel, preserves order). */
 export async function resolvePersistedTracks(
     player: Player,
     storedTracks: PersistedQueueTrack[]
-): Promise<{ resolved: Track[]; failed: number }> {
+): Promise<{ resolved: Track[]; failed: number; transientFailures: number }> {
     if (storedTracks.length === 0) {
-        return { resolved: [], failed: 0 }
+        return { resolved: [], failed: 0, transientFailures: 0 }
     }
 
     const slots: (Track | null)[] = new Array(storedTracks.length).fill(null)
     let nextIndex = 0
+    let transientFailures = 0
 
     async function worker(): Promise<void> {
         while (true) {
             const i = nextIndex++
             if (i >= storedTracks.length) return
-            slots[i] = await resolvePersistedTrackAtIndex(player, storedTracks[i]!)
+            const outcome = await resolvePersistedTrackAtIndex(player, storedTracks[i]!)
+            slots[i] = outcome.track
+            if (!outcome.track && outcome.transientFailure) {
+                transientFailures += 1
+            }
         }
     }
 
@@ -118,5 +129,5 @@ export async function resolvePersistedTracks(
     for (const track of slots) {
         if (track) resolved.push(track)
     }
-    return { resolved, failed: storedTracks.length - resolved.length }
+    return { resolved, failed: storedTracks.length - resolved.length, transientFailures }
 }

--- a/src/util/playlistQueue.lock.test.ts
+++ b/src/util/playlistQueue.lock.test.ts
@@ -4,16 +4,16 @@ import type { Player, Track } from "lavalink-client"
 import { withGuildPlayerQueueLock } from "./guildPlayerQueueLock.js"
 import { playerHasQueueContent } from "./playlistQueue.js"
 
-function mockTrack(): Track {
+function mockTrack(id: string): Track {
     return {
-        encoded: "enc",
+        encoded: `enc-${id}`,
         info: {
-            title: "Song",
+            title: id,
             author: "Artist",
-            uri: "https://example.com/t",
+            uri: `https://example.com/${id}`,
             duration: 1000,
             isStream: false,
-            identifier: "id",
+            identifier: id,
             isSeekable: true,
             sourceName: "http",
             artworkUrl: null,
@@ -23,12 +23,24 @@ function mockTrack(): Track {
     } as unknown as Track
 }
 
-function mockEmptyPlayer(guildId: string): Player {
+function mockMutablePlayer(guildId: string, initial: Track[] = []): Player {
+    const tracks = [...initial]
     return {
         guildId,
+        playing: true,
         queue: {
             current: null,
-            tracks: [] as Track[],
+            tracks,
+            add(items: Track | Track[]) {
+                const list = Array.isArray(items) ? items : [items]
+                tracks.push(...list)
+            },
+            async splice(start: number, deleteCount: number, ...insert: Track[]) {
+                return tracks.splice(start, deleteCount, ...insert.flat())
+            },
+        },
+        get() {
+            return undefined
         },
     } as unknown as Player
 }
@@ -36,11 +48,11 @@ function mockEmptyPlayer(guildId: string): Player {
 describe("playlist orphan cleanup vs enqueue lock", () => {
     it("skips destroy when enqueue wins the guild queue lock first", async () => {
         const guildId = "guild-playlist-race"
-        const player = mockEmptyPlayer(guildId)
+        const player = mockMutablePlayer(guildId)
         let destroyed = false
 
         await withGuildPlayerQueueLock(guildId, async () => {
-            player.queue.tracks.push(mockTrack())
+            player.queue.add(mockTrack("queued"))
         })
 
         await withGuildPlayerQueueLock(guildId, async () => {
@@ -54,7 +66,7 @@ describe("playlist orphan cleanup vs enqueue lock", () => {
 
     it("blocks enqueue until orphan cleanup finishes under the same lock", async () => {
         const guildId = "guild-playlist-serialize"
-        const player = mockEmptyPlayer(guildId)
+        const player = mockMutablePlayer(guildId)
         const events: string[] = []
         let releaseCleanup!: () => void
         const cleanupGate = new Promise<void>((resolve) => {
@@ -72,7 +84,7 @@ describe("playlist orphan cleanup vs enqueue lock", () => {
         })
 
         const enqueueP = withGuildPlayerQueueLock(guildId, async () => {
-            player.queue.tracks.push(mockTrack())
+            player.queue.add(mockTrack("queued"))
             events.push("enqueue")
         })
 
@@ -84,5 +96,87 @@ describe("playlist orphan cleanup vs enqueue lock", () => {
         assert.equal(destroyed, true)
         assert.deepEqual(events, ["cleanup-start", "cleanup-destroy", "enqueue"])
         assert.equal(playerHasQueueContent(player), true)
+    })
+})
+
+describe("playlist replace clear+add must share one guild lock", () => {
+    it("keeps concurrent enqueue after clear+add (atomic replace contract)", async () => {
+        const guildId = "guild-playlist-replace-atomic"
+        const player = mockMutablePlayer(guildId, [mockTrack("old-upcoming")])
+        const events: string[] = []
+        let releaseReplace!: () => void
+        const replaceGate = new Promise<void>((resolve) => {
+            releaseReplace = resolve
+        })
+
+        // Mirrors replaceUpcomingWithResolvedPlaylistTracks: clear + add under one lock.
+        const replaceP = withGuildPlayerQueueLock(guildId, async () => {
+            const size = player.queue.tracks.length
+            if (size > 0) await player.queue.splice(0, size)
+            events.push("replace-cleared")
+            await replaceGate
+            player.queue.add([mockTrack("playlist-a"), mockTrack("playlist-b")])
+            events.push("replace-added")
+        })
+
+        // Ensure replace has entered the lock before scheduling concurrent enqueue.
+        await Promise.resolve()
+        await Promise.resolve()
+        assert.deepEqual(events, ["replace-cleared"])
+        assert.deepEqual(
+            player.queue.tracks.map((t) => t.info.title),
+            []
+        )
+
+        const enqueueP = withGuildPlayerQueueLock(guildId, async () => {
+            player.queue.add(mockTrack("concurrent-add"))
+            events.push("enqueue")
+        })
+
+        releaseReplace()
+        await Promise.all([replaceP, enqueueP])
+
+        assert.deepEqual(events, ["replace-cleared", "replace-added", "enqueue"])
+        assert.deepEqual(
+            player.queue.tracks.map((t) => t.info.title),
+            ["playlist-a", "playlist-b", "concurrent-add"]
+        )
+    })
+})
+
+describe("queue clear vs reorder under guild lock", () => {
+    it("prevents clear from interleaving between reorder remove and insert", async () => {
+        const guildId = "guild-reorder-clear-race"
+        const player = mockMutablePlayer(guildId, [
+            mockTrack("a"),
+            mockTrack("b"),
+            mockTrack("c"),
+        ])
+        const events: string[] = []
+        let releaseReorder!: () => void
+        const reorderGate = new Promise<void>((resolve) => {
+            releaseReorder = resolve
+        })
+
+        const reorderP = withGuildPlayerQueueLock(guildId, async () => {
+            events.push("reorder-remove")
+            const [track] = await player.queue.splice(0, 1)
+            await reorderGate
+            await player.queue.splice(player.queue.tracks.length, 0, track!)
+            events.push("reorder-insert")
+        })
+
+        const clearP = withGuildPlayerQueueLock(guildId, async () => {
+            const size = player.queue.tracks.length
+            if (size > 0) await player.queue.splice(0, size)
+            events.push("cleared")
+        })
+
+        await Promise.resolve()
+        assert.deepEqual(events, ["reorder-remove"])
+        releaseReorder()
+        await Promise.all([reorderP, clearP])
+        assert.deepEqual(events, ["reorder-remove", "reorder-insert", "cleared"])
+        assert.equal(player.queue.tracks.length, 0)
     })
 })

--- a/src/util/playlistQueue.lock.test.ts
+++ b/src/util/playlistQueue.lock.test.ts
@@ -147,11 +147,7 @@ describe("playlist replace clear+add must share one guild lock", () => {
 describe("queue clear vs reorder under guild lock", () => {
     it("prevents clear from interleaving between reorder remove and insert", async () => {
         const guildId = "guild-reorder-clear-race"
-        const player = mockMutablePlayer(guildId, [
-            mockTrack("a"),
-            mockTrack("b"),
-            mockTrack("c"),
-        ])
+        const player = mockMutablePlayer(guildId, [mockTrack("a"), mockTrack("b"), mockTrack("c")])
         const events: string[] = []
         let releaseReorder!: () => void
         const reorderGate = new Promise<void>((resolve) => {

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -114,6 +114,37 @@ export async function clearUpcomingQueue(player: Player): Promise<void> {
     }
 }
 
+async function enqueueTracksUnderLock(
+    player: Player,
+    tracks: Track[],
+    requesterId: string,
+    shuffle: boolean
+): Promise<EnqueuePlaylistResult> {
+    const toQueue = shuffle ? shuffleArray(tracks) : tracks
+    stampRequesterUserIdOnTracks(toQueue, requesterId)
+    player.queue.add(toQueue)
+    if (isRRQActive(player)) {
+        await rebalancePlayerQueueRoundRobin(player)
+    }
+    let playbackStarted = false
+    let playbackError: string | undefined
+    if (!player.playing) {
+        try {
+            await startPlaybackIfNeeded(player)
+            playbackStarted = true
+        } catch (error: unknown) {
+            playbackError = error instanceof Error ? error.message : String(error)
+        }
+    }
+    schedulePlayerSessionSave(player)
+    return {
+        queued: toQueue.length,
+        failed: 0,
+        playbackStarted,
+        playbackError,
+    }
+}
+
 /** Adds resolved tracks to the player queue and starts playback when idle. */
 export async function enqueueResolvedPlaylistTracks(
     player: Player,
@@ -124,29 +155,55 @@ export async function enqueueResolvedPlaylistTracks(
     if (tracks.length === 0) {
         return { queued: 0, failed: 0, playbackStarted: false }
     }
+    return withGuildPlayerQueueLock(player.guildId, () =>
+        enqueueTracksUnderLock(player, tracks, requesterId, shuffle)
+    )
+}
+
+/**
+ * Atomically replaces the upcoming queue with resolved playlist tracks.
+ * Snapshot + clear + enqueue run under one guild lock so a concurrent
+ * searchAndEnqueue cannot land between clear and add (silent track loss).
+ */
+export async function replaceUpcomingWithResolvedPlaylistTracks(
+    player: Player,
+    tracks: Track[],
+    requesterId: string,
+    shuffle: boolean
+): Promise<EnqueuePlaylistResult> {
+    if (tracks.length === 0) {
+        return { queued: 0, failed: 0, playbackStarted: false }
+    }
     return withGuildPlayerQueueLock(player.guildId, async () => {
-        const toQueue = shuffle ? shuffleArray(tracks) : tracks
-        stampRequesterUserIdOnTracks(toQueue, requesterId)
-        player.queue.add(toQueue)
-        if (isRRQActive(player)) {
-            await rebalancePlayerQueueRoundRobin(player)
-        }
-        let playbackStarted = false
-        let playbackError: string | undefined
-        if (!player.playing) {
-            try {
-                await startPlaybackIfNeeded(player)
-                playbackStarted = true
-            } catch (error: unknown) {
-                playbackError = error instanceof Error ? error.message : String(error)
+        const savedUpcoming = snapshotUpcomingQueue(player)
+        try {
+            const size = player.queue.tracks.length
+            if (size > 0) {
+                await player.queue.splice(0, size)
             }
-        }
-        schedulePlayerSessionSave(player)
-        return {
-            queued: toQueue.length,
-            failed: 0,
-            playbackStarted,
-            playbackError,
+            return await enqueueTracksUnderLock(player, tracks, requesterId, shuffle)
+        } catch (enqueueErr: unknown) {
+            try {
+                const size = player.queue.tracks.length
+                if (size > 0) {
+                    await player.queue.splice(0, size)
+                }
+                if (savedUpcoming.length > 0) {
+                    await player.queue.splice(0, 0, savedUpcoming)
+                }
+                schedulePlayerSessionSave(player)
+            } catch (restoreErr: unknown) {
+                const restoreMessage =
+                    restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
+                console.error(
+                    "[replaceUpcomingWithResolvedPlaylistTracks] failed to restore queue after enqueue error",
+                    {
+                        guildId: player.guildId,
+                        restoreMessage,
+                    }
+                )
+            }
+            throw enqueueErr
         }
     })
 }

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -3,7 +3,7 @@ import type { PlaylistTrackData } from "../types/index.js"
 import { thumbnailFromLavalinkTrack } from "./trackThumbnail.js"
 import {
     isRRQActive,
-    rebalancePlayerQueueRoundRobin,
+    rebalancePlayerQueueRoundRobinAssumingLock,
     stampRequesterUserIdOnTracks,
 } from "./rrqDisconnect.js"
 import { startPlaybackIfNeeded } from "./musicManager.js"
@@ -124,7 +124,8 @@ async function enqueueTracksUnderLock(
     stampRequesterUserIdOnTracks(toQueue, requesterId)
     player.queue.add(toQueue)
     if (isRRQActive(player)) {
-        await rebalancePlayerQueueRoundRobin(player)
+        // Already holding the guild queue lock -- do not re-enter via rebalancePlayerQueueRoundRobin.
+        await rebalancePlayerQueueRoundRobinAssumingLock(player)
     }
     let playbackStarted = false
     let playbackError: string | undefined

--- a/src/util/restorePlayerSessions.test.ts
+++ b/src/util/restorePlayerSessions.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { isStaleSessionDiscordError } from "./restorePlayerSessions.js"
+
+describe("isStaleSessionDiscordError", () => {
+    it("treats unknown channel/guild as permanently stale (safe to delete session)", () => {
+        assert.equal(isStaleSessionDiscordError({ code: 10003 }), true)
+        assert.equal(isStaleSessionDiscordError({ code: 10004 }), true)
+        assert.equal(isStaleSessionDiscordError({ code: "10003" }), true)
+    })
+
+    it("treats permission, rate-limit, and network-shaped failures as transient (keep session)", () => {
+        assert.equal(isStaleSessionDiscordError({ code: 50001 }), false) // Missing Access
+        assert.equal(isStaleSessionDiscordError({ code: 50013 }), false) // Missing Permissions
+        assert.equal(isStaleSessionDiscordError({ code: 429 }), false)
+        assert.equal(isStaleSessionDiscordError({ code: "EAI_AGAIN" }), false)
+        assert.equal(isStaleSessionDiscordError(new Error("fetch failed")), false)
+        assert.equal(isStaleSessionDiscordError(null), false)
+    })
+})

--- a/src/util/restorePlayerSessions.test.ts
+++ b/src/util/restorePlayerSessions.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
-import { isStaleSessionDiscordError } from "./restorePlayerSessions.js"
+import {
+    isStaleSessionDiscordError,
+    shouldPersistRestoredPlayerSession,
+} from "./restorePlayerSessions.js"
 
 describe("isStaleSessionDiscordError", () => {
     it("treats unknown channel/guild as permanently stale (safe to delete session)", () => {
@@ -16,5 +19,17 @@ describe("isStaleSessionDiscordError", () => {
         assert.equal(isStaleSessionDiscordError({ code: "EAI_AGAIN" }), false)
         assert.equal(isStaleSessionDiscordError(new Error("fetch failed")), false)
         assert.equal(isStaleSessionDiscordError(null), false)
+    })
+})
+
+describe("shouldPersistRestoredPlayerSession", () => {
+    it("allows save when every track resolved (no transient failures)", () => {
+        assert.equal(shouldPersistRestoredPlayerSession(0), true)
+    })
+
+    it("blocks save when at least one track failed transiently (partial hydrate)", () => {
+        // One resolved + one transient failure must not overwrite the full prior snapshot.
+        assert.equal(shouldPersistRestoredPlayerSession(1), false)
+        assert.equal(shouldPersistRestoredPlayerSession(2), false)
     })
 })

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -24,7 +24,12 @@ const STALE_SESSION_DISCORD_CODES = new Set([
     10004, // Unknown Guild
 ])
 
-function isStaleSessionDiscordError(error: unknown): boolean {
+/**
+ * True when a Discord API failure means the persisted voice channel/guild is gone
+ * (safe to delete the session). Transient/network errors must return false so restore
+ * can retry later without wiping the queue snapshot.
+ */
+export function isStaleSessionDiscordError(error: unknown): boolean {
     const code = getDiscordErrorCode(error)
     return code !== undefined && STALE_SESSION_DISCORD_CODES.has(code)
 }

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -13,6 +13,7 @@ import {
     schedulePlayerSessionSave,
 } from "./playerSessionPersistence.js"
 import { resolvePersistedTracks } from "./playerSessionTracks.js"
+import { withGuildPlayerLifecycleReservation } from "./guildPlayerQueueLock.js"
 import { countHumanMembers } from "./voiceChannelMembers.js"
 
 let discordReady = false
@@ -138,63 +139,73 @@ async function restoreSingleSession(client: BotClient, session: PlayerSessionDat
     markPlayerSessionRestoreInProgress(guildId)
 
     try {
-        const player = await client.lavalink.createPlayer({
-            guildId,
-            voiceChannelId,
-            textChannelId: textChannelId ?? undefined,
-            selfDeaf: true,
-            volume: snapshot.volume,
-        })
-
-        await ensurePlayerConnected(client, player, voiceChannel)
-
-        const { resolved, failed, transientFailures } = await resolvePersistedTracks(
-            player,
-            tracksToRestore
-        )
-        if (failed > 0) {
-            client.warn(
-                `[playerSession] restore for ${guildId}: ${failed}/${tracksToRestore.length} tracks failed to resolve` +
-                    (transientFailures > 0 ? ` (${transientFailures} transient)` : "")
-            )
-        }
-        if (resolved.length === 0) {
-            await player.destroy()
-            // Lavalink/source blips that throw during decode/search must not wipe the snapshot.
-            // Deterministic no-match (search returned nothing usable) still deletes.
-            if (transientFailures > 0) {
-                client.warn(
-                    `[playerSession] restore for ${guildId}: no tracks resolved due to transient failures; preserving session`
+        await withGuildPlayerLifecycleReservation(guildId, async () => {
+            // Re-check under the reservation: a concurrent create may have won the race.
+            if (client.lavalink.getPlayer(guildId)) {
+                client.debug(
+                    `[playerSession] restore skipped for ${guildId}: player appeared before hydrate`
                 )
                 return
             }
-            client.warn(
-                `[playerSession] restore for ${guildId}: no tracks resolved; destroying player`
+
+            const player = await client.lavalink.createPlayer({
+                guildId,
+                voiceChannelId,
+                textChannelId: textChannelId ?? undefined,
+                selfDeaf: true,
+                volume: snapshot.volume,
+            })
+
+            await ensurePlayerConnected(client, player, voiceChannel)
+
+            const { resolved, failed, transientFailures } = await resolvePersistedTracks(
+                player,
+                tracksToRestore
             )
-            await deletePlayerSession(guildId)
-            return
-        }
+            if (failed > 0) {
+                client.warn(
+                    `[playerSession] restore for ${guildId}: ${failed}/${tracksToRestore.length} tracks failed to resolve` +
+                        (transientFailures > 0 ? ` (${transientFailures} transient)` : "")
+                )
+            }
+            if (resolved.length === 0) {
+                await player.destroy()
+                // Lavalink/source blips that throw during decode/search must not wipe the snapshot.
+                // Deterministic no-match (search returned nothing usable) still deletes.
+                if (transientFailures > 0) {
+                    client.warn(
+                        `[playerSession] restore for ${guildId}: no tracks resolved due to transient failures; preserving session`
+                    )
+                    return
+                }
+                client.warn(
+                    `[playerSession] restore for ${guildId}: no tracks resolved; destroying player`
+                )
+                await deletePlayerSession(guildId)
+                return
+            }
 
-        await player.queue.add(resolved)
+            await player.queue.add(resolved)
 
-        if (snapshot.repeatMode !== "off") {
-            await player.setRepeatMode(snapshot.repeatMode)
-        }
-        player.set("autoplay", snapshot.autoplay)
-        player.set("rrqEnabled", snapshot.rrqEnabled)
+            if (snapshot.repeatMode !== "off") {
+                await player.setRepeatMode(snapshot.repeatMode)
+            }
+            player.set("autoplay", snapshot.autoplay)
+            player.set("rrqEnabled", snapshot.rrqEnabled)
 
-        await startPlaybackIfNeeded(player)
-        if (snapshot.paused && player.playing) {
-            await player.pause()
-        }
+            await startPlaybackIfNeeded(player)
+            if (snapshot.paused && player.playing) {
+                await player.pause()
+            }
 
-        client.info(
-            `[playerSession] restored player for guild ${guildId} (${resolved.length} tracks, humans=${humans})`
-        )
+            client.info(
+                `[playerSession] restored player for guild ${guildId} (${resolved.length} tracks, humans=${humans})`
+            )
 
-        scheduleControlMessageUpdate(client, guildId)
-        playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
-        schedulePlayerSessionSave(player)
+            scheduleControlMessageUpdate(client, guildId)
+            playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
+            schedulePlayerSessionSave(player)
+        })
     } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
         client.error(`[playerSession] restore failed for guild ${guildId}: ${msg}`)

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -148,17 +148,29 @@ async function restoreSingleSession(client: BotClient, session: PlayerSessionDat
 
         await ensurePlayerConnected(client, player, voiceChannel)
 
-        const { resolved, failed } = await resolvePersistedTracks(player, tracksToRestore)
+        const { resolved, failed, transientFailures } = await resolvePersistedTracks(
+            player,
+            tracksToRestore
+        )
         if (failed > 0) {
             client.warn(
-                `[playerSession] restore for ${guildId}: ${failed}/${tracksToRestore.length} tracks failed to resolve`
+                `[playerSession] restore for ${guildId}: ${failed}/${tracksToRestore.length} tracks failed to resolve` +
+                    (transientFailures > 0 ? ` (${transientFailures} transient)` : "")
             )
         }
         if (resolved.length === 0) {
+            await player.destroy()
+            // Lavalink/source blips that throw during decode/search must not wipe the snapshot.
+            // Deterministic no-match (search returned nothing usable) still deletes.
+            if (transientFailures > 0) {
+                client.warn(
+                    `[playerSession] restore for ${guildId}: no tracks resolved due to transient failures; preserving session`
+                )
+                return
+            }
             client.warn(
                 `[playerSession] restore for ${guildId}: no tracks resolved; destroying player`
             )
-            await player.destroy()
             await deletePlayerSession(guildId)
             return
         }

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -1,4 +1,5 @@
 import type { VoiceBasedChannel } from "discord.js"
+import type { Player } from "lavalink-client"
 import type BotClient from "../lib/BotClient.js"
 import type { PlayerSessionData } from "../types/index.js"
 import { deletePlayerSession, listPlayerSessions } from "../repositories/playerSessionRepository.js"
@@ -138,6 +139,7 @@ async function restoreSingleSession(client: BotClient, session: PlayerSessionDat
     const textChannelId = resolveTextChannelId(session)
     markPlayerSessionRestoreInProgress(guildId)
 
+    let playerToPersist: Player | null = null
     try {
         await withGuildPlayerLifecycleReservation(guildId, async () => {
             // Re-check under the reservation: a concurrent create may have won the race.
@@ -204,7 +206,8 @@ async function restoreSingleSession(client: BotClient, session: PlayerSessionDat
 
             scheduleControlMessageUpdate(client, guildId)
             playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
-            schedulePlayerSessionSave(player)
+            // schedulePlayerSessionSave is a no-op while restore-in-progress; persist after clear.
+            playerToPersist = player
         })
     } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
@@ -213,9 +216,14 @@ async function restoreSingleSession(client: BotClient, session: PlayerSessionDat
         if (orphan) {
             await orphan.destroy().catch(() => undefined)
         }
+        playerToPersist = null
         // Transient failures (Lavalink/Discord blips) must not wipe the persisted snapshot.
     } finally {
         clearPlayerSessionRestoreInProgress(guildId)
+    }
+
+    if (playerToPersist) {
+        schedulePlayerSessionSave(playerToPersist)
     }
 }
 

--- a/src/util/restorePlayerSessions.ts
+++ b/src/util/restorePlayerSessions.ts
@@ -17,6 +17,14 @@ import { resolvePersistedTracks } from "./playerSessionTracks.js"
 import { withGuildPlayerLifecycleReservation } from "./guildPlayerQueueLock.js"
 import { countHumanMembers } from "./voiceChannelMembers.js"
 
+/**
+ * Whether a successful partial hydrate may overwrite the persisted session snapshot.
+ * Transient resolve failures must keep the prior full snapshot on disk.
+ */
+export function shouldPersistRestoredPlayerSession(transientFailures: number): boolean {
+    return transientFailures <= 0
+}
+
 let discordReady = false
 let restoreInFlight = false
 
@@ -207,7 +215,15 @@ async function restoreSingleSession(client: BotClient, session: PlayerSessionDat
             scheduleControlMessageUpdate(client, guildId)
             playerBroadcaster.broadcastPlayerEvent(guildId, player, "queueUpdate")
             // schedulePlayerSessionSave is a no-op while restore-in-progress; persist after clear.
-            playerToPersist = player
+            // Skip save when some tracks failed transiently — otherwise a partial hydrate would
+            // permanently drop those entries from the session snapshot.
+            if (shouldPersistRestoredPlayerSession(transientFailures)) {
+                playerToPersist = player
+            } else {
+                client.warn(
+                    `[playerSession] restore for ${guildId}: skipping session save after ${transientFailures} transient failure(s); preserving prior snapshot`
+                )
+            }
         })
     } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)

--- a/src/util/rrqDisconnect.test.ts
+++ b/src/util/rrqDisconnect.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player, Track } from "lavalink-client"
+import {
+    clearDisconnectedUser,
+    getDisconnectedUsers,
+    hasTrackedDisconnect,
+    isDisconnectTimeoutCurrent,
+    isRRQActive,
+    roundRobinReorderTracks,
+    stampRequesterUserIdOnTracks,
+    toggleRRQ,
+    trackDisconnectedUser,
+    userHasQueuedTracks,
+} from "./rrqDisconnect.js"
+
+function mockTrack(requester: unknown, title = "t"): Track {
+    return {
+        encoded: "enc",
+        info: {
+            title,
+            author: "a",
+            uri: `https://example.com/${title}`,
+            duration: 1000,
+            isStream: false,
+            identifier: title,
+            isSeekable: true,
+            sourceName: "http",
+            artworkUrl: null,
+            isrc: null,
+        },
+        requester,
+    } as unknown as Track
+}
+
+function mockPlayer(tracks: Track[] = []): Player {
+    const store = new Map<string, unknown>()
+    return {
+        guildId: "guild-rrq",
+        queue: {
+            current: null,
+            tracks,
+        },
+        get: (key: string) => store.get(key),
+        set: (key: string, value: unknown) => {
+            store.set(key, value)
+        },
+    } as unknown as Player
+}
+
+describe("roundRobinReorderTracks", () => {
+    it("returns a shallow copy for empty or single-track queues", () => {
+        const empty = roundRobinReorderTracks([], "__rrq_none__")
+        assert.deepEqual(empty, [])
+        assert.notEqual(empty, [])
+
+        const one = [mockTrack("a", "only")]
+        const reordered = roundRobinReorderTracks(one, "a")
+        assert.equal(reordered.length, 1)
+        assert.equal(reordered[0], one[0])
+        assert.notEqual(reordered, one)
+    })
+
+    it("avoids the previous requester when another user has tracks", () => {
+        const a1 = mockTrack("a", "a1")
+        const a2 = mockTrack("a", "a2")
+        const b1 = mockTrack("b", "b1")
+        const ordered = roundRobinReorderTracks([a1, a2, b1], "a")
+        assert.equal(ordered[0], b1)
+        assert.ok(ordered.slice(1).every((t) => t.requester === "a"))
+    })
+
+    it("prefers the heavier remaining requester among valid candidates", () => {
+        const a1 = mockTrack("a", "a1")
+        const b1 = mockTrack("b", "b1")
+        const b2 = mockTrack("b", "b2")
+        const b3 = mockTrack("b", "b3")
+        const c1 = mockTrack("c", "c1")
+        // Previous was c → candidates a (1) and b (3); pick b first.
+        const ordered = roundRobinReorderTracks([a1, b1, b2, b3, c1], "c")
+        assert.equal(ordered[0]?.requester, "b")
+        // Never place the same requester twice in a row while another user still has tracks.
+        for (let i = 1; i < ordered.length; i++) {
+            const prev = ordered[i - 1]?.requester
+            const cur = ordered[i]?.requester
+            if (prev === cur) {
+                const othersRemain = ordered.slice(i).some((t) => t.requester !== cur)
+                assert.equal(
+                    othersRemain,
+                    false,
+                    `unexpected back-to-back ${String(cur)} while others remain`
+                )
+            }
+        }
+    })
+
+    it("falls back to same requester when no alternate remains", () => {
+        const a1 = mockTrack("a", "a1")
+        const a2 = mockTrack("a", "a2")
+        const ordered = roundRobinReorderTracks([a1, a2], "a")
+        assert.deepEqual(
+            ordered.map((t) => t.info.title),
+            ["a1", "a2"]
+        )
+    })
+
+    it("treats missing requesters as a shared unknown bucket", () => {
+        const missing = mockTrack(null, "missing")
+        const other = mockTrack("u1", "other")
+        const ordered = roundRobinReorderTracks([missing, other], "__rrq_none__")
+        // Heavier-first among candidates from no previous: both length 1; first key wins reduce.
+        assert.equal(ordered.length, 2)
+        assert.ok(ordered.includes(missing))
+        assert.ok(ordered.includes(other))
+        // After placing one, the next should prefer the other bucket over repeating unknown/user.
+        assert.notEqual(ordered[0]?.requester ?? null, ordered[1]?.requester ?? null)
+    })
+
+    it("reads object-shaped requesters the same as string ids", () => {
+        const a = mockTrack({ id: "user-a" }, "a")
+        const b = mockTrack({ id: "user-b" }, "b")
+        const ordered = roundRobinReorderTracks([a, a, b], "user-a")
+        assert.equal(ordered[0], b)
+    })
+})
+
+describe("stampRequesterUserIdOnTracks", () => {
+    it("stamps a stable string requester on each track", () => {
+        const tracks = [mockTrack({ id: "old" }, "t1"), mockTrack("other", "t2")]
+        stampRequesterUserIdOnTracks(tracks, "discord-user")
+        assert.equal(tracks[0]?.requester, "discord-user")
+        assert.equal(tracks[1]?.requester, "discord-user")
+    })
+})
+
+describe("RRQ disconnect tracking", () => {
+    it("creates, replaces, and clears disconnect timers without leaving stale handles", () => {
+        const player = mockPlayer()
+        const first = setTimeout(() => {}, 60_000)
+        const second = setTimeout(() => {}, 60_000)
+        try {
+            trackDisconnectedUser(player, "u1", first)
+            assert.equal(hasTrackedDisconnect(player, "u1"), true)
+            assert.equal(isDisconnectTimeoutCurrent(player, "u1", first), true)
+
+            trackDisconnectedUser(player, "u1", second)
+            assert.equal(isDisconnectTimeoutCurrent(player, "u1", first), false)
+            assert.equal(isDisconnectTimeoutCurrent(player, "u1", second), true)
+
+            clearDisconnectedUser(player, "u1")
+            assert.equal(hasTrackedDisconnect(player, "u1"), false)
+            assert.equal(getDisconnectedUsers(player).size, 0)
+        } finally {
+            clearTimeout(first)
+            clearTimeout(second)
+        }
+    })
+
+    it("toggleRRQ clears pending disconnect timers when disabling", () => {
+        const player = mockPlayer()
+        const handle = setTimeout(() => {}, 60_000)
+        try {
+            assert.equal(isRRQActive(player), false)
+            assert.equal(toggleRRQ(player), true)
+            assert.equal(isRRQActive(player), true)
+
+            trackDisconnectedUser(player, "u1", handle)
+            assert.equal(hasTrackedDisconnect(player, "u1"), true)
+
+            assert.equal(toggleRRQ(player), false)
+            assert.equal(isRRQActive(player), false)
+            assert.equal(hasTrackedDisconnect(player, "u1"), false)
+        } finally {
+            clearTimeout(handle)
+        }
+    })
+
+    it("userHasQueuedTracks inspects upcoming tracks only", () => {
+        const player = mockPlayer([mockTrack("u1", "q1"), mockTrack("u2", "q2")])
+        assert.equal(userHasQueuedTracks(player, "u1"), true)
+        assert.equal(userHasQueuedTracks(player, "u3"), false)
+    })
+})

--- a/src/util/rrqDisconnect.ts
+++ b/src/util/rrqDisconnect.ts
@@ -1,6 +1,7 @@
 import type { Player, Track, UnresolvedTrack } from "lavalink-client"
 import type { RRQDisconnectedUsersMap } from "../types/index.js"
-import { createGuildAsyncChain } from "./guildAsyncChain.js"
+import { withGuildPlayerQueueLock } from "./guildPlayerQueueLock.js"
+import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
 
 const RRQ_DISCONNECTED_USERS_KEY = "rrqDisconnectedUsers"
 const RRQ_ENABLED_KEY = "rrqEnabled"
@@ -89,8 +90,11 @@ export function roundRobinReorderTracks(
     return result
 }
 
-/** Core reorder; must run inside enqueueRrqMutation (or call exported rebalancePlayerQueueRoundRobin). */
-async function rebalancePlayerQueueRoundRobinImpl(player: Player): Promise<void> {
+/**
+ * Core reorder. Callers must already hold {@link withGuildPlayerQueueLock} for this guild
+ * (or use {@link rebalancePlayerQueueRoundRobin}, which acquires it).
+ */
+export async function rebalancePlayerQueueRoundRobinAssumingLock(player: Player): Promise<void> {
     if (!isRRQActive(player)) return
     const tracks = player.queue.tracks
     const n = tracks.length
@@ -110,10 +114,13 @@ async function rebalancePlayerQueueRoundRobinImpl(player: Player): Promise<void>
 
 /**
  * Re-sorts `player.queue.tracks` for round-robin fairness when RRQ mode is on.
- * Serialized per guild with other RRQ queue mutations so snapshot/reorder cannot race concurrent splices.
+ * Uses the shared guild player queue lock so rebalance cannot race dashboard/Discord clears
+ * (a separate RRQ-only chain could splice a pre-clear snapshot back after clear).
  */
 export async function rebalancePlayerQueueRoundRobin(player: Player): Promise<void> {
-    return enqueueRrqMutation(player.guildId, () => rebalancePlayerQueueRoundRobinImpl(player))
+    return withGuildPlayerQueueLock(player.guildId, () =>
+        rebalancePlayerQueueRoundRobinAssumingLock(player)
+    )
 }
 
 /** Returns the per-player map of users pending RRQ disconnect cleanup, creating it if missing. */
@@ -216,8 +223,6 @@ export async function removeUserTracksFromQueue(player: Player, userId: string):
     return removed
 }
 
-const enqueueRrqMutation = createGuildAsyncChain()
-
 export type RemoveAndRebalanceRrqHooks = {
     onRemoveError?: (err: unknown) => void
     onRebalanceError?: (err: unknown) => void
@@ -225,14 +230,14 @@ export type RemoveAndRebalanceRrqHooks = {
 
 /**
  * Runs disconnect cleanup (remove user’s queued tracks, clear disconnect tracking, optional rebalance)
- * serialized per guild so reordering cannot race with other RRQ queue mutations for that player.
+ * under the shared guild player queue lock so clear/enqueue/reorder cannot interleave with splices.
  */
 export async function removeAndRebalanceRrqAfterDisconnect(
     player: Player,
     userId: string,
     hooks?: RemoveAndRebalanceRrqHooks
 ): Promise<number> {
-    return enqueueRrqMutation(player.guildId, async () => {
+    return withGuildPlayerQueueLock(player.guildId, async () => {
         let removedCount = 0
         try {
             removedCount = await removeUserTracksFromQueue(player, userId)
@@ -244,10 +249,14 @@ export async function removeAndRebalanceRrqAfterDisconnect(
 
         if (removedCount > 0 && isRRQActive(player)) {
             try {
-                await rebalancePlayerQueueRoundRobinImpl(player)
+                await rebalancePlayerQueueRoundRobinAssumingLock(player)
             } catch (rebalErr: unknown) {
                 hooks?.onRebalanceError?.(rebalErr)
             }
+        }
+
+        if (removedCount > 0) {
+            schedulePlayerSessionSave(player)
         }
 
         return removedCount

--- a/src/util/rrqDisconnect.ts
+++ b/src/util/rrqDisconnect.ts
@@ -239,9 +239,11 @@ export async function removeAndRebalanceRrqAfterDisconnect(
 ): Promise<number> {
     return withGuildPlayerQueueLock(player.guildId, async () => {
         let removedCount = 0
+        let removeFailed = false
         try {
             removedCount = await removeUserTracksFromQueue(player, userId)
         } catch (err: unknown) {
+            removeFailed = true
             hooks?.onRemoveError?.(err)
         } finally {
             clearDisconnectedUser(player, userId)
@@ -255,7 +257,8 @@ export async function removeAndRebalanceRrqAfterDisconnect(
             }
         }
 
-        if (removedCount > 0) {
+        // Persist even when remove threw mid-loop (partial mutation, removedCount still 0).
+        if (removedCount > 0 || removeFailed) {
             schedulePlayerSessionSave(player)
         }
 

--- a/src/util/rrqQueueLock.test.ts
+++ b/src/util/rrqQueueLock.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player, Track } from "lavalink-client"
+import { createGuildAsyncChain } from "./guildAsyncChain.js"
+import { withGuildPlayerQueueLock } from "./guildPlayerQueueLock.js"
+import {
+    rebalancePlayerQueueRoundRobin,
+    removeAndRebalanceRrqAfterDisconnect,
+    stampRequesterUserIdOnTracks,
+} from "./rrqDisconnect.js"
+
+function mockTrack(id: string, requesterId: string): Track {
+    return {
+        encoded: `enc-${id}`,
+        info: {
+            title: id,
+            author: "Artist",
+            uri: `https://example.com/${id}`,
+            duration: 1000,
+            isStream: false,
+            identifier: id,
+            isSeekable: true,
+            sourceName: "http",
+            artworkUrl: null,
+            isrc: null,
+        },
+        requester: requesterId,
+    } as unknown as Track
+}
+
+function mockMutablePlayer(guildId: string, initial: Track[] = []): Player {
+    const tracks = [...initial]
+    const store = new Map<string, unknown>()
+    store.set("rrqEnabled", true)
+    return {
+        guildId,
+        playing: true,
+        queue: {
+            current: null,
+            tracks,
+            add(items: Track | Track[], index?: number) {
+                const list = Array.isArray(items) ? items : [items]
+                if (typeof index === "number") tracks.splice(index, 0, ...list)
+                else tracks.push(...list)
+            },
+            async splice(start: number, deleteCount: number, ...insert: Track[]) {
+                return tracks.splice(start, deleteCount, ...insert.flat())
+            },
+        },
+        get(key: string) {
+            return store.get(key)
+        },
+        set(key: string, value: unknown) {
+            store.set(key, value)
+        },
+    } as unknown as Player
+}
+
+describe("RRQ vs guild queue lock", () => {
+    it("legacy separate RRQ chain can resurrect tracks after a guild-locked clear", async () => {
+        // Documents the pre-fix race: RRQ splice on its own chain after clear under guild lock.
+        const guildId = "guild-rrq-legacy-race"
+        const player = mockMutablePlayer(guildId, [
+            mockTrack("a1", "user-a"),
+            mockTrack("b1", "user-b"),
+            mockTrack("a2", "user-a"),
+        ])
+        const rrqOnlyChain = createGuildAsyncChain()
+
+        let releaseRebalance!: () => void
+        const rebalanceGate = new Promise<void>((resolve) => {
+            releaseRebalance = resolve
+        })
+
+        const rebalanceP = rrqOnlyChain(guildId, async () => {
+            const snapshot = [...player.queue.tracks]
+            const n = snapshot.length
+            await rebalanceGate
+            await player.queue.splice(0, n, snapshot)
+        })
+
+        await Promise.resolve()
+
+        const clearP = withGuildPlayerQueueLock(guildId, async () => {
+            const size = player.queue.tracks.length
+            if (size > 0) await player.queue.splice(0, size)
+        })
+
+        // Clear can finish while rebalance is still gated (separate chains).
+        await clearP
+        assert.equal(player.queue.tracks.length, 0)
+
+        releaseRebalance()
+        await rebalanceP
+        assert.equal(player.queue.tracks.length, 3, "separate RRQ chain resurrects cleared queue")
+    })
+
+    it("shared guild lock prevents rebalance from resurrecting a concurrent clear", async () => {
+        const guildId = "guild-rrq-shared-lock"
+        const player = mockMutablePlayer(guildId, [
+            mockTrack("a1", "user-a"),
+            mockTrack("b1", "user-b"),
+            mockTrack("a2", "user-a"),
+        ])
+
+        let releaseRebalance!: () => void
+        const rebalanceGate = new Promise<void>((resolve) => {
+            releaseRebalance = resolve
+        })
+
+        const rebalanceP = withGuildPlayerQueueLock(guildId, async () => {
+            const snapshot = [...player.queue.tracks]
+            const n = snapshot.length
+            await rebalanceGate
+            await player.queue.splice(0, n, snapshot)
+        })
+
+        await Promise.resolve()
+
+        const clearP = withGuildPlayerQueueLock(guildId, async () => {
+            const size = player.queue.tracks.length
+            if (size > 0) await player.queue.splice(0, size)
+        })
+
+        releaseRebalance()
+        await Promise.all([rebalanceP, clearP])
+        assert.equal(player.queue.tracks.length, 0)
+    })
+
+    it("rebalancePlayerQueueRoundRobin serializes with clear on the guild lock", async () => {
+        const guildId = "guild-rrq-public-api"
+        const a1 = mockTrack("a1", "user-a")
+        const b1 = mockTrack("b1", "user-b")
+        stampRequesterUserIdOnTracks([a1], "user-a")
+        stampRequesterUserIdOnTracks([b1], "user-b")
+        const player = mockMutablePlayer(guildId, [a1, b1])
+
+        const rebalanceP = rebalancePlayerQueueRoundRobin(player)
+        const clearP = withGuildPlayerQueueLock(guildId, async () => {
+            const size = player.queue.tracks.length
+            if (size > 0) await player.queue.splice(0, size)
+        })
+        await Promise.all([rebalanceP, clearP])
+        assert.equal(player.queue.tracks.length, 0)
+    })
+
+    it("removeAndRebalanceRrqAfterDisconnect removes only the disconnected user's tracks", async () => {
+        const guildId = "guild-rrq-remove-user"
+        const a1 = mockTrack("a1", "user-a")
+        const b1 = mockTrack("b1", "user-b")
+        const a2 = mockTrack("a2", "user-a")
+        stampRequesterUserIdOnTracks([a1, a2], "user-a")
+        stampRequesterUserIdOnTracks([b1], "user-b")
+        const player = mockMutablePlayer(guildId, [a1, b1, a2])
+
+        const removed = await removeAndRebalanceRrqAfterDisconnect(player, "user-a")
+        assert.equal(removed, 2)
+        assert.equal(player.queue.tracks.length, 1)
+        assert.equal(player.queue.tracks[0]?.info.title, "b1")
+    })
+})

--- a/src/util/sameVoiceChannel.test.ts
+++ b/src/util/sameVoiceChannel.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { memberMayControlPlayerVoice } from "./sameVoiceChannel.js"
+
+describe("memberMayControlPlayerVoice", () => {
+    it("allows when the player has no voice channel id", () => {
+        assert.equal(memberMayControlPlayerVoice(undefined, "vc-a"), true)
+        assert.equal(memberMayControlPlayerVoice(null, "vc-a"), true)
+        assert.equal(memberMayControlPlayerVoice("", "vc-a"), true)
+    })
+
+    it("allows when member is in the same channel as the player", () => {
+        assert.equal(memberMayControlPlayerVoice("vc-a", "vc-a"), true)
+    })
+
+    it("rejects when member is in a different channel", () => {
+        assert.equal(memberMayControlPlayerVoice("vc-a", "vc-b"), false)
+    })
+})

--- a/src/util/sameVoiceChannel.test.ts
+++ b/src/util/sameVoiceChannel.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
-import { memberMayControlPlayerVoice } from "./sameVoiceChannel.js"
+import {
+    memberMayControlPlayerVoice,
+    memberMayJoinOccupiedVoice,
+    resolveOccupiedVoiceChannelId,
+} from "./sameVoiceChannel.js"
 
 describe("memberMayControlPlayerVoice", () => {
     it("allows when the player has no voice channel id", () => {
@@ -15,5 +19,42 @@ describe("memberMayControlPlayerVoice", () => {
 
     it("rejects when member is in a different channel", () => {
         assert.equal(memberMayControlPlayerVoice("vc-a", "vc-b"), false)
+    })
+})
+
+describe("resolveOccupiedVoiceChannelId", () => {
+    it("prefers live bot Discord VC (local playback with no Lavalink player)", () => {
+        const guild = {
+            members: { me: { voice: { channelId: "bot-vc" } } },
+        }
+        assert.equal(resolveOccupiedVoiceChannelId(guild, null), "bot-vc")
+    })
+
+    it("falls back to player voiceChannelId when bot is not in a VC", () => {
+        const guild = {
+            members: { me: { voice: { channelId: null } } },
+        }
+        assert.equal(
+            resolveOccupiedVoiceChannelId(guild, { voiceChannelId: "player-vc" }),
+            "player-vc"
+        )
+    })
+
+    it("returns null when idle", () => {
+        const guild = {
+            members: { me: { voice: { channelId: null } } },
+        }
+        assert.equal(resolveOccupiedVoiceChannelId(guild, null), null)
+    })
+})
+
+describe("memberMayJoinOccupiedVoice", () => {
+    it("allows any channel when nothing is occupied", () => {
+        assert.equal(memberMayJoinOccupiedVoice(null, "any"), true)
+    })
+
+    it("requires the same channel when occupied", () => {
+        assert.equal(memberMayJoinOccupiedVoice("vc-a", "vc-a"), true)
+        assert.equal(memberMayJoinOccupiedVoice("vc-a", "vc-b"), false)
     })
 })

--- a/src/util/sameVoiceChannel.ts
+++ b/src/util/sameVoiceChannel.ts
@@ -1,0 +1,11 @@
+/**
+ * Whether a member in `memberVoiceChannelId` may control a player in `playerVoiceChannelId`.
+ * Matches Skip / control-button semantics: missing player channel is treated as allowed.
+ */
+export function memberMayControlPlayerVoice(
+    playerVoiceChannelId: string | null | undefined,
+    memberVoiceChannelId: string
+): boolean {
+    if (!playerVoiceChannelId) return true
+    return playerVoiceChannelId === memberVoiceChannelId
+}

--- a/src/util/sameVoiceChannel.ts
+++ b/src/util/sameVoiceChannel.ts
@@ -9,3 +9,38 @@ export function memberMayControlPlayerVoice(
     if (!playerVoiceChannelId) return true
     return playerVoiceChannelId === memberVoiceChannelId
 }
+
+/**
+ * Voice channel the bot currently occupies for playback.
+ * Prefers the live Discord voice state so local (@discordjs/voice) playback is
+ * visible when the Lavalink player was destroyed.
+ */
+export function resolveOccupiedVoiceChannelId(
+    guild: {
+        members: {
+            me?: {
+                voice?: {
+                    channelId?: string | null
+                    channel?: { id: string } | null
+                } | null
+            } | null
+        }
+    },
+    player?: { voiceChannelId?: string | null } | null
+): string | null {
+    const botVc = guild.members.me?.voice?.channelId ?? guild.members.me?.voice?.channel?.id ?? null
+    const playerVc = player?.voiceChannelId ?? null
+    return botVc || playerVc || null
+}
+
+/**
+ * Whether a member in `memberVoiceChannelId` may take over / play into an occupied channel.
+ * Empty occupation (bot idle, no player binding) is allowed.
+ */
+export function memberMayJoinOccupiedVoice(
+    occupiedVoiceChannelId: string | null | undefined,
+    memberVoiceChannelId: string
+): boolean {
+    if (!occupiedVoiceChannelId) return true
+    return occupiedVoiceChannelId === memberVoiceChannelId
+}

--- a/src/util/saveControlChannel.ts
+++ b/src/util/saveControlChannel.ts
@@ -7,6 +7,7 @@ import {
     replaceGuildSettingsStoreInDatabase,
 } from "../repositories/guildSettingsRepository.js"
 import { resolveGuildSettingsDeleteIds } from "./guildSettingsDeleteIds.js"
+import { GUILD_SETTING_FIELD_KEYS, mergeGuildSettingsRow } from "./guildSettingsMerge.js"
 import { loggerFromPartial } from "./loggerFromPartial.js"
 
 const __dirname = import.meta.dirname
@@ -98,56 +99,6 @@ async function withGuildSettingsSaveLock<T>(work: () => Promise<T>): Promise<T> 
     } finally {
         release()
     }
-}
-
-const GUILD_SETTING_FIELD_KEYS: (keyof GuildSettings)[] = [
-    "controlChannelId",
-    "controlMessageId",
-    "downloadsMaxMb",
-    "discordLog",
-]
-
-function cloneGuildSettingsRow(row: GuildSettings): GuildSettings {
-    return typeof structuredClone === "function"
-        ? structuredClone(row)
-        : (JSON.parse(JSON.stringify(row)) as GuildSettings)
-}
-
-/**
- * Merges only fields present in `snapshotRow` onto `dbRow`, then removes `clearedFields`.
- * Omitted snapshot fields keep their latest database values (prevents cross-field clobber races).
- */
-function mergeGuildSettingsRow(
-    dbRow: GuildSettings | undefined,
-    snapshotRow: GuildSettings | undefined,
-    clearedFields: (keyof GuildSettings)[] = []
-): GuildSettings {
-    const merged: GuildSettings = dbRow ? cloneGuildSettingsRow(dbRow) : {}
-    if (snapshotRow) {
-        for (const key of GUILD_SETTING_FIELD_KEYS) {
-            if (key in snapshotRow) {
-                const value = snapshotRow[key]
-                if (value !== undefined) {
-                    switch (key) {
-                        case "controlChannelId":
-                        case "controlMessageId":
-                            merged[key] = value as string
-                            break
-                        case "downloadsMaxMb":
-                            merged.downloadsMaxMb = value as number
-                            break
-                        case "discordLog":
-                            merged.discordLog = value as GuildSettings["discordLog"]
-                            break
-                    }
-                }
-            }
-        }
-    }
-    for (const key of clearedFields) {
-        delete merged[key]
-    }
-    return merged
 }
 
 export type SaveGuildSettingsOptions = {

--- a/src/util/similarSongsQueries.test.ts
+++ b/src/util/similarSongsQueries.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    formatTrackSearchQuery,
+    youtubeSearchQueriesForCatalogTrack,
+} from "./similarSongsService.js"
+
+describe("formatTrackSearchQuery", () => {
+    it("joins artist and title, and falls back when one side is missing", () => {
+        assert.equal(formatTrackSearchQuery({ artist: "A", title: "T" }), "A - T")
+        assert.equal(formatTrackSearchQuery({ artist: "  A  ", title: "  T  " }), "A - T")
+        assert.equal(formatTrackSearchQuery({ title: "Only Title" }), "Only Title")
+        assert.equal(formatTrackSearchQuery({ artist: "Only Artist" }), "Only Artist")
+        assert.equal(formatTrackSearchQuery({}), "")
+        assert.equal(formatTrackSearchQuery({ artist: "  ", title: "" }), "")
+    })
+})
+
+describe("youtubeSearchQueriesForCatalogTrack", () => {
+    it("returns an empty list when artist and title are blank", () => {
+        assert.deepEqual(youtubeSearchQueriesForCatalogTrack({}), [])
+        assert.deepEqual(youtubeSearchQueriesForCatalogTrack({ artist: " ", title: " " }), [])
+    })
+
+    it("orders ytsearch variants from specific official audio to bare query", () => {
+        const queries = youtubeSearchQueriesForCatalogTrack({
+            artist: "Artist",
+            title: "Song",
+        })
+        assert.deepEqual(queries, [
+            "ytsearch:Artist - Song official audio",
+            "ytsearch:Artist - Song official music video",
+            "ytsearch:Artist - Song audio",
+            "ytsearch:Artist - Song",
+        ])
+    })
+})

--- a/src/util/skipCurrentTrack.test.ts
+++ b/src/util/skipCurrentTrack.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { skipCurrentTrack } from "./skipCurrentTrack.js"
+
+describe("skipCurrentTrack", () => {
+    it("uses default skip when upcoming tracks exist", async () => {
+        const calls: Array<{ skipTo?: number; throwError?: boolean }> = []
+        await skipCurrentTrack({
+            queue: { tracks: { length: 2 } },
+            skip: async (skipTo, throwError) => {
+                calls.push({ skipTo, throwError })
+            },
+        })
+        assert.deepEqual(calls, [{ skipTo: undefined, throwError: undefined }])
+    })
+
+    it("uses skip(0, false) when only the current track remains", async () => {
+        const calls: Array<{ skipTo?: number; throwError?: boolean }> = []
+        await skipCurrentTrack({
+            queue: { tracks: { length: 0 } },
+            skip: async (skipTo, throwError) => {
+                calls.push({ skipTo, throwError })
+            },
+        })
+        assert.deepEqual(calls, [{ skipTo: 0, throwError: false }])
+    })
+})

--- a/src/util/skipCurrentTrack.test.ts
+++ b/src/util/skipCurrentTrack.test.ts
@@ -14,7 +14,7 @@ describe("skipCurrentTrack", () => {
         assert.deepEqual(calls, [{ skipTo: undefined, throwError: undefined }])
     })
 
-    it("uses skip(0, false) when only the current track remains", async () => {
+    it("uses skip(0, false) when the upcoming queue is empty", async () => {
         const calls: Array<{ skipTo?: number; throwError?: boolean }> = []
         await skipCurrentTrack({
             queue: { tracks: { length: 0 } },

--- a/src/util/skipCurrentTrack.ts
+++ b/src/util/skipCurrentTrack.ts
@@ -1,0 +1,14 @@
+/**
+ * Advances past the current track without using default `skip()`, which throws when the
+ * upcoming queue is empty (lavalink-client). Matches `/skip`, control buttons, and web player.
+ */
+export async function skipCurrentTrack(player: {
+    queue: { tracks: { length: number } }
+    skip: (skipTo?: number, throwError?: boolean) => Promise<unknown>
+}): Promise<void> {
+    if (player.queue.tracks.length > 0) {
+        await player.skip()
+        return
+    }
+    await player.skip(0, false)
+}

--- a/src/util/trackThumbnail.test.ts
+++ b/src/util/trackThumbnail.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { thumbnailFromLavalinkTrack, thumbnailUrlFromUri } from "./trackThumbnail.js"
+
+describe("thumbnailUrlFromUri", () => {
+    it("extracts YouTube ids across common host/path shapes", () => {
+        const id = "dQw4w9WgXcQ"
+        const expected = `https://img.youtube.com/vi/${id}/hqdefault.jpg`
+        assert.equal(thumbnailUrlFromUri(`https://www.youtube.com/watch?v=${id}`), expected)
+        assert.equal(thumbnailUrlFromUri(`https://youtu.be/${id}`), expected)
+        assert.equal(thumbnailUrlFromUri(`https://www.youtube.com/embed/${id}`), expected)
+        assert.equal(thumbnailUrlFromUri(`https://www.youtube.com/shorts/${id}`), expected)
+        assert.equal(
+            thumbnailUrlFromUri(`https://music.youtube.com/watch?v=${id}&list=x`),
+            expected
+        )
+    })
+
+    it("returns null for blank or non-YouTube URIs", () => {
+        assert.equal(thumbnailUrlFromUri(""), null)
+        assert.equal(thumbnailUrlFromUri("   "), null)
+        assert.equal(thumbnailUrlFromUri("https://open.spotify.com/track/abc"), null)
+        assert.equal(thumbnailUrlFromUri("https://www.youtube.com/watch?v=short"), null)
+    })
+})
+
+describe("thumbnailFromLavalinkTrack", () => {
+    it("prefers artworkUrl, then YouTube identifier, then URI parse", () => {
+        assert.equal(
+            thumbnailFromLavalinkTrack({
+                info: { artworkUrl: "https://cdn.example/art.jpg", uri: "" },
+            } as never),
+            "https://cdn.example/art.jpg"
+        )
+        assert.equal(
+            thumbnailFromLavalinkTrack({
+                info: {
+                    identifier: "dQw4w9WgXcQ",
+                    sourceName: "youtube",
+                    uri: "https://example.com",
+                },
+            } as never),
+            "https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+        )
+        assert.equal(
+            thumbnailFromLavalinkTrack({
+                info: {
+                    sourceName: "http",
+                    uri: "https://youtu.be/dQw4w9WgXcQ",
+                },
+            } as never),
+            "https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+        )
+    })
+})

--- a/src/util/voiceChannelMembers.test.ts
+++ b/src/util/voiceChannelMembers.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { VoiceBasedChannel } from "discord.js"
+import { countHumanMembers } from "./voiceChannelMembers.js"
+
+type VoiceStateLike = { channelId: string | null; id: string }
+
+function mockVoiceChannel(opts: {
+    channelId: string
+    botId?: string | null
+    voiceStates: VoiceStateLike[]
+}): VoiceBasedChannel {
+    const cache = {
+        filter(predicate: (vs: VoiceStateLike) => boolean) {
+            const matches = opts.voiceStates.filter(predicate)
+            return { size: matches.length }
+        },
+    }
+    return {
+        id: opts.channelId,
+        guild: {
+            client: { user: opts.botId === null ? null : { id: opts.botId ?? "bot-1" } },
+            voiceStates: { cache },
+        },
+    } as unknown as VoiceBasedChannel
+}
+
+describe("countHumanMembers", () => {
+    it("counts voiceStates in this channel and excludes the bot by id", () => {
+        const channel = mockVoiceChannel({
+            channelId: "vc-1",
+            botId: "bot-1",
+            voiceStates: [
+                { id: "bot-1", channelId: "vc-1" },
+                { id: "human-1", channelId: "vc-1" },
+                { id: "human-2", channelId: "vc-1" },
+                { id: "human-other", channelId: "vc-2" },
+            ],
+        })
+        assert.equal(countHumanMembers(channel), 2)
+    })
+
+    it("returns 0 when only the bot (or nobody) is in the channel", () => {
+        assert.equal(
+            countHumanMembers(
+                mockVoiceChannel({
+                    channelId: "vc-1",
+                    voiceStates: [{ id: "bot-1", channelId: "vc-1" }],
+                })
+            ),
+            0
+        )
+        assert.equal(
+            countHumanMembers(mockVoiceChannel({ channelId: "vc-1", voiceStates: [] })),
+            0
+        )
+    })
+
+    it("does not rely on GuildMember cache (voiceStates remain authoritative)", () => {
+        // Regression: voiceChannel.members can be empty when members are uncached even though
+        // humans are connected — restore must not delete the session in that case.
+        const channel = mockVoiceChannel({
+            channelId: "vc-1",
+            voiceStates: [{ id: "human-uncached", channelId: "vc-1" }],
+        })
+        assert.equal(countHumanMembers(channel), 1)
+    })
+})

--- a/src/util/voiceChannelMembers.test.ts
+++ b/src/util/voiceChannelMembers.test.ts
@@ -50,10 +50,7 @@ describe("countHumanMembers", () => {
             ),
             0
         )
-        assert.equal(
-            countHumanMembers(mockVoiceChannel({ channelId: "vc-1", voiceStates: [] })),
-            0
-        )
+        assert.equal(countHumanMembers(mockVoiceChannel({ channelId: "vc-1", voiceStates: [] })), 0)
     })
 
     it("does not rely on GuildMember cache (voiceStates remain authoritative)", () => {

--- a/src/util/webAuthAndSanitize.test.ts
+++ b/src/util/webAuthAndSanitize.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { authErrorMessage } from "../web/lib/auth-error-message.js"
+import { normalizeSearchParam } from "../web/lib/normalize-search-param.js"
+import { sanitizeErrorText } from "../web/lib/sanitize-log-text.js"
+
+describe("sanitizeErrorText", () => {
+    it("redacts bearer/basic auth, password, and token key=value forms", () => {
+        const out = sanitizeErrorText(
+            "Authorization Bearer abc.def-ghi Authorization Basic dXNlcjpwYXNz password=supersecret token=xyz apikey=abc123 secret=shh",
+            2000
+        )
+        assert.match(out, /Bearer \[REDACTED]/)
+        assert.match(out, /Basic \[REDACTED]/)
+        assert.match(out, /password=\[REDACTED]/)
+        assert.match(out, /token=\[REDACTED]/)
+        assert.match(out, /secret=\[REDACTED]/)
+        assert.doesNotMatch(out, /supersecret|xyz|abc123|shh|abc\.def/)
+    })
+
+    it("redacts JSON secret keys, DB URLs, and JWTs", () => {
+        const jwt =
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP2S3AkMNUzSOQy6lc45VWXisES5l2kCuba8"
+        const out = sanitizeErrorText(
+            `{"access_token":"tok","client_secret":"cs","api_key":"k"} postgres://user:pass@host/db ${jwt}`,
+            4000
+        )
+        assert.match(out, /"access_token":"\[REDACTED]"/)
+        assert.match(out, /"client_secret":"\[REDACTED]"/)
+        assert.match(out, /"api_key":"\[REDACTED]"/)
+        assert.match(out, /postgres:\/\/\[REDACTED]@/)
+        assert.match(out, /\[REDACTED_JWT]/)
+        assert.doesNotMatch(out, /user:pass|tok"|"cs"|"k"|eyJhbGci/)
+    })
+
+    it("truncates output to maxLen with an ellipsis", () => {
+        const out = sanitizeErrorText("abcdefghij", 5)
+        assert.equal(out, "abcde…")
+    })
+})
+
+describe("normalizeSearchParam", () => {
+    it("returns undefined for missing values", () => {
+        assert.equal(normalizeSearchParam(undefined), undefined)
+    })
+
+    it("returns the first non-empty trimmed entry from repeated keys", () => {
+        assert.equal(normalizeSearchParam(["", "  ", " first ", "second"]), "first")
+        assert.equal(normalizeSearchParam(["only"]), "only")
+    })
+
+    it("falls back to the first string when all entries are empty", () => {
+        assert.equal(normalizeSearchParam(["", "  "]), "")
+        assert.equal(normalizeSearchParam([]), undefined)
+    })
+
+    it("passes through a single string unchanged", () => {
+        assert.equal(normalizeSearchParam("access_denied"), "access_denied")
+    })
+})
+
+describe("authErrorMessage", () => {
+    it("maps known OAuth codes to specific copy", () => {
+        assert.match(authErrorMessage("please_restart_the_process"), /expired or was interrupted/i)
+        assert.match(authErrorMessage("ACCESS_DENIED"), /cancelled/i)
+        assert.match(authErrorMessage(" invalid_code "), /already been used/i)
+        assert.match(authErrorMessage("invalid_grant"), /already been used/i)
+    })
+
+    it("uses a generic message for missing or unknown codes", () => {
+        assert.match(authErrorMessage(undefined), /could not be completed/i)
+        assert.match(authErrorMessage(""), /could not be completed/i)
+        assert.match(authErrorMessage("totally_unknown"), /Try again from the home page/i)
+    })
+})

--- a/src/util/webDashboardUrl.test.ts
+++ b/src/util/webDashboardUrl.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { guildWebPlayerPageUrl, webDashboardPromoAppend } from "./webDashboardUrl.js"
+
+describe("guildWebPlayerPageUrl", () => {
+    it("returns null when BETTER_AUTH_URL is missing, invalid, or non-http", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            delete process.env.BETTER_AUTH_URL
+            assert.equal(guildWebPlayerPageUrl("123"), null)
+
+            process.env.BETTER_AUTH_URL = "   "
+            assert.equal(guildWebPlayerPageUrl("123"), null)
+
+            process.env.BETTER_AUTH_URL = "not a url"
+            assert.equal(guildWebPlayerPageUrl("123"), null)
+
+            process.env.BETTER_AUTH_URL = "ftp://dashboard.example.com"
+            assert.equal(guildWebPlayerPageUrl("123"), null)
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+
+    it("builds /dashboard/<guildId> from the public origin and encodes the id", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            process.env.BETTER_AUTH_URL = "https://dash.example.com/"
+            assert.equal(
+                guildWebPlayerPageUrl("987654321"),
+                "https://dash.example.com/dashboard/987654321"
+            )
+
+            process.env.BETTER_AUTH_URL = "http://localhost:3000///"
+            assert.equal(
+                guildWebPlayerPageUrl("guild/with spaces"),
+                "http://localhost:3000/dashboard/guild%2Fwith%20spaces"
+            )
+
+            // Path on BETTER_AUTH_URL is ignored; only origin is used.
+            process.env.BETTER_AUTH_URL = "https://dash.example.com/auth/callback"
+            assert.equal(
+                guildWebPlayerPageUrl("1"),
+                "https://dash.example.com/dashboard/1"
+            )
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+})
+
+describe("webDashboardPromoAppend", () => {
+    it("returns empty string without a resolvable dashboard URL", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            delete process.env.BETTER_AUTH_URL
+            assert.equal(webDashboardPromoAppend("1"), "")
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+
+    it("appends a markdown dashboard link when BETTER_AUTH_URL is set", () => {
+        const prev = process.env.BETTER_AUTH_URL
+        try {
+            process.env.BETTER_AUTH_URL = "https://dash.example.com"
+            const text = webDashboardPromoAppend("42")
+            assert.match(text, /^\n\n\*\*Web player:\*\*/)
+            assert.match(text, /\[dashboard\]\(https:\/\/dash\.example\.com\/dashboard\/42\)/)
+        } finally {
+            if (prev === undefined) delete process.env.BETTER_AUTH_URL
+            else process.env.BETTER_AUTH_URL = prev
+        }
+    })
+})

--- a/src/util/webDashboardUrl.test.ts
+++ b/src/util/webDashboardUrl.test.ts
@@ -40,10 +40,7 @@ describe("guildWebPlayerPageUrl", () => {
 
             // Path on BETTER_AUTH_URL is ignored; only origin is used.
             process.env.BETTER_AUTH_URL = "https://dash.example.com/auth/callback"
-            assert.equal(
-                guildWebPlayerPageUrl("1"),
-                "https://dash.example.com/dashboard/1"
-            )
+            assert.equal(guildWebPlayerPageUrl("1"), "https://dash.example.com/dashboard/1")
         } finally {
             if (prev === undefined) delete process.env.BETTER_AUTH_URL
             else process.env.BETTER_AUTH_URL = prev

--- a/src/util/webUrlAndPlaylistTimeout.test.ts
+++ b/src/util/webUrlAndPlaylistTimeout.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { playlistPlayTimeoutMs } from "../web/lib/playlist-play-timeout.js"
+import { sanitizeHttpUrl } from "../web/lib/url-utils.js"
+
+describe("sanitizeHttpUrl", () => {
+    it("accepts http(s) URLs and normalizes via URL", () => {
+        assert.equal(sanitizeHttpUrl("https://example.com/a"), "https://example.com/a")
+        assert.equal(sanitizeHttpUrl("http://example.com"), "http://example.com/")
+    })
+
+    it("rejects non-strings, empty values, and non-http(s) schemes", () => {
+        assert.equal(sanitizeHttpUrl(null), null)
+        assert.equal(sanitizeHttpUrl(undefined), null)
+        assert.equal(sanitizeHttpUrl(""), null)
+        assert.equal(sanitizeHttpUrl("javascript:alert(1)"), null)
+        assert.equal(sanitizeHttpUrl("data:text/html,hi"), null)
+        assert.equal(sanitizeHttpUrl("ftp://example.com/file"), null)
+        assert.equal(sanitizeHttpUrl("not a url"), null)
+    })
+})
+
+describe("playlistPlayTimeoutMs", () => {
+    it("uses a one-track baseline for non-positive or non-finite counts", () => {
+        assert.equal(playlistPlayTimeoutMs(1), 32_500)
+        assert.equal(playlistPlayTimeoutMs(0), 32_500)
+        assert.equal(playlistPlayTimeoutMs(-3), 32_500)
+        assert.equal(playlistPlayTimeoutMs(Number.NaN), 32_500)
+    })
+
+    it("scales with track count and floors fractional counts", () => {
+        assert.equal(playlistPlayTimeoutMs(2), 35_000)
+        assert.equal(playlistPlayTimeoutMs(2.9), 35_000)
+        assert.equal(playlistPlayTimeoutMs(10), 55_000)
+    })
+
+    it("caps at five minutes for very large playlists", () => {
+        assert.equal(playlistPlayTimeoutMs(200), 300_000)
+        assert.equal(playlistPlayTimeoutMs(10_000), 300_000)
+    })
+})

--- a/src/web/lib/admin-access.ts
+++ b/src/web/lib/admin-access.ts
@@ -22,20 +22,29 @@ export async function resolveAdminAccess(reqHeaders: Headers): Promise<AdminAcce
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)
         console.error("[admin-access] getSession failed:", message)
-        return decideAdminAccess({
+        const decision = decideAdminAccess({
             sessionLoadFailed: true,
             hasSessionUser: false,
             discordUserId: null,
             ownerId: null,
         })
+        if (decision.ok === false) return decision
+        return {
+            ok: false,
+            status: 503,
+            error: "Service Unavailable",
+            details: "Could not load your session. Please try again later.",
+        }
     }
 
     if (!session?.user?.id) {
-        return decideAdminAccess({
+        const decision = decideAdminAccess({
             hasSessionUser: false,
             discordUserId: null,
             ownerId: getCachedOwnerId(),
         })
+        if (decision.ok === false) return decision
+        return { ok: false, status: 401, error: "Unauthorized" }
     }
 
     let discordUserId: string | null

--- a/src/web/lib/admin-access.ts
+++ b/src/web/lib/admin-access.ts
@@ -2,9 +2,9 @@ import { headers } from "next/headers"
 import { NextResponse } from "next/server"
 import { auth } from "@/auth"
 import type { AuthenticatedSession } from "@/lib/api-auth"
-import { decideAdminAccess } from "../../shared/admin-access-decision.js"
-import { resolveDiscordUserSnowflake } from "../../shared/discord-user-id.js"
-import { getCachedOwnerId } from "../../shared/permissions.js"
+import { decideAdminAccess } from "@/shared/admin-access-decision"
+import { resolveDiscordUserSnowflake } from "@/shared/discord-user-id"
+import { getCachedOwnerId } from "@/shared/permissions"
 
 export type AdminAccessResult =
     | { ok: true; session: AuthenticatedSession; discordUserId: string }
@@ -22,29 +22,20 @@ export async function resolveAdminAccess(reqHeaders: Headers): Promise<AdminAcce
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)
         console.error("[admin-access] getSession failed:", message)
-        const decision = decideAdminAccess({
+        return decideAdminAccess({
             sessionLoadFailed: true,
             hasSessionUser: false,
             discordUserId: null,
             ownerId: null,
-        })
-        if (decision.ok === false) return decision
-        return {
-            ok: false,
-            status: 503,
-            error: "Service Unavailable",
-            details: "Could not load your session. Please try again later.",
-        }
+        }) as Extract<AdminAccessResult, { ok: false }>
     }
 
     if (!session?.user?.id) {
-        const decision = decideAdminAccess({
+        return decideAdminAccess({
             hasSessionUser: false,
             discordUserId: null,
             ownerId: getCachedOwnerId(),
-        })
-        if (decision.ok === false) return decision
-        return { ok: false, status: 401, error: "Unauthorized" }
+        }) as Extract<AdminAccessResult, { ok: false }>
     }
 
     let discordUserId: string | null

--- a/src/web/lib/admin-access.ts
+++ b/src/web/lib/admin-access.ts
@@ -2,6 +2,7 @@ import { headers } from "next/headers"
 import { NextResponse } from "next/server"
 import { auth } from "@/auth"
 import type { AuthenticatedSession } from "@/lib/api-auth"
+import { decideAdminAccess } from "../../shared/admin-access-decision.js"
 import { resolveDiscordUserSnowflake } from "../../shared/discord-user-id.js"
 import { getCachedOwnerId } from "../../shared/permissions.js"
 
@@ -21,52 +22,43 @@ export async function resolveAdminAccess(reqHeaders: Headers): Promise<AdminAcce
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)
         console.error("[admin-access] getSession failed:", message)
-        return {
-            ok: false,
-            status: 503,
-            error: "Service Unavailable",
-            details: "Could not load your session. Please try again later.",
-        }
+        return decideAdminAccess({
+            sessionLoadFailed: true,
+            hasSessionUser: false,
+            discordUserId: null,
+            ownerId: null,
+        })
     }
 
     if (!session?.user?.id) {
-        return { ok: false, status: 401, error: "Unauthorized" }
+        return decideAdminAccess({
+            hasSessionUser: false,
+            discordUserId: null,
+            ownerId: getCachedOwnerId(),
+        })
     }
 
     let discordUserId: string | null
+    let discordResolveFailed = false
     try {
         discordUserId = await resolveDiscordUserSnowflake(session.user.id, reqHeaders)
     } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
         console.error("[admin-access] resolveDiscordUserSnowflake failed:", msg)
-        return {
-            ok: false,
-            status: 403,
-            error: "Discord account required",
-            details: "Sign in with Discord, or sign out and sign in again.",
-        }
-    }
-    if (!discordUserId) {
-        return {
-            ok: false,
-            status: 403,
-            error: "Discord account required",
-            details:
-                "We could not resolve your Discord user id. Sign in with Discord, or sign out and sign in again.",
-        }
+        discordUserId = null
+        discordResolveFailed = true
     }
 
-    const ownerId = getCachedOwnerId()
-    if (!ownerId || discordUserId !== ownerId) {
-        return {
-            ok: false,
-            status: 403,
-            error: "Forbidden",
-            details: "Developer access required.",
-        }
+    const decision = decideAdminAccess({
+        hasSessionUser: true,
+        discordResolveFailed,
+        discordUserId,
+        ownerId: getCachedOwnerId(),
+    })
+    if (decision.ok === false) {
+        return decision
     }
-
-    return { ok: true, session, discordUserId }
+    return { ok: true, session, discordUserId: decision.discordUserId }
 }
 
 /** True when the current session is the bot owner (`OWNER_ID`). */

--- a/src/web/lib/dashboard-permissions.ts
+++ b/src/web/lib/dashboard-permissions.ts
@@ -1,43 +1,12 @@
 import type { GuildDashboardPermissionSnapshot } from "@/types/web"
 import type { WebPermissionKey } from "@/lib/web-permission-keys"
 import { webPlayerTrace } from "@/lib/web-player-debug-log"
-
-type WebPermissionDecision =
-    | { allowed: true; reason: string; memberResolved: boolean }
-    | { allowed: false; reason: string; memberResolved: boolean }
-
-/** Shared primary vs OAuth-fallback rules for dashboard gating (matches {@link requirePermissions}). */
-function resolveWebPermissionDecision(
-    snapshot: GuildDashboardPermissionSnapshot,
-    perm: WebPermissionKey
-): WebPermissionDecision {
-    if (snapshot.primaryPermissions.includes(perm)) {
-        return {
-            allowed: true,
-            reason: "allow:primaryPermissions",
-            memberResolved: snapshot.memberResolved,
-        }
-    }
-    if (!snapshot.memberResolved && snapshot.oauthPermissions.includes(perm)) {
-        return {
-            allowed: true,
-            reason: "allow:oauthPermissions (member not resolved by bot)",
-            memberResolved: snapshot.memberResolved,
-        }
-    }
-    if (snapshot.memberResolved) {
-        return {
-            allowed: false,
-            reason: `deny:memberResolved=true but primaryPermissions lacks "${perm}" (OAuth fallback is not used when the bot resolved a member)`,
-            memberResolved: true,
-        }
-    }
-    return {
-        allowed: false,
-        reason: `deny:neither primary nor oauth lists include "${perm}"`,
-        memberResolved: false,
-    }
-}
+import {
+    dashboardHasAllWebPermissions as sharedDashboardHasAllWebPermissions,
+    dashboardHasWebPermission as sharedDashboardHasWebPermission,
+    explainDashboardWebPermission as sharedExplainDashboardWebPermission,
+    resolveWebPermissionDecision,
+} from "@/shared/dashboard-web-permission"
 
 /**
  * Human-readable reason for {@link dashboardHasWebPermission} (for troubleshooting).
@@ -46,7 +15,7 @@ export function explainDashboardWebPermission(
     snapshot: GuildDashboardPermissionSnapshot,
     perm: WebPermissionKey
 ): string {
-    return resolveWebPermissionDecision(snapshot, perm).reason
+    return sharedExplainDashboardWebPermission(snapshot, perm)
 }
 
 /**
@@ -76,21 +45,15 @@ export function dashboardHasAllWebPermissions(
     snapshot: GuildDashboardPermissionSnapshot,
     perms: WebPermissionKey[]
 ): boolean {
-    const denied: WebPermissionKey[] = []
-    for (const perm of perms) {
-        const decision = resolveWebPermissionDecision(snapshot, perm)
-        if (!decision.allowed) {
-            denied.push(perm)
-        }
-    }
-    if (denied.length > 0) {
+    const allowed = sharedDashboardHasAllWebPermissions(snapshot, perms)
+    if (!allowed) {
+        const denied = perms.filter((perm) => !sharedDashboardHasWebPermission(snapshot, perm))
         webPlayerTrace("dashboardHasAllWebPermissions: denied", {
             denied,
             memberResolved: snapshot.memberResolved,
             primary: snapshot.primaryPermissions,
             oauth: snapshot.oauthPermissions,
         })
-        return false
     }
-    return true
+    return allowed
 }


### PR DESCRIPTION
## Summary

- Consolidates open integration PRs #151 and #161 into one review branch for CodeRabbit and human review
- Integration branch: `chore/consolidated-cursor-fixes-jul-2026-all` from current `main`
- Source PRs closed as superseded on create (skill override of close-after-merge)

## Supersedes

- #151 — chore: consolidate Cursor fixes and regression tests (Jul 2026) (https://github.com/bpeters132/DimbyBot2/pull/151)
- #161 — chore: consolidate Cursor fixes and regression tests (Jul 2026 wave 2) (https://github.com/bpeters132/DimbyBot2/pull/161)

(Those PRs themselves superseded Cursor draft PRs from earlier waves.)

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` (238 pass)
- [ ] `npm run audit:check-imports` — skipped (not in this repo)
- [ ] Spot-check player lifecycle, voice-channel gates, session restore, and local-play handoff in the diff

## Version

- Current: `0.2.0`
- Recommended: `0.2.1` (`patch`) — correctness fixes across player lifecycle, voice gates, sessions, downloads; plus regression tests
- Bump not committed unless requested

## Notes

- Cherry-picked oldest-first (#151 then #161); conflicts resolved on the integration branch:
  - Merged `sameVoiceChannel` helpers from both waves (`memberMayControlPlayerVoice` + occupied-voice APIs)
  - Kept lifecycle reservations while applying suppress-lease / occupied-voice / restore transient-failure behavior
- Do not merge source PRs individually; this PR is the single review unit