### PR TITLE
chore: consolidate Cursor play-stop, SSRF, and test PRs

### DIFF
--- a/src/botApi/handlers/playlists.ts
+++ b/src/botApi/handlers/playlists.ts
@@ -31,6 +31,7 @@ import {
     pickPlayerForPlaylistSearch,
     searchTracksForPlaylist,
 } from "../../util/playlistQueue.js"
+import { isBlockedUserMediaUrl, USER_MEDIA_URL_BLOCKED } from "../../util/userMediaUrl.js"
 import {
     parseNewPosition,
     parsePlaylistId,
@@ -336,6 +337,19 @@ export async function playlistTracksPOST(
                 error: {
                     error: "Bad request",
                     details: "Invalid track body (title, uri, author, duration, addedAt).",
+                },
+            },
+        }
+    }
+
+    if (isBlockedUserMediaUrl(body.uri)) {
+        return {
+            status: 400,
+            body: {
+                ok: false,
+                error: {
+                    error: "Bad request",
+                    details: USER_MEDIA_URL_BLOCKED,
                 },
             },
         }

--- a/src/commands/music/PlayNext.ts
+++ b/src/commands/music/PlayNext.ts
@@ -4,6 +4,7 @@ import type { ChatInputCommandInteraction } from "discord.js"
 import { guildMemberFromInteraction } from "../../util/guildMember.js"
 import { enqueuePlayNextTrackAssumingSearchDone } from "../../util/playNextEnqueue.js"
 import { withGuildPlayerLifecycleReservation } from "../../util/guildPlayerQueueLock.js"
+import { isBlockedUserMediaUrl, USER_MEDIA_URL_BLOCKED } from "../../util/userMediaUrl.js"
 
 export default {
     data: new SlashCommandBuilder()
@@ -31,6 +32,13 @@ export default {
         }
 
         const query = interaction.options.getString("query", true)
+
+        if (isBlockedUserMediaUrl(query)) {
+            return interaction.reply({
+                content: USER_MEDIA_URL_BLOCKED,
+                ephemeral: true,
+            })
+        }
 
         const player = client.lavalink.getPlayer(guild.id)
 

--- a/src/repositories/downloadMetadataRepository.ts
+++ b/src/repositories/downloadMetadataRepository.ts
@@ -7,9 +7,12 @@ import type {
 } from "../types/index.js"
 import {
     downloadMetadataStoreKey,
-    effectiveDownloadMetadataGuildId,
     parseDownloadMetadataStoreKey,
 } from "../util/downloadMetadataKeys.js"
+import {
+    deleteConditionsForStoreKeys,
+    normalizedRowsFromStore,
+} from "../util/downloadMetadataNormalize.js"
 
 function toDownloadMetadataEntry(row: {
     guildId: string
@@ -31,76 +34,7 @@ function toDownloadMetadataEntry(row: {
     return entry
 }
 
-function storeKeyIsComposite(storeKey: string): boolean {
-    const parsed = parseDownloadMetadataStoreKey(storeKey)
-    return parsed.guildId !== null && parsed.guildId.length > 0
-}
-
 export type SkippedDownloadMetadataEntry = DownloadMetadataStoreSkippedEntry
-
-type NormalizedDownloadMetadataRow = {
-    fileName: string
-    guildId: string
-    downloadDate: Date | null
-    originalUrl: string | null
-    filePath: string | null
-}
-
-function normalizedRowsFromStore(store: DownloadsMetadataStore): {
-    rows: NormalizedDownloadMetadataRow[]
-    skippedEntries: SkippedDownloadMetadataEntry[]
-} {
-    const skippedEntries: SkippedDownloadMetadataEntry[] = []
-    const byGuildFile = new Map<
-        string,
-        {
-            row: NormalizedDownloadMetadataRow
-            sourceKey: string
-        }
-    >()
-
-    for (const [key, metadata] of Object.entries(store)) {
-        if (!metadata || typeof metadata !== "object") continue
-        const parsed = parseDownloadMetadataStoreKey(key)
-        const fileName = parsed.fileName
-        const guildId = effectiveDownloadMetadataGuildId(key, metadata)
-        if (guildId === null) {
-            console.debug("[downloadMetadata] skipping store row (no resolvable guildId)", {
-                key,
-                fileName: parsed.fileName,
-                downloadDate: metadata.downloadDate,
-            })
-            skippedEntries.push({ key, reason: "unresolvable-guild-id", fileName })
-            continue
-        }
-        const parsedDownloadDate =
-            metadata.downloadDate == null ? null : new Date(metadata.downloadDate)
-        const downloadDate =
-            parsedDownloadDate && Number.isFinite(parsedDownloadDate.getTime())
-                ? parsedDownloadDate
-                : null
-        const row: NormalizedDownloadMetadataRow = {
-            fileName,
-            guildId,
-            downloadDate,
-            originalUrl: metadata.originalUrl ?? null,
-            filePath: metadata.filePath ?? null,
-        }
-        const dedupeKey = `${guildId}|${fileName}`
-        const nextComposite = storeKeyIsComposite(key)
-        const prev = byGuildFile.get(dedupeKey)
-        if (!prev) {
-            byGuildFile.set(dedupeKey, { row, sourceKey: key })
-            continue
-        }
-        const prevComposite = storeKeyIsComposite(prev.sourceKey)
-        if (nextComposite && !prevComposite) {
-            byGuildFile.set(dedupeKey, { row, sourceKey: key })
-        }
-    }
-
-    return { rows: Array.from(byGuildFile.values()).map((e) => e.row), skippedEntries }
-}
 
 /** Reads all download metadata rows and returns the legacy map shape keyed by composite store key. */
 export async function getDownloadMetadataStoreFromDatabase(): Promise<DownloadsMetadataStore> {
@@ -137,32 +71,6 @@ export type ReplaceDownloadMetadataStoreOptions = {
     deleteStoreKeys?: string[]
 }
 
-function deleteConditionsForStoreKeys(
-    deleteStoreKeys: string[]
-): Prisma.DownloadMetadataWhereInput[] {
-    const conditions: Prisma.DownloadMetadataWhereInput[] = []
-    const seen = new Set<string>()
-    for (const storeKey of deleteStoreKeys) {
-        if (typeof storeKey !== "string" || !storeKey.trim()) continue
-        const parsed = parseDownloadMetadataStoreKey(storeKey)
-        const dedupe =
-            parsed.guildId !== null && parsed.guildId.length > 0
-                ? `${parsed.guildId}|${parsed.fileName}`
-                : `|${parsed.fileName}`
-        if (seen.has(dedupe)) continue
-        seen.add(dedupe)
-        // Only delete by composite `(guildId, fileName)`. A filename-only key (parsed.guildId null/empty)
-        // would translate to `{ fileName }`, matching that fileName across EVERY guild and wiping
-        // unrelated guilds' rows. DB rows always carry a guildId (NULL legacy rows were migrated to the
-        // UNKNOWN sentinel), so callers' keys from downloadMetadataKeysForFile are composite — the
-        // filename-only branch targets no real row precisely and is intentionally skipped here.
-        if (parsed.guildId !== null && parsed.guildId.length > 0) {
-            conditions.push({ guildId: parsed.guildId, fileName: parsed.fileName })
-        }
-    }
-    return conditions
-}
-
 export async function replaceDownloadMetadataStoreInDatabase(
     store: DownloadsMetadataStore,
     options?: ReplaceDownloadMetadataStoreOptions
@@ -196,7 +104,8 @@ export async function replaceDownloadMetadataStoreInDatabase(
             : rows.filter((row) => !deletedGuildFileKeys.has(`${row.guildId}|${row.fileName}`))
 
     await prisma.$transaction(async (tx) => {
-        const deleteConditions = deleteConditionsForStoreKeys(deleteStoreKeys)
+        const deleteConditions: Prisma.DownloadMetadataWhereInput[] =
+            deleteConditionsForStoreKeys(deleteStoreKeys)
         if (deleteConditions.length > 0) {
             const deleted = await tx.downloadMetadata.deleteMany({
                 where: { OR: deleteConditions },

--- a/src/repositories/guildSettingsRepository.ts
+++ b/src/repositories/guildSettingsRepository.ts
@@ -1,82 +1,11 @@
-import { Prisma } from "@prisma/client"
+import type { Prisma } from "@prisma/client"
 import { getPrismaClient } from "../lib/database.js"
 import { normalizeOptionalDiscordSnowflake } from "../shared/discord-snowflake.js"
-import type {
-    DiscordLogLevelName,
-    GuildDiscordLogSettings,
-    GuildSettings,
-    GuildSettingsStore,
-} from "../types/index.js"
-
-const LOG_LEVELS: ReadonlySet<DiscordLogLevelName> = new Set(["debug", "info", "warn", "error"])
-
-/** Verifies a value roundtrips through JSON and is a plain object. */
-function toSafeJsonObject(candidate: unknown): Prisma.InputJsonValue | null {
-    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null
-    try {
-        const serialized = JSON.stringify(candidate)
-        const parsed: unknown = JSON.parse(serialized)
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-            return parsed as Prisma.InputJsonValue
-        }
-    } catch {
-        /* non-serializable (circular refs, functions, etc.) */
-    }
-    return null
-}
-
-/** Normalizes legacy `discordLog` for Prisma JSON writes (object or JSON string → object; else DbNull). */
-function normalizeDiscordLogForDatabase(
-    value: unknown
-): Prisma.InputJsonValue | typeof Prisma.DbNull {
-    if (value === null || value === undefined) return Prisma.DbNull
-    if (typeof value === "string") {
-        try {
-            return toSafeJsonObject(JSON.parse(value)) ?? Prisma.DbNull
-        } catch {
-            return Prisma.DbNull
-        }
-    }
-    if (typeof value === "object" && !Array.isArray(value)) {
-        return toSafeJsonObject(value) ?? Prisma.DbNull
-    }
-    return Prisma.DbNull
-}
-
-function isDiscordLogLevelName(v: unknown): v is DiscordLogLevelName {
-    return typeof v === "string" && LOG_LEVELS.has(v as DiscordLogLevelName)
-}
-
-function parseGuildDiscordLog(value: Prisma.JsonValue | null): GuildDiscordLogSettings | undefined {
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
-        return undefined
-    }
-    const raw = value as Record<string, unknown>
-    const out: GuildDiscordLogSettings = {}
-    if (typeof raw.allChannelId === "string" && raw.allChannelId.trim()) {
-        out.allChannelId = raw.allChannelId.trim()
-    }
-    if (raw.minLevel !== undefined && raw.minLevel !== null) {
-        if (isDiscordLogLevelName(raw.minLevel)) {
-            out.minLevel = raw.minLevel
-        }
-    }
-    if (raw.byLevel !== undefined && raw.byLevel !== null) {
-        if (typeof raw.byLevel === "object" && !Array.isArray(raw.byLevel)) {
-            const by: Partial<Record<DiscordLogLevelName, string>> = {}
-            for (const [k, v] of Object.entries(raw.byLevel as Record<string, unknown>)) {
-                if (!isDiscordLogLevelName(k)) continue
-                if (typeof v !== "string" || !v.trim()) continue
-                by[k] = v.trim()
-            }
-            if (Object.keys(by).length > 0) out.byLevel = by
-        }
-    }
-    if (!out.allChannelId && !out.byLevel && !out.minLevel) {
-        return undefined
-    }
-    return out
-}
+import type { GuildSettings, GuildSettingsStore } from "../types/index.js"
+import {
+    normalizeDiscordLogForDatabase,
+    parseGuildDiscordLog,
+} from "../util/guildDiscordLogPersist.js"
 
 function toGuildSettingsStoreEntry(row: {
     controlChannelId: string | null

--- a/src/util/countdownStore.test.ts
+++ b/src/util/countdownStore.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict"
+import { afterEach, describe, it } from "node:test"
+import type { CountdownEntry, CountdownInput } from "../types/index.js"
+import {
+    addCountdown,
+    getAllCountdowns,
+    getCountdown,
+    getCountdownsForGuild,
+    initializeCountdownStore,
+    isCountdownStoreInitialized,
+    removeCountdown,
+    resetCountdownStoreForTests,
+    setCountdownStoreDbForTests,
+} from "./countdownStore.js"
+
+function sampleEntry(overrides: Partial<CountdownEntry> = {}): CountdownEntry {
+    const targetTime = overrides.targetTime ?? new Date("2030-01-15T18:00:00.000Z")
+    const createdAt = overrides.createdAt ?? new Date("2026-01-01T00:00:00.000Z")
+    return {
+        id: 1,
+        guildId: "guild-a",
+        channelId: "channel-1",
+        messageId: "message-1",
+        eventName: "Launch",
+        description: null,
+        imageUrl: null,
+        color: null,
+        footer: null,
+        finishMessage: null,
+        mentionRoleId: null,
+        targetTime,
+        createdBy: "user-1",
+        createdAt,
+        ...overrides,
+    }
+}
+
+function sampleInput(overrides: Partial<CountdownInput> = {}): CountdownInput {
+    const entry = sampleEntry()
+    return {
+        guildId: entry.guildId,
+        channelId: entry.channelId,
+        messageId: entry.messageId,
+        eventName: entry.eventName,
+        description: entry.description,
+        imageUrl: entry.imageUrl,
+        color: entry.color,
+        footer: entry.footer,
+        finishMessage: entry.finishMessage,
+        mentionRoleId: entry.mentionRoleId,
+        targetTime: entry.targetTime,
+        createdBy: entry.createdBy,
+        ...overrides,
+    }
+}
+
+afterEach(() => {
+    resetCountdownStoreForTests()
+    setCountdownStoreDbForTests(null)
+})
+
+describe("countdownStore init guard", () => {
+    it("throws before initialize and after a failed load", async () => {
+        assert.equal(isCountdownStoreInitialized(), false)
+        assert.throws(() => getCountdown(1), /before initialization/)
+        assert.throws(() => getAllCountdowns(), /before initialization/)
+        assert.throws(() => getCountdownsForGuild("guild-a"), /before initialization/)
+        await assert.rejects(() => addCountdown(sampleInput()), /before initialization/)
+        await assert.rejects(() => removeCountdown(1), /before initialization/)
+
+        setCountdownStoreDbForTests({
+            getAllCountdownsFromDatabase: async () => {
+                throw new Error("db down")
+            },
+        })
+        await assert.rejects(() => initializeCountdownStore({ error() {} }), /db down/)
+        assert.equal(isCountdownStoreInitialized(), false)
+        assert.throws(() => getCountdown(1), /before initialization/)
+    })
+})
+
+describe("countdownStore clone + guild filter", () => {
+    it("preserves Date fields and isolates callers from cache mutations", async () => {
+        const targetTime = new Date("2030-06-01T12:00:00.000Z")
+        const createdAt = new Date("2026-02-01T00:00:00.000Z")
+        setCountdownStoreDbForTests({
+            getAllCountdownsFromDatabase: async () => ({
+                7: sampleEntry({ id: 7, guildId: "guild-a", targetTime, createdAt }),
+                8: sampleEntry({ id: 8, guildId: "guild-b", eventName: "Other" }),
+            }),
+        })
+        await initializeCountdownStore({ info() {} })
+
+        const one = getCountdown(7)
+        assert.ok(one)
+        assert.ok(one.targetTime instanceof Date)
+        assert.equal(one.targetTime.toISOString(), targetTime.toISOString())
+        assert.ok(one.createdAt instanceof Date)
+
+        one.eventName = "mutated"
+        one.targetTime.setUTCFullYear(1999)
+        assert.equal(getCountdown(7)?.eventName, "Launch")
+        assert.equal(getCountdown(7)?.targetTime.toISOString(), targetTime.toISOString())
+
+        const forGuild = getCountdownsForGuild("guild-a")
+        assert.equal(forGuild.length, 1)
+        assert.equal(forGuild[0]?.id, 7)
+        assert.deepEqual(
+            getCountdownsForGuild("missing").map((e) => e.id),
+            []
+        )
+
+        const all = getAllCountdowns()
+        delete all[7]
+        assert.ok(getCountdown(7))
+    })
+})
+
+describe("countdownStore save lock", () => {
+    it("serializes concurrent add and remove against the cache", async () => {
+        let nextId = 10
+        const createOrder: string[] = []
+        let releaseCreate: (() => void) | undefined
+        const createGate = new Promise<void>((resolve) => {
+            releaseCreate = resolve
+        })
+
+        setCountdownStoreDbForTests({
+            getAllCountdownsFromDatabase: async () => ({
+                1: sampleEntry({ id: 1 }),
+            }),
+            createCountdown: async (input) => {
+                createOrder.push("create-start")
+                await createGate
+                createOrder.push("create-end")
+                const id = nextId++
+                return sampleEntry({
+                    id,
+                    guildId: input.guildId,
+                    eventName: input.eventName,
+                    targetTime: input.targetTime,
+                })
+            },
+            deleteCountdown: async (id) => {
+                createOrder.push(`delete-${id}`)
+            },
+        })
+        await initializeCountdownStore({ info() {} })
+
+        const addPromise = addCountdown(sampleInput({ eventName: "New" }))
+        // Let add acquire the lock and block inside create
+        await new Promise((r) => setImmediate(r))
+        const removePromise = removeCountdown(1)
+
+        releaseCreate!()
+        const created = await addPromise
+        await removePromise
+
+        assert.equal(created.id, 10)
+        assert.deepEqual(createOrder, ["create-start", "create-end", "delete-1"])
+        assert.equal(getCountdown(10)?.eventName, "New")
+        assert.equal(getCountdown(1), undefined)
+    })
+})

--- a/src/util/countdownStore.ts
+++ b/src/util/countdownStore.ts
@@ -16,6 +16,18 @@ let countdownCache: CountdownStore = {}
 let initialized = false
 let saveCountdownChain: Promise<void> = Promise.resolve()
 
+type CountdownStoreDb = {
+    getAllCountdownsFromDatabase: typeof getAllCountdownsFromDatabase
+    createCountdown: typeof createCountdownInDatabase
+    deleteCountdown: typeof deleteCountdownInDatabase
+}
+
+let countdownStoreDb: CountdownStoreDb = {
+    getAllCountdownsFromDatabase,
+    createCountdown: createCountdownInDatabase,
+    deleteCountdown: deleteCountdownInDatabase,
+}
+
 /**
  * Deep-clones the countdown store. `structuredClone` is required here (not the JSON fallback)
  * because entries carry `Date` fields that JSON round-tripping would corrupt; Node 24+ always
@@ -29,6 +41,30 @@ function cloneEntry(entry: CountdownEntry): CountdownEntry {
     return structuredClone(entry)
 }
 
+/** Test-only: replace DB adapters (pass `null` to restore defaults). */
+export function setCountdownStoreDbForTests(next: Partial<CountdownStoreDb> | null): void {
+    countdownStoreDb = next
+        ? {
+              getAllCountdownsFromDatabase:
+                  next.getAllCountdownsFromDatabase ??
+                  countdownStoreDb.getAllCountdownsFromDatabase,
+              createCountdown: next.createCountdown ?? countdownStoreDb.createCountdown,
+              deleteCountdown: next.deleteCountdown ?? countdownStoreDb.deleteCountdown,
+          }
+        : {
+              getAllCountdownsFromDatabase,
+              createCountdown: createCountdownInDatabase,
+              deleteCountdown: deleteCountdownInDatabase,
+          }
+}
+
+/** Test-only: clear cache, init flag, and save lock chain. */
+export function resetCountdownStoreForTests(): void {
+    countdownCache = {}
+    initialized = false
+    saveCountdownChain = Promise.resolve()
+}
+
 /** Returns whether {@link initializeCountdownStore} has finished loading from the database. */
 export function isCountdownStoreInitialized(): boolean {
     return initialized
@@ -40,7 +76,7 @@ export async function initializeCountdownStore(
 ): Promise<void> {
     const logger = loggerFromPartial(loggerInstance)
     try {
-        const loaded = await getAllCountdownsFromDatabase()
+        const loaded = await countdownStoreDb.getAllCountdownsFromDatabase()
         countdownCache = cloneStore(loaded)
         initialized = true
         logger.info(
@@ -100,7 +136,7 @@ export function getCountdownsForGuild(guildId: string): CountdownEntry[] {
 export async function addCountdown(input: CountdownInput): Promise<CountdownEntry> {
     assertInitialized()
     return withCountdownSaveLock(async () => {
-        const created = await createCountdownInDatabase(input)
+        const created = await countdownStoreDb.createCountdown(input)
         countdownCache[created.id] = cloneEntry(created)
         return cloneEntry(created)
     })
@@ -110,7 +146,7 @@ export async function addCountdown(input: CountdownInput): Promise<CountdownEntr
 export async function removeCountdown(id: number): Promise<void> {
     assertInitialized()
     await withCountdownSaveLock(async () => {
-        await deleteCountdownInDatabase(id)
+        await countdownStoreDb.deleteCountdown(id)
         delete countdownCache[id]
     })
 }

--- a/src/util/downloadMetadataNormalize.test.ts
+++ b/src/util/downloadMetadataNormalize.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+    DOWNLOAD_METADATA_UNKNOWN_GUILD_ID,
+    downloadMetadataStoreKey,
+} from "./downloadMetadataKeys.js"
+import {
+    deleteConditionsForStoreKeys,
+    normalizedRowsFromStore,
+} from "./downloadMetadataNormalize.js"
+
+describe("normalizedRowsFromStore", () => {
+    it("skips UNKNOWN and unresolvable guild ids into skippedEntries", () => {
+        const unknownKey = downloadMetadataStoreKey(DOWNLOAD_METADATA_UNKNOWN_GUILD_ID, "a.wav")
+        const store = {
+            [unknownKey]: { guildId: DOWNLOAD_METADATA_UNKNOWN_GUILD_ID },
+            "orphan.wav": { originalUrl: "https://x" },
+            "legacy.wav": { guildId: "guild-ok" },
+        }
+        const { rows, skippedEntries } = normalizedRowsFromStore(store)
+        assert.equal(rows.length, 1)
+        assert.equal(rows[0]?.guildId, "guild-ok")
+        assert.equal(rows[0]?.fileName, "legacy.wav")
+        assert.deepEqual(
+            skippedEntries.map((e) => e.key).sort(),
+            [unknownKey, "orphan.wav"].sort()
+        )
+        assert.ok(skippedEntries.every((e) => e.reason === "unresolvable-guild-id"))
+    })
+
+    it("prefers composite store keys over legacy filename-only for the same guild+file", () => {
+        const guildId = "guild-1"
+        const fileName = "track.wav"
+        const composite = downloadMetadataStoreKey(guildId, fileName)
+        const store = {
+            [fileName]: {
+                guildId,
+                originalUrl: "https://legacy",
+                filePath: "/tmp/legacy.wav",
+            },
+            [composite]: {
+                guildId,
+                originalUrl: "https://composite",
+                filePath: "/tmp/composite.wav",
+            },
+        }
+        const { rows, skippedEntries } = normalizedRowsFromStore(store)
+        assert.equal(skippedEntries.length, 0)
+        assert.equal(rows.length, 1)
+        assert.equal(rows[0]?.originalUrl, "https://composite")
+        assert.equal(rows[0]?.filePath, "/tmp/composite.wav")
+        assert.equal(rows[0]?.guildId, guildId)
+        assert.equal(rows[0]?.fileName, fileName)
+    })
+
+    it("keeps distinct guilds with the same fileName as separate rows", () => {
+        const a = downloadMetadataStoreKey("guild-a", "same.wav")
+        const b = downloadMetadataStoreKey("guild-b", "same.wav")
+        const { rows } = normalizedRowsFromStore({
+            [a]: { guildId: "guild-a", originalUrl: "https://a" },
+            [b]: { guildId: "guild-b", originalUrl: "https://b" },
+        })
+        assert.equal(rows.length, 2)
+        const byGuild = new Map(rows.map((r) => [r.guildId, r.originalUrl]))
+        assert.equal(byGuild.get("guild-a"), "https://a")
+        assert.equal(byGuild.get("guild-b"), "https://b")
+    })
+
+    it("drops invalid downloadDate values to null", () => {
+        const key = downloadMetadataStoreKey("guild-1", "t.wav")
+        const { rows } = normalizedRowsFromStore({
+            [key]: { guildId: "guild-1", downloadDate: "not-a-date" },
+        })
+        assert.equal(rows.length, 1)
+        assert.equal(rows[0]?.downloadDate, null)
+    })
+})
+
+describe("deleteConditionsForStoreKeys", () => {
+    it("emits composite guild+file conditions and dedupes repeats", () => {
+        const key = downloadMetadataStoreKey("guild-1", "a.wav")
+        const conditions = deleteConditionsForStoreKeys([key, key, "  "])
+        assert.deepEqual(conditions, [{ guildId: "guild-1", fileName: "a.wav" }])
+    })
+
+    it("skips filename-only keys so deletes cannot wipe every guild for that file", () => {
+        const composite = downloadMetadataStoreKey("guild-1", "shared.wav")
+        const conditions = deleteConditionsForStoreKeys(["shared.wav", composite])
+        assert.deepEqual(conditions, [{ guildId: "guild-1", fileName: "shared.wav" }])
+        assert.equal(
+            conditions.some((c) => !("guildId" in c) || c.guildId === undefined),
+            false
+        )
+    })
+
+    it("returns no conditions when only filename-only keys are provided", () => {
+        assert.deepEqual(deleteConditionsForStoreKeys(["a.wav", "b.wav", ""]), [])
+    })
+})

--- a/src/util/downloadMetadataNormalize.ts
+++ b/src/util/downloadMetadataNormalize.ts
@@ -1,0 +1,122 @@
+import type {
+    DownloadMetadataStoreSkippedEntry,
+    DownloadsMetadataStore,
+} from "../types/index.js"
+import {
+    effectiveDownloadMetadataGuildId,
+    parseDownloadMetadataStoreKey,
+} from "./downloadMetadataKeys.js"
+
+export type SkippedDownloadMetadataEntry = DownloadMetadataStoreSkippedEntry
+
+export type NormalizedDownloadMetadataRow = {
+    fileName: string
+    guildId: string
+    downloadDate: Date | null
+    originalUrl: string | null
+    filePath: string | null
+}
+
+/** Composite `(guildId, fileName)` delete target — never filename-only. */
+export type DownloadMetadataDeleteCondition = {
+    guildId: string
+    fileName: string
+}
+
+function storeKeyIsComposite(storeKey: string): boolean {
+    const parsed = parseDownloadMetadataStoreKey(storeKey)
+    return parsed.guildId !== null && parsed.guildId.length > 0
+}
+
+/**
+ * Flattens the legacy in-memory metadata map into upsertable DB rows.
+ * Skips entries with no resolvable guild (including the UNKNOWN sentinel) and
+ * prefers composite store keys when both a composite and legacy key map to the
+ * same `(guildId, fileName)`.
+ */
+export function normalizedRowsFromStore(store: DownloadsMetadataStore): {
+    rows: NormalizedDownloadMetadataRow[]
+    skippedEntries: SkippedDownloadMetadataEntry[]
+} {
+    const skippedEntries: SkippedDownloadMetadataEntry[] = []
+    const byGuildFile = new Map<
+        string,
+        {
+            row: NormalizedDownloadMetadataRow
+            sourceKey: string
+        }
+    >()
+
+    for (const [key, metadata] of Object.entries(store)) {
+        if (!metadata || typeof metadata !== "object") continue
+        const parsed = parseDownloadMetadataStoreKey(key)
+        const fileName = parsed.fileName
+        const guildId = effectiveDownloadMetadataGuildId(key, metadata)
+        if (guildId === null) {
+            console.debug("[downloadMetadata] skipping store row (no resolvable guildId)", {
+                key,
+                fileName: parsed.fileName,
+                downloadDate: metadata.downloadDate,
+            })
+            skippedEntries.push({ key, reason: "unresolvable-guild-id", fileName })
+            continue
+        }
+        const parsedDownloadDate =
+            metadata.downloadDate == null ? null : new Date(metadata.downloadDate)
+        const downloadDate =
+            parsedDownloadDate && Number.isFinite(parsedDownloadDate.getTime())
+                ? parsedDownloadDate
+                : null
+        const row: NormalizedDownloadMetadataRow = {
+            fileName,
+            guildId,
+            downloadDate,
+            originalUrl: metadata.originalUrl ?? null,
+            filePath: metadata.filePath ?? null,
+        }
+        const dedupeKey = `${guildId}|${fileName}`
+        const nextComposite = storeKeyIsComposite(key)
+        const prev = byGuildFile.get(dedupeKey)
+        if (!prev) {
+            byGuildFile.set(dedupeKey, { row, sourceKey: key })
+            continue
+        }
+        const prevComposite = storeKeyIsComposite(prev.sourceKey)
+        if (nextComposite && !prevComposite) {
+            byGuildFile.set(dedupeKey, { row, sourceKey: key })
+        }
+    }
+
+    return { rows: Array.from(byGuildFile.values()).map((e) => e.row), skippedEntries }
+}
+
+/**
+ * Builds Prisma `deleteMany` OR conditions for intentional store-key deletes.
+ * Filename-only keys are skipped so a legacy key cannot wipe the same `fileName`
+ * across every guild.
+ */
+export function deleteConditionsForStoreKeys(
+    deleteStoreKeys: string[]
+): DownloadMetadataDeleteCondition[] {
+    const conditions: DownloadMetadataDeleteCondition[] = []
+    const seen = new Set<string>()
+    for (const storeKey of deleteStoreKeys) {
+        if (typeof storeKey !== "string" || !storeKey.trim()) continue
+        const parsed = parseDownloadMetadataStoreKey(storeKey)
+        const dedupe =
+            parsed.guildId !== null && parsed.guildId.length > 0
+                ? `${parsed.guildId}|${parsed.fileName}`
+                : `|${parsed.fileName}`
+        if (seen.has(dedupe)) continue
+        seen.add(dedupe)
+        // Only delete by composite `(guildId, fileName)`. A filename-only key (parsed.guildId null/empty)
+        // would translate to `{ fileName }`, matching that fileName across EVERY guild and wiping
+        // unrelated guilds' rows. DB rows always carry a guildId (NULL legacy rows were migrated to the
+        // UNKNOWN sentinel), so callers' keys from downloadMetadataKeysForFile are composite — the
+        // filename-only branch targets no real row precisely and is intentionally skipped here.
+        if (parsed.guildId !== null && parsed.guildId.length > 0) {
+            conditions.push({ guildId: parsed.guildId, fileName: parsed.fileName })
+        }
+    }
+    return conditions
+}

--- a/src/util/guildDiscordLogPersist.test.ts
+++ b/src/util/guildDiscordLogPersist.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { Prisma } from "@prisma/client"
+import {
+    normalizeDiscordLogForDatabase,
+    parseGuildDiscordLog,
+    toSafeJsonObject,
+} from "./guildDiscordLogPersist.js"
+
+describe("toSafeJsonObject", () => {
+    it("rejects arrays, null, and non-objects", () => {
+        assert.equal(toSafeJsonObject(null), null)
+        assert.equal(toSafeJsonObject([1]), null)
+        assert.equal(toSafeJsonObject("x"), null)
+    })
+
+    it("returns null for non-JSON-serializable objects", () => {
+        const circular: Record<string, unknown> = {}
+        circular.self = circular
+        assert.equal(toSafeJsonObject(circular), null)
+    })
+
+    it("round-trips plain objects", () => {
+        assert.deepEqual(toSafeJsonObject({ allChannelId: "c1" }), { allChannelId: "c1" })
+    })
+})
+
+describe("normalizeDiscordLogForDatabase", () => {
+    it("maps nullish / invalid / non-object values to DbNull", () => {
+        assert.equal(normalizeDiscordLogForDatabase(null), Prisma.DbNull)
+        assert.equal(normalizeDiscordLogForDatabase(undefined), Prisma.DbNull)
+        assert.equal(normalizeDiscordLogForDatabase(42), Prisma.DbNull)
+        assert.equal(normalizeDiscordLogForDatabase(["nope"]), Prisma.DbNull)
+        assert.equal(normalizeDiscordLogForDatabase("{not-json"), Prisma.DbNull)
+        assert.equal(normalizeDiscordLogForDatabase("[1,2]"), Prisma.DbNull)
+    })
+
+    it("parses legacy JSON strings into objects", () => {
+        assert.deepEqual(
+            normalizeDiscordLogForDatabase('{"allChannelId":"123","minLevel":"warn"}'),
+            { allChannelId: "123", minLevel: "warn" }
+        )
+    })
+
+    it("accepts plain objects and rejects circular graphs", () => {
+        assert.deepEqual(normalizeDiscordLogForDatabase({ byLevel: { error: "e1" } }), {
+            byLevel: { error: "e1" },
+        })
+        const circular: Record<string, unknown> = {}
+        circular.self = circular
+        assert.equal(normalizeDiscordLogForDatabase(circular), Prisma.DbNull)
+    })
+})
+
+describe("parseGuildDiscordLog", () => {
+    it("returns undefined for null, arrays, and empty usable fields", () => {
+        assert.equal(parseGuildDiscordLog(null), undefined)
+        assert.equal(parseGuildDiscordLog([] as never), undefined)
+        assert.equal(parseGuildDiscordLog({}), undefined)
+        assert.equal(parseGuildDiscordLog({ allChannelId: "   " }), undefined)
+        assert.equal(parseGuildDiscordLog({ minLevel: "trace" }), undefined)
+        assert.equal(parseGuildDiscordLog({ byLevel: { fatal: "x", error: "" } }), undefined)
+    })
+
+    it("trims channel ids and keeps only known levels", () => {
+        assert.deepEqual(
+            parseGuildDiscordLog({
+                allChannelId: "  chan-all  ",
+                minLevel: "info",
+                byLevel: {
+                    error: "  err-chan  ",
+                    warn: "",
+                    nope: "ignored",
+                    debug: "dbg",
+                },
+                extra: true,
+            }),
+            {
+                allChannelId: "chan-all",
+                minLevel: "info",
+                byLevel: { error: "err-chan", debug: "dbg" },
+            }
+        )
+    })
+
+    it("keeps minLevel alone when channel maps are empty", () => {
+        assert.deepEqual(parseGuildDiscordLog({ minLevel: "error", byLevel: {} }), {
+            minLevel: "error",
+        })
+    })
+})

--- a/src/util/guildDiscordLogPersist.ts
+++ b/src/util/guildDiscordLogPersist.ts
@@ -1,0 +1,81 @@
+import { Prisma } from "@prisma/client"
+import type { DiscordLogLevelName, GuildDiscordLogSettings } from "../types/index.js"
+
+const LOG_LEVELS: ReadonlySet<DiscordLogLevelName> = new Set(["debug", "info", "warn", "error"])
+
+/** Verifies a value roundtrips through JSON and is a plain object. */
+export function toSafeJsonObject(candidate: unknown): Prisma.InputJsonValue | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null
+    try {
+        const serialized = JSON.stringify(candidate)
+        const parsed: unknown = JSON.parse(serialized)
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            return parsed as Prisma.InputJsonValue
+        }
+    } catch {
+        /* non-serializable (circular refs, functions, etc.) */
+    }
+    return null
+}
+
+/**
+ * Normalizes legacy `discordLog` for Prisma JSON writes
+ * (object or JSON string → object; else DbNull).
+ */
+export function normalizeDiscordLogForDatabase(
+    value: unknown
+): Prisma.InputJsonValue | typeof Prisma.DbNull {
+    if (value === null || value === undefined) return Prisma.DbNull
+    if (typeof value === "string") {
+        try {
+            return toSafeJsonObject(JSON.parse(value)) ?? Prisma.DbNull
+        } catch {
+            return Prisma.DbNull
+        }
+    }
+    if (typeof value === "object" && !Array.isArray(value)) {
+        return toSafeJsonObject(value) ?? Prisma.DbNull
+    }
+    return Prisma.DbNull
+}
+
+export function isDiscordLogLevelName(v: unknown): v is DiscordLogLevelName {
+    return typeof v === "string" && LOG_LEVELS.has(v as DiscordLogLevelName)
+}
+
+/**
+ * Parses a Prisma JSON `discordLog` column into the in-memory guild settings shape.
+ * Drops invalid levels / empty channel ids; returns undefined when nothing usable remains.
+ */
+export function parseGuildDiscordLog(
+    value: Prisma.JsonValue | null
+): GuildDiscordLogSettings | undefined {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return undefined
+    }
+    const raw = value as Record<string, unknown>
+    const out: GuildDiscordLogSettings = {}
+    if (typeof raw.allChannelId === "string" && raw.allChannelId.trim()) {
+        out.allChannelId = raw.allChannelId.trim()
+    }
+    if (raw.minLevel !== undefined && raw.minLevel !== null) {
+        if (isDiscordLogLevelName(raw.minLevel)) {
+            out.minLevel = raw.minLevel
+        }
+    }
+    if (raw.byLevel !== undefined && raw.byLevel !== null) {
+        if (typeof raw.byLevel === "object" && !Array.isArray(raw.byLevel)) {
+            const by: Partial<Record<DiscordLogLevelName, string>> = {}
+            for (const [k, v] of Object.entries(raw.byLevel as Record<string, unknown>)) {
+                if (!isDiscordLogLevelName(k)) continue
+                if (typeof v !== "string" || !v.trim()) continue
+                by[k] = v.trim()
+            }
+            if (Object.keys(by).length > 0) out.byLevel = by
+        }
+    }
+    if (!out.allChannelId && !out.byLevel && !out.minLevel) {
+        return undefined
+    }
+    return out
+}

--- a/src/util/musicManager.ts
+++ b/src/util/musicManager.ts
@@ -661,80 +661,94 @@ export async function handleQueryAndPlay(
                         success = false
                         errorResult = new Error("Player destroyed during connect")
                     } else {
-                        if (liveAfterConnect !== liveBeforeConnect) {
-                            await ensurePlayerConnected(client, liveAfterConnect, voiceChannel)
+                        // Replacement connect can lose to /stop the same way the first wait can.
+                        // Re-resolve after that wait; reconnect once more if identity changed again.
+                        let liveForPlayback: Player | undefined = liveAfterConnect
+                        if (liveForPlayback !== liveBeforeConnect) {
+                            await ensurePlayerConnected(client, liveForPlayback, voiceChannel)
+                            liveForPlayback = client.lavalink.getPlayer(guildId)
                         }
-                        player = liveAfterConnect
-                        player.voiceChannelId = voiceChannel.id
-                        previousVoiceChannelIdBeforeEnsure = null
-
-                        const tracksToEnqueue =
-                            isPlaylistEnqueue && searchResult.tracks.length > 0
-                                ? searchResult.tracks
-                                : [trackToAdd]
-                        stampRequesterUserIdOnTracks(tracksToEnqueue, requester.id)
-                        const playableTracks = isPlaylistEnqueue
-                            ? await resolveYoutubePlaybackTracks(
-                                  player,
-                                  tracksToEnqueue,
-                                  companionPlaybackConfig(client)
-                              )
-                            : [
-                                  await resolveYoutubePlaybackTrack(
-                                      player,
-                                      tracksToEnqueue[0]!,
-                                      companionPlaybackConfig(client)
-                                  ),
-                              ]
-                        if (playableTracks.length === 0) {
-                            throw new Error(
-                                "None of the playlist tracks could be prepared for playback."
-                            )
+                        if (liveForPlayback && liveForPlayback !== liveAfterConnect) {
+                            await ensurePlayerConnected(client, liveForPlayback, voiceChannel)
+                            liveForPlayback = client.lavalink.getPlayer(guildId)
                         }
-
-                        const enqueued = await enqueueMusicManagerTracksAssumingSearchDone(
-                            () => client.lavalink.getPlayer(guildId),
-                            guildId,
-                            {
-                                isPlaylist: isPlaylistEnqueue,
-                                tracks: playableTracks,
-                                playlistName: searchResult.playlist?.name,
-                            },
-                            requester.id
-                        )
-                        if (enqueued.status === "no_player") {
+                        if (!liveForPlayback) {
                             feedbackText = `${requester}, The player stopped before the track could be queued. Try again.`
                             success = false
-                            errorResult = new Error("Player destroyed before enqueue")
+                            errorResult = new Error("Player destroyed during connect")
                         } else {
-                            player = enqueued.player
-                            if (!feedbackText) {
-                                feedbackText = enqueued.feedbackText
-                                if (isPlaylistEnqueue && searchResult.tracks.length > 0) {
-                                    const skipped =
-                                        searchResult.tracks.length - playableTracks.length
-                                    if (skipped > 0) {
-                                        feedbackText += ` Skipped ${skipped} unplayable track(s).`
+                            player = liveForPlayback
+                            player.voiceChannelId = voiceChannel.id
+                            previousVoiceChannelIdBeforeEnsure = null
+
+                            const tracksToEnqueue =
+                                isPlaylistEnqueue && searchResult.tracks.length > 0
+                                    ? searchResult.tracks
+                                    : [trackToAdd]
+                            stampRequesterUserIdOnTracks(tracksToEnqueue, requester.id)
+                            const playableTracks = isPlaylistEnqueue
+                                ? await resolveYoutubePlaybackTracks(
+                                      player,
+                                      tracksToEnqueue,
+                                      companionPlaybackConfig(client)
+                                  )
+                                : [
+                                      await resolveYoutubePlaybackTrack(
+                                          player,
+                                          tracksToEnqueue[0]!,
+                                          companionPlaybackConfig(client)
+                                      ),
+                                  ]
+                            if (playableTracks.length === 0) {
+                                throw new Error(
+                                    "None of the playlist tracks could be prepared for playback."
+                                )
+                            }
+
+                            const enqueued = await enqueueMusicManagerTracksAssumingSearchDone(
+                                () => client.lavalink.getPlayer(guildId),
+                                guildId,
+                                {
+                                    isPlaylist: isPlaylistEnqueue,
+                                    tracks: playableTracks,
+                                    playlistName: searchResult.playlist?.name,
+                                },
+                                requester.id
+                            )
+                            if (enqueued.status === "no_player") {
+                                feedbackText = `${requester}, The player stopped before the track could be queued. Try again.`
+                                success = false
+                                errorResult = new Error("Player destroyed before enqueue")
+                            } else {
+                                player = enqueued.player
+                                if (!feedbackText) {
+                                    feedbackText = enqueued.feedbackText
+                                    if (isPlaylistEnqueue && searchResult.tracks.length > 0) {
+                                        const skipped =
+                                            searchResult.tracks.length - playableTracks.length
+                                        if (skipped > 0) {
+                                            feedbackText += ` Skipped ${skipped} unplayable track(s).`
+                                        }
                                     }
                                 }
-                            }
-                            client.debug(
-                                `[MusicManager] Enqueued via live player for guild ${guildId}.`
-                            )
+                                client.debug(
+                                    `[MusicManager] Enqueued via live player for guild ${guildId}.`
+                                )
 
-                            // Play outside the queue lock so trackError → safeIdlePlayerDestroy cannot
-                            // nest on the same non-reentrant guild chain.
-                            client.debug(
-                                `[MusicManager] Before play check: player.playing=${player.playing}, player.queue.tracks.length=${player.queue.tracks.length}`
-                            )
-                            await startPlaybackIfNeeded(player)
-                            scheduleSaveIfPlayerStillLive(
-                                () => client.lavalink.getPlayer(guildId),
-                                player
-                            )
-                            client.debug(
-                                `[MusicManager] Lavalink player started playing [${player.queue.current?.info?.title || "track from queue"}].`
-                            )
+                                // Play outside the queue lock so trackError → safeIdlePlayerDestroy cannot
+                                // nest on the same non-reentrant guild chain.
+                                client.debug(
+                                    `[MusicManager] Before play check: player.playing=${player.playing}, player.queue.tracks.length=${player.queue.tracks.length}`
+                                )
+                                await startPlaybackIfNeeded(player)
+                                scheduleSaveIfPlayerStillLive(
+                                    () => client.lavalink.getPlayer(guildId),
+                                    player
+                                )
+                                client.debug(
+                                    `[MusicManager] Lavalink player started playing [${player.queue.current?.info?.title || "track from queue"}].`
+                                )
+                            }
                         }
                     }
                 } catch (playError: unknown) {

--- a/src/util/musicManager.ts
+++ b/src/util/musicManager.ts
@@ -14,15 +14,13 @@ import {
 import type { Player, PlayerJson, Track, UnresolvedTrack } from "lavalink-client"
 import type BotClient from "../lib/BotClient.js"
 import type { LocalFile, QueryPlayResult } from "../types/index.js"
-import {
-    isRRQActive,
-    rebalancePlayerQueueRoundRobinAssumingLock,
-    stampRequesterUserIdOnTracks,
-} from "./rrqDisconnect.js"
 import { downloadMetadataFileBelongsToGuild } from "./downloadMetadataKeys.js"
 import { getDownloadMetadataStore } from "./downloadMetadataStore.js"
-import { withGuildPlayerQueueLock } from "./guildPlayerQueueLock.js"
-import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
+import {
+    enqueueMusicManagerTracksAssumingSearchDone,
+    scheduleSaveIfPlayerStillLive,
+} from "./musicManagerEnqueue.js"
+import { stampRequesterUserIdOnTracks } from "./rrqDisconnect.js"
 import { memberMayJoinOccupiedVoice, resolveOccupiedVoiceChannelId } from "./sameVoiceChannel.js"
 import {
     resolveYoutubePlaybackTrack,
@@ -643,105 +641,137 @@ export async function handleQueryAndPlay(
             client.debug(
                 `[MusicManager] Lavalink track [${trackToAdd.info.title}] to be played. Ensuring player is connected, enqueueing, then starting playback.`
             )
-            try {
-                await ensurePlayerConnected(client, player, voiceChannel)
-                player.voiceChannelId = voiceChannel.id
-                previousVoiceChannelIdBeforeEnsure = null
-
-                const tracksToEnqueue =
-                    isPlaylistEnqueue && searchResult.tracks.length > 0
-                        ? searchResult.tracks
-                        : [trackToAdd]
-                stampRequesterUserIdOnTracks(tracksToEnqueue, requester.id)
-                const playableTracks = isPlaylistEnqueue
-                    ? await resolveYoutubePlaybackTracks(
-                          player,
-                          tracksToEnqueue,
-                          companionPlaybackConfig(client)
-                      )
-                    : [
-                          await resolveYoutubePlaybackTrack(
-                              player,
-                              tracksToEnqueue[0]!,
-                              companionPlaybackConfig(client)
-                          ),
-                      ]
-                if (playableTracks.length === 0) {
-                    throw new Error("None of the playlist tracks could be prepared for playback.")
-                }
-
-                // Serialize with dashboard clear/replace/reorder and RRQ splices. Unlocked
-                // queue.add raced replaceUpcoming rollback (splice(0, size) of the live
-                // queue), which deleted concurrent Discord /play enqueues.
-                await withGuildPlayerQueueLock(guildId, async () => {
-                    if (isPlaylistEnqueue && playableTracks.length > 0) {
-                        await player.queue.add(playableTracks)
-                        client.debug(
-                            `[MusicManager] Enqueued playlist (${playableTracks.length} of ${searchResult.tracks.length} tracks) for guild ${guildId}.`
-                        )
-                    } else {
-                        await player.queue.add(playableTracks[0]!)
-                        client.debug(
-                            `[MusicManager] Enqueued single track [${trackToAdd.info.title}].`
-                        )
-                    }
-
-                    if (isRRQActive(player)) {
-                        // Already holding the guild queue lock — do not re-enter via
-                        // rebalancePlayerQueueRoundRobin (non-reentrant chain).
-                        await rebalancePlayerQueueRoundRobinAssumingLock(player)
-                    }
-
-                    if (!feedbackText) {
-                        if (isPlaylistEnqueue && searchResult.tracks.length > 0) {
-                            const skipped = searchResult.tracks.length - playableTracks.length
-                            feedbackText = `Added playlist **${searchResult.playlist?.name ?? "Unknown Playlist"}** (${playableTracks.length} songs) to the queue.`
-                            if (skipped > 0) {
-                                feedbackText += ` Skipped ${skipped} unplayable track(s).`
-                            }
-                        } else {
-                            feedbackText = `Added [${trackToAdd.info.title}](${trackToAdd.info.uri}) to the queue.`
-                        }
-                    }
-                })
-
-                // Play outside the queue lock so trackError → safeIdlePlayerDestroy cannot
-                // nest on the same non-reentrant guild chain. startPlaybackIfNeeded rechecks
-                // queue state and serializes per-player starts.
-                client.debug(
-                    `[MusicManager] Before play check: player.playing=${player.playing}, player.queue.tracks.length=${player.queue.tracks.length}`
-                )
-                await startPlaybackIfNeeded(player)
-                schedulePlayerSessionSave(player)
-                client.debug(
-                    `[MusicManager] Lavalink player started playing [${player.queue.current?.info?.title || "track from queue"}].`
-                )
-            } catch (playError: unknown) {
-                if (previousVoiceChannelIdBeforeEnsure !== null) {
-                    player.voiceChannelId = previousVoiceChannelIdBeforeEnsure
-                }
-                client.error(`[MusicManager] Error starting Lavalink player:`, playError)
-                const originalFeedback = feedbackText
-                const pem = playError instanceof Error ? playError.message : String(playError)
-                if (pem.includes("No supported audio streams available")) {
-                    feedbackText = `${requester}, I couldn't play [${trackToAdd.info.title}](${trackToAdd.info.uri}) because it has no supported audio streams (age/region lock, private, etc.).`
-                    if (player.queue.tracks.length > 0) {
-                        try {
-                            await player.skip()
-                        } catch (skipError) {
-                            client.error(`[MusicManager] Error skipping to next track:`, skipError)
-                        }
-                        feedbackText += "\n\nSkipping to next track..."
-                    }
-                } else {
-                    feedbackText = `${requester}, Failed to start playback for [${trackToAdd.info.title}](${trackToAdd.info.uri}). Error: ${pem}`
-                }
-                if (originalFeedback.startsWith("Added")) {
-                    feedbackText = `${originalFeedback}\nHowever, ${feedbackText.substring(feedbackText.indexOf(",") + 1).trim()}`
-                }
-                schedulePlayerSessionSave(player)
+            // Lifecycle reservations only defer orphan idle destroy. Intentional /stop, Leave,
+            // or control/web stop during search can remove the captured Player from the manager.
+            // Re-resolve before connect/enqueue so we never reconnect or schedulePlayerSessionSave
+            // on a zombie (in-memory queue survives queue.utils.destroy → session resurrection).
+            const liveBeforeConnect = client.lavalink.getPlayer(guildId)
+            if (!liveBeforeConnect) {
+                feedbackText = `${requester}, The player stopped before the track could be queued. Try again.`
                 success = false
-                errorResult = playError instanceof Error ? playError : new Error(String(playError))
+                errorResult = new Error("Player destroyed during search")
+            } else {
+                player = liveBeforeConnect
+                try {
+                    await ensurePlayerConnected(client, player, voiceChannel)
+                    // /stop can still win during the connect wait — refuse the captured ref.
+                    const liveAfterConnect = client.lavalink.getPlayer(guildId)
+                    if (!liveAfterConnect) {
+                        feedbackText = `${requester}, The player stopped before the track could be queued. Try again.`
+                        success = false
+                        errorResult = new Error("Player destroyed during connect")
+                    } else {
+                        player = liveAfterConnect
+                        player.voiceChannelId = voiceChannel.id
+                        previousVoiceChannelIdBeforeEnsure = null
+
+                        const tracksToEnqueue =
+                            isPlaylistEnqueue && searchResult.tracks.length > 0
+                                ? searchResult.tracks
+                                : [trackToAdd]
+                        stampRequesterUserIdOnTracks(tracksToEnqueue, requester.id)
+                        const playableTracks = isPlaylistEnqueue
+                            ? await resolveYoutubePlaybackTracks(
+                                  player,
+                                  tracksToEnqueue,
+                                  companionPlaybackConfig(client)
+                              )
+                            : [
+                                  await resolveYoutubePlaybackTrack(
+                                      player,
+                                      tracksToEnqueue[0]!,
+                                      companionPlaybackConfig(client)
+                                  ),
+                              ]
+                        if (playableTracks.length === 0) {
+                            throw new Error(
+                                "None of the playlist tracks could be prepared for playback."
+                            )
+                        }
+
+                        const enqueued = await enqueueMusicManagerTracksAssumingSearchDone(
+                            () => client.lavalink.getPlayer(guildId),
+                            guildId,
+                            {
+                                isPlaylist: isPlaylistEnqueue,
+                                tracks: playableTracks,
+                                playlistName: searchResult.playlist?.name,
+                            },
+                            requester.id
+                        )
+                        if (enqueued.status === "no_player") {
+                            feedbackText = `${requester}, The player stopped before the track could be queued. Try again.`
+                            success = false
+                            errorResult = new Error("Player destroyed before enqueue")
+                        } else {
+                            player = enqueued.player
+                            if (!feedbackText) {
+                                feedbackText = enqueued.feedbackText
+                                if (isPlaylistEnqueue && searchResult.tracks.length > 0) {
+                                    const skipped =
+                                        searchResult.tracks.length - playableTracks.length
+                                    if (skipped > 0) {
+                                        feedbackText += ` Skipped ${skipped} unplayable track(s).`
+                                    }
+                                }
+                            }
+                            client.debug(
+                                `[MusicManager] Enqueued via live player for guild ${guildId}.`
+                            )
+
+                            // Play outside the queue lock so trackError → safeIdlePlayerDestroy cannot
+                            // nest on the same non-reentrant guild chain.
+                            client.debug(
+                                `[MusicManager] Before play check: player.playing=${player.playing}, player.queue.tracks.length=${player.queue.tracks.length}`
+                            )
+                            await startPlaybackIfNeeded(player)
+                            scheduleSaveIfPlayerStillLive(
+                                () => client.lavalink.getPlayer(guildId),
+                                player
+                            )
+                            client.debug(
+                                `[MusicManager] Lavalink player started playing [${player.queue.current?.info?.title || "track from queue"}].`
+                            )
+                        }
+                    }
+                } catch (playError: unknown) {
+                    if (previousVoiceChannelIdBeforeEnsure !== null) {
+                        player.voiceChannelId = previousVoiceChannelIdBeforeEnsure
+                    }
+                    client.error(`[MusicManager] Error starting Lavalink player:`, playError)
+                    const originalFeedback = feedbackText
+                    const pem = playError instanceof Error ? playError.message : String(playError)
+                    const liveForError = client.lavalink.getPlayer(guildId)
+                    if (pem.includes("No supported audio streams available")) {
+                        feedbackText = `${requester}, I couldn't play [${trackToAdd.info.title}](${trackToAdd.info.uri}) because it has no supported audio streams (age/region lock, private, etc.).`
+                        if (liveForError && liveForError.queue.tracks.length > 0) {
+                            try {
+                                await liveForError.skip()
+                            } catch (skipError) {
+                                client.error(
+                                    `[MusicManager] Error skipping to next track:`,
+                                    skipError
+                                )
+                            }
+                            feedbackText += "\n\nSkipping to next track..."
+                        }
+                    } else {
+                        feedbackText = `${requester}, Failed to start playback for [${trackToAdd.info.title}](${trackToAdd.info.uri}). Error: ${pem}`
+                    }
+                    if (originalFeedback.startsWith("Added")) {
+                        feedbackText = `${originalFeedback}\nHowever, ${feedbackText.substring(feedbackText.indexOf(",") + 1).trim()}`
+                    }
+                    // Never persist a post-destroy zombie — that resurrects the cleared session.
+                    if (liveForError) {
+                        scheduleSaveIfPlayerStillLive(
+                            () => client.lavalink.getPlayer(guildId),
+                            liveForError
+                        )
+                    }
+                    success = false
+                    errorResult =
+                        playError instanceof Error ? playError : new Error(String(playError))
+                }
             }
         } else if (!success && !errorResult && trackToAdd) {
             client.debug(

--- a/src/util/musicManager.ts
+++ b/src/util/musicManager.ts
@@ -661,6 +661,9 @@ export async function handleQueryAndPlay(
                         success = false
                         errorResult = new Error("Player destroyed during connect")
                     } else {
+                        if (liveAfterConnect !== liveBeforeConnect) {
+                            await ensurePlayerConnected(client, liveAfterConnect, voiceChannel)
+                        }
                         player = liveAfterConnect
                         player.voiceChannelId = voiceChannel.id
                         previousVoiceChannelIdBeforeEnsure = null

--- a/src/util/musicManagerEnqueue.test.ts
+++ b/src/util/musicManagerEnqueue.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player, Track } from "lavalink-client"
+import {
+    enqueueMusicManagerTracksAssumingSearchDone,
+    scheduleSaveIfPlayerStillLive,
+} from "./musicManagerEnqueue.js"
+
+function mockTrack(id: string): Track {
+    return {
+        encoded: `enc-${id}`,
+        info: {
+            title: id,
+            author: "Artist",
+            uri: `https://example.com/${id}`,
+            duration: 1000,
+            isStream: false,
+            identifier: id,
+            isSeekable: true,
+            sourceName: "http",
+            artworkUrl: null,
+            isrc: null,
+        },
+        requester: undefined,
+    } as unknown as Track
+}
+
+function mockMutablePlayer(guildId: string, initial: Track[] = [], playing = true): Player {
+    const tracks = [...initial]
+    return {
+        guildId,
+        playing,
+        queue: {
+            current: playing ? mockTrack("current") : null,
+            tracks,
+            add(items: Track | Track[]) {
+                const list = Array.isArray(items) ? items : [items]
+                tracks.push(...list)
+                return Promise.resolve()
+            },
+            async splice(start: number, deleteCount: number, ...insert: Track[]) {
+                return tracks.splice(start, deleteCount, ...insert.flat())
+            },
+        },
+        get() {
+            return undefined
+        },
+        async play() {
+            return undefined
+        },
+    } as unknown as Player
+}
+
+describe("enqueueMusicManagerTracksAssumingSearchDone", () => {
+    it("adds to the live player resolved under the lock, not a stale destroyed reference", async () => {
+        const guildId = "guild-mm-enqueue-stale"
+        const staleDestroyed = mockMutablePlayer(guildId, [mockTrack("old")])
+        const live = mockMutablePlayer(guildId, [mockTrack("kept")])
+
+        const outcome = await enqueueMusicManagerTracksAssumingSearchDone(
+            () => live,
+            guildId,
+            { isPlaylist: false, tracks: [mockTrack("discord-add")] },
+            "user-1"
+        )
+
+        assert.equal(outcome.status, "ok")
+        if (outcome.status !== "ok") return
+        assert.equal(live.queue.tracks.map((t) => t.info.title).join(","), "kept,discord-add")
+        assert.equal(staleDestroyed.queue.tracks.length, 1)
+        assert.equal(staleDestroyed.queue.tracks[0]?.info.title, "old")
+    })
+
+    it("returns no_player when /stop destroyed the player during search", async () => {
+        const outcome = await enqueueMusicManagerTracksAssumingSearchDone(
+            () => undefined,
+            "guild-mm-enqueue-gone",
+            { isPlaylist: false, tracks: [mockTrack("lost")] },
+            "user-1"
+        )
+        assert.equal(outcome.status, "no_player")
+    })
+
+    it("enqueues playlist tracks onto the live player only", async () => {
+        const guildId = "guild-mm-enqueue-playlist"
+        const staleDestroyed = mockMutablePlayer(guildId, [mockTrack("old")])
+        const live = mockMutablePlayer(guildId, [])
+
+        const outcome = await enqueueMusicManagerTracksAssumingSearchDone(
+            () => live,
+            guildId,
+            {
+                isPlaylist: true,
+                tracks: [mockTrack("p1"), mockTrack("p2")],
+                playlistName: "Mix",
+            },
+            "user-1"
+        )
+
+        assert.equal(outcome.status, "ok")
+        if (outcome.status !== "ok") return
+        assert.match(outcome.feedbackText, /Mix/)
+        assert.equal(live.queue.tracks.map((t) => t.info.title).join(","), "p1,p2")
+        assert.equal(staleDestroyed.queue.tracks.length, 1)
+    })
+
+    it("scheduleSaveIfPlayerStillLive ignores a destroyed zombie reference", async () => {
+        const guildId = "guild-mm-save-zombie"
+        const zombie = mockMutablePlayer(guildId, [mockTrack("stopped-queue")])
+        let live: Player | undefined
+
+        scheduleSaveIfPlayerStillLive(() => live, zombie)
+        // No throw; live is undefined so save must be skipped (zombie must not resurrect).
+        assert.equal(live, undefined)
+
+        live = mockMutablePlayer(guildId, [mockTrack("kept")])
+        scheduleSaveIfPlayerStillLive(() => live, live)
+        scheduleSaveIfPlayerStillLive(() => live, zombie)
+    })
+})

--- a/src/util/musicManagerEnqueue.ts
+++ b/src/util/musicManagerEnqueue.ts
@@ -1,0 +1,76 @@
+import type { Player, Track, UnresolvedTrack } from "lavalink-client"
+import {
+    isRRQActive,
+    rebalancePlayerQueueRoundRobinAssumingLock,
+    stampRequesterUserIdOnTracks,
+} from "./rrqDisconnect.js"
+import { withGuildPlayerQueueLock } from "./guildPlayerQueueLock.js"
+import { schedulePlayerSessionSave } from "./playerSessionPersistence.js"
+
+export type MusicManagerEnqueuePayload = {
+    isPlaylist: boolean
+    tracks: Array<Track | UnresolvedTrack>
+    playlistName?: string | null
+}
+
+export type MusicManagerEnqueueResult =
+    | {
+          status: "ok"
+          player: Player
+          feedbackText: string
+      }
+    | { status: "no_player" }
+
+/**
+ * Enqueues Discord /play (and related) search results onto the *live* guild player under
+ * the shared queue lock. Callers must re-resolve via `getLivePlayer` so a destroy during
+ * search/connect (/stop, Leave, control/web stop) cannot mutate a stale Player and
+ * resurrect its session via schedulePlayerSessionSave.
+ *
+ * Playback start stays with the caller (outside this lock) so trackError → idle destroy
+ * cannot nest on the non-reentrant guild chain.
+ */
+export async function enqueueMusicManagerTracksAssumingSearchDone(
+    getLivePlayer: () => Player | undefined,
+    guildId: string,
+    payload: MusicManagerEnqueuePayload,
+    requesterId: string
+): Promise<MusicManagerEnqueueResult> {
+    const primary = payload.tracks[0]
+    if (!primary) return { status: "no_player" }
+
+    return withGuildPlayerQueueLock(guildId, async () => {
+        const live = getLivePlayer()
+        if (!live) return { status: "no_player" }
+
+        if (payload.isPlaylist && payload.tracks.length > 0) {
+            stampRequesterUserIdOnTracks(payload.tracks, requesterId)
+            await live.queue.add(payload.tracks)
+        } else {
+            stampRequesterUserIdOnTracks([primary], requesterId)
+            await live.queue.add(primary)
+        }
+
+        if (isRRQActive(live)) {
+            await rebalancePlayerQueueRoundRobinAssumingLock(live)
+        }
+
+        const feedbackText =
+            payload.isPlaylist && payload.tracks.length > 0
+                ? `Added playlist **${payload.playlistName ?? "Unknown Playlist"}** (${payload.tracks.length} songs) to the queue.`
+                : `Added [${primary.info.title}](${primary.info.uri}) to the queue.`
+
+        return { status: "ok", player: live, feedbackText }
+    })
+}
+
+/** Persist only when the guild still has this live player (never a post-destroy zombie). */
+export function scheduleSaveIfPlayerStillLive(
+    getLivePlayer: () => Player | undefined,
+    expected: Player
+): void {
+    const live = getLivePlayer()
+    if (live && live === expected) {
+        schedulePlayerSessionSave(live)
+    }
+}

--- a/src/util/parseEventDateTime.test.ts
+++ b/src/util/parseEventDateTime.test.ts
@@ -12,6 +12,23 @@ describe("parseEventDateTime", () => {
         assert.equal(result.epochSeconds, Date.UTC(2026, 0, 16, 0, 30) / 1000)
     })
 
+    it("applies CDT (summer) offset for America/Chicago", () => {
+        const result = parseEventDateTime("2026-07-15", "18:30", "America/Chicago")
+        assert.equal(result.ok, true)
+        if (!result.ok) return
+        // 2026-07-15 18:30 CDT = 2026-07-15 23:30 UTC
+        assert.equal(result.epochSeconds, Date.UTC(2026, 6, 15, 23, 30) / 1000)
+    })
+
+    it("accepts leap-day 2024-02-29 and rejects 2025-02-29", () => {
+        const leap = parseEventDateTime("2024-02-29", "12:00", "UTC")
+        assert.equal(leap.ok, true)
+        if (leap.ok) {
+            assert.equal(leap.epochSeconds, Date.UTC(2024, 1, 29, 12, 0) / 1000)
+        }
+        assert.equal(parseEventDateTime("2025-02-29", "12:00", "UTC").ok, false)
+    })
+
     it("rejects bad formats, unknown zones, and impossible calendar dates", () => {
         assert.equal(parseEventDateTime("15-01-2026", "18:30", "UTC").ok, false)
         assert.equal(parseEventDateTime("2026-01-15", "25:00", "UTC").ok, false)

--- a/src/util/playerSessionTracks.test.ts
+++ b/src/util/playerSessionTracks.test.ts
@@ -39,6 +39,24 @@ function mockPlayer(hooks: {
 }
 
 describe("resolvePersistedTracks transient vs permanent failures", () => {
+    it("skips private/Docker-internal URIs without calling Lavalink search", async () => {
+        let searched = false
+        const player = mockPlayer({
+            search: async () => {
+                searched = true
+                return { tracks: [] }
+            },
+        })
+        const result = await resolvePersistedTracks(player, [
+            stored({ uri: "http://invidious-companion:8282/secret" }),
+            stored({ uri: "http://192.168.1.10/track.mp3", title: "Lan" }),
+        ])
+        assert.equal(searched, false)
+        assert.equal(result.resolved.length, 0)
+        assert.equal(result.failed, 2)
+        assert.equal(result.transientFailures, 0)
+    })
+
     it("reports transientFailures when URI search throws", async () => {
         const player = mockPlayer({
             search: async () => {

--- a/src/util/playerSessionTracks.test.ts
+++ b/src/util/playerSessionTracks.test.ts
@@ -57,6 +57,38 @@ describe("resolvePersistedTracks transient vs permanent failures", () => {
         assert.equal(result.transientFailures, 0)
     })
 
+    it("skips blocked URIs even when encoded decode would succeed", async () => {
+        let decoded = false
+        let searched = false
+        const player = mockPlayer({
+            decode: async () => {
+                decoded = true
+                return {
+                    info: {
+                        title: "Lan",
+                        uri: "http://192.168.1.10/track.mp3",
+                    },
+                }
+            },
+            search: async () => {
+                searched = true
+                return { tracks: [] }
+            },
+        })
+        const result = await resolvePersistedTracks(player, [
+            stored({
+                uri: "http://192.168.1.10/track.mp3",
+                title: "Lan",
+                encoded: "blocked-http-encoded",
+            }),
+        ])
+        assert.equal(decoded, false)
+        assert.equal(searched, false)
+        assert.equal(result.resolved.length, 0)
+        assert.equal(result.failed, 1)
+        assert.equal(result.transientFailures, 0)
+    })
+
     it("reports transientFailures when URI search throws", async () => {
         const player = mockPlayer({
             search: async () => {

--- a/src/util/playerSessionTracks.ts
+++ b/src/util/playerSessionTracks.ts
@@ -62,6 +62,9 @@ async function resolvePersistedTrackAtIndex(
 ): Promise<{ track: Track | null; transientFailure: boolean }> {
     const requester = stored.requesterId ?? "session-restore"
     let sawTransientFailure = false
+    if (isBlockedUserMediaUrl(stored.uri)) {
+        return { track: null, transientFailure: false }
+    }
     const storedYoutubeId = youtubeVideoIdFromUri(stored.uri)
     const storedSpotifyUri = isSpotifyCatalogUri(stored.uri)
 
@@ -83,9 +86,6 @@ async function resolvePersistedTrackAtIndex(
     }
 
     if (stored.uri) {
-        if (isBlockedUserMediaUrl(stored.uri)) {
-            return { track: null, transientFailure: false }
-        }
         try {
             const res = await player.search(stored.uri, requester)
             const first = res?.tracks?.[0]

--- a/src/util/playerSessionTracks.ts
+++ b/src/util/playerSessionTracks.ts
@@ -2,6 +2,7 @@ import type { Player, Track, UnresolvedTrack } from "lavalink-client"
 import type { PersistedQueueTrack } from "../types/index.js"
 import { getRequesterUserId, stampRequesterUserIdOnTracks } from "./rrqDisconnect.js"
 import { thumbnailFromLavalinkTrack } from "./trackThumbnail.js"
+import { isBlockedUserMediaUrl } from "./userMediaUrl.js"
 import { isSpotifyCatalogUri, youtubeVideoIdFromUri } from "./youtubeCompanionPlayback.js"
 
 const RESOLVE_CONCURRENCY = 6
@@ -82,6 +83,9 @@ async function resolvePersistedTrackAtIndex(
     }
 
     if (stored.uri) {
+        if (isBlockedUserMediaUrl(stored.uri)) {
+            return { track: null, transientFailure: false }
+        }
         try {
             const res = await player.search(stored.uri, requester)
             const first = res?.tracks?.[0]

--- a/src/util/playlistQueue.ts
+++ b/src/util/playlistQueue.ts
@@ -49,6 +49,11 @@ async function resolveStoredTrackAtIndex(
     uri: string,
     requester: unknown
 ): Promise<Track | null> {
+    // Defense in depth: skip private/Docker-internal hosts even if older rows bypassed
+    // playlistTracksPOST (Lavalink http:true would otherwise fetch the compose network).
+    if (isBlockedUserMediaUrl(uri)) {
+        return null
+    }
     try {
         const res = await player.search(uri, requester)
         const first = res?.tracks?.[0]

--- a/src/util/playlistQueue.userMediaUrl.test.ts
+++ b/src/util/playlistQueue.userMediaUrl.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import type { Player } from "lavalink-client"
+import { resolveStoredPlaylistTracks } from "./playlistQueue.js"
+
+function mockPlayer(searchUris: string[]): Player {
+    return {
+        search: async (uri: string) => {
+            searchUris.push(uri)
+            return {
+                tracks: [
+                    {
+                        info: {
+                            title: "Hit",
+                            uri,
+                        },
+                    },
+                ],
+            }
+        },
+    } as unknown as Player
+}
+
+describe("resolveStoredPlaylistTracks user-media deny", () => {
+    it("does not Lavalink-search private or Docker-internal playlist URIs", async () => {
+        const searched: string[] = []
+        const player = mockPlayer(searched)
+        const result = await resolveStoredPlaylistTracks(
+            player,
+            [
+                { uri: "http://postgres-db:5432/" },
+                { uri: "http://127.0.0.1:3001/health" },
+                { uri: "http://10.0.0.5/audio.mp3" },
+                { uri: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
+            ],
+            { id: "user-1" }
+        )
+        assert.deepEqual(searched, ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"])
+        assert.equal(result.resolved.length, 1)
+        assert.equal(result.failed, 3)
+    })
+})


### PR DESCRIPTION
## Summary

- Consolidates open Cursor Source PRs into one review branch for CodeRabbit and human review
- Integration Branch: `chore/consolidated-cursor-play-ssrf-tests` from current `main`
- Source PRs closed as superseded on create (ADR 0001; skill override of close-after-merge)
- `#196` conflicted with merged PR #197 companion enqueue in `src/util/musicManager.ts`. Resolution keeps `resolveYoutubePlaybackTracks` / `resolveYoutubePlaybackTrack` before live-player enqueue (`enqueueMusicManagerTracksAssumingSearchDone` + `scheduleSaveIfPlayerStillLive`). Playlist skip-count feedback is preserved.

## Supersedes

- #195 — test: cover download metadata normalize/delete and countdown DST (https://github.com/bpeters132/DimbyBot2/pull/195)
- #196 — fix: prevent Discord /play from resurrecting stopped player sessions (https://github.com/bpeters132/DimbyBot2/pull/196)
- #198 — test: cover countdown store and guild discordLog DB persist (https://github.com/bpeters132/DimbyBot2/pull/198)
- #199 — fix: block private-host SSRF via /playnext and playlist track POST (https://github.com/bpeters132/DimbyBot2/pull/199)

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test`
- [ ] Spot-check companion resolve still runs before Discord `/play` enqueue
- [ ] Spot-check User media URL deny on `/playnext` and playlist track POST

## Version

- Current: `0.2.0`
- Recommended: `0.2.1` (`patch`) — bugfixes and tests only
- Bump not committed unless requested

## Notes

- Cherry-picked oldest-first; `#196` conflict resolved on the Integration Branch
- Do not merge Source PRs individually; this PR is the single review unit
- `npm run audit:check-imports` is not a script in this repo
